### PR TITLE
Run omnisharp test commands from vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,21 @@
                 "command": "o.execute",
                 "title": "Run Command",
                 "category": "dnx"
+            },
+            {
+                "command": "o.runSingleTest",
+                "title": "Run Single Test",
+                "category": "OmniSharp"
+            },
+            {
+                "command": "o.runFixtureTests",
+                "title": "Run Fixture Tests",
+                "category": "OmniSharp"
+            },
+            {
+                "command": "o.runAllTests",
+                "title": "Run All Tests",
+                "category": "OmniSharp"
             }
         ],
         "keybindings": [
@@ -106,6 +121,21 @@
                 "command": "o.execute-last-command",
                 "key": "Ctrl+L R",
                 "mac": "Cmd+L R"
+            },
+            {
+                "command": "o.runSingleTest",
+                "key": "Ctrl+R R",
+                "mac": "Ctrl+R R"
+            },
+            {
+                "command": "o.runFixtureTests",
+                "key": "Ctrl+R F",
+                "mac": "Ctrl+R F"
+            },
+            {
+                "command": "o.runAllTests",
+                "key": "Ctrl+R A",
+                "mac": "Ctrl+R A"
             },
             {
                 "key": "shift+0",

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -7,10 +7,12 @@
 
 import * as proto from '../protocol';
 import {OmnisharpServer} from '../omnisharpServer';
-import {Disposable, ViewColumn, commands, window} from 'vscode';
+import {Disposable, ViewColumn, commands, window, OutputChannel} from 'vscode';
 import {join, dirname, basename} from 'path';
 import findLaunchTargets from '../launchTargetFinder';
 import {runInTerminal} from 'run-in-terminal';
+import {createRequest, toRange} from '../typeConvertion';
+import {spawn, ChildProcess} from 'child_process';
 
 const isWin = /^win/.test(process.platform);
 
@@ -21,7 +23,10 @@ export default function registerCommands(server: OmnisharpServer) {
 	let d4 = commands.registerCommand('o.execute', () => dnxExecuteCommand(server));
 	let d5 = commands.registerCommand('o.execute-last-command', () => dnxExecuteLastCommand(server));
 	let d6 = commands.registerCommand('o.showOutput', () => server.getChannel().show(ViewColumn.Three));
-	return Disposable.from(d1, d2, d3, d4, d5, d6);
+    let d7 = commands.registerCommand('o.runSingleTest', () => runTests(server, "Single"));
+    let d8 = commands.registerCommand('o.runFixtureTests', () => runTests(server, "Fixture"));
+    let d9 = commands.registerCommand('o.runAllTests', () => runTests(server, "All"));
+    return Disposable.from(d1, d2, d3, d4, d5, d6, d7, d8, d9);
 }
 
 function pickProjectAndStart(server: OmnisharpServer) {
@@ -168,4 +173,45 @@ export function dnxRestoreForProject(server: OmnisharpServer, fileName: string) 
 
 		return Promise.reject(`Failed to execute restore, try to run 'dnu restore' manually for ${fileName}.`)
 	});
+}
+
+export function runTests(server: OmnisharpServer, testType) {
+
+    let channel = window.createOutputChannel("Tasks");
+    channel.clear();
+
+    let activeEditor = window.activeTextEditor;
+
+    let request = createRequest<proto.GetTestContextRequest>(activeEditor.document, activeEditor.selection.start);
+    request.Type = testType;
+
+    return server.makeRequest<proto.GetTestContextResponse>(proto.GetTestContext, request).then(value => {
+        let cwd = dirname(activeEditor.document.fileName);
+        return runCommandInOutputChannel(value.TestCommand, channel, cwd);
+    });
+}
+
+export function runCommandInOutputChannel(command: string, channel: OutputChannel, cwd: string): Promise<ChildProcess> {
+
+    return new Promise<ChildProcess>((resolve, reject) => {
+        let args = command.split(" ");
+        let cmd = args.shift();
+        let childprocess: ChildProcess;
+        try {
+            channel.appendLine("[INFO] Running command: " + command);
+            childprocess = spawn(cmd, args, { cwd: cwd});
+        } catch (e) {
+            channel.appendLine("[ERROR]" + e);
+        }
+
+        childprocess.on('error', function(err: any) {
+            channel.appendLine("[ERROR]" + err);
+        });
+
+        childprocess.stdout.on('data', (data: NodeBuffer) => {
+            channel.append(data.toString());
+        });
+
+        resolve(childprocess);
+    });
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -45,6 +45,8 @@ export var FilesChanged = '/filesChanged';
 
 export var SignatureHelp = '/signatureHelp';
 
+export var GetTestContext = '/gettestcontext';
+
 export interface Request {
 	Filename: string;
 	Line?: number;
@@ -334,6 +336,14 @@ export interface UnresolvedDependenciesMessage {
 export interface PackageDependency {
 	Name: string;
 	Version: string;
+}
+
+export interface GetTestContextRequest extends Request {
+    Type : string;
+}
+
+export interface GetTestContextResponse {
+    TestCommand: string;
 }
 
 export namespace V2 {


### PR DESCRIPTION
Hi @jrieken
First I would like to thank you for a great extension, I love it! 
This PR introduces running omnisharp test commands inside vscode output channel. There are three commands:

- Run Single Test (Ctrl+R, R)
- Run Fixture Tests (Ctrl+R, F)
- Run All Test (Ctrl+R, A)

How does it work:
Test output is displayed in standard output channel like any other task. Additionally test execution summary i.e. `Total: 2, Errors: 0, Failed: 1, Skipped: 0, Time: 0.110s` is displayed in status bar. If one of tests fails, output channel is opened at the end of execution, otherwise not so you are not disturbed when tests went smoothly. Currently XUnit and NUnit output format is supported. Those formats right now are [hardcoded](https://github.com/rawman/omnisharp-vscode/commit/1a2a5c107c8d1ad76f88e217d6c97c8f0d7215af#diff-113e1dad6c46a89eadca3377b572593aR233) which I don't like too much, but I don't see better way to understand test output. 

Let me know what do you think. I'm starting to play with TypeScript so I hope I didn't make any horrible things ;)