### PR TITLE
Fix issue with 'Add tasks.json' command

### DIFF
--- a/src/pathHelpers.ts
+++ b/src/pathHelpers.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export enum PathKind {
+    File,
+    Directory
+}
+
+export function getPathKind(path: string): Promise<PathKind> {
+    return new Promise<PathKind>((resolve, reject) =>
+    {
+        fs.lstat(path, (err, stats) => {
+            if (err) {
+                reject(err);
+            }
+            else if (stats.isFile()) {
+                resolve(PathKind.File);
+            }
+            else if (stats.isDirectory()) {
+                resolve(PathKind.Directory);
+            }
+            else {
+                reject(Error(`Path is not file or directory: ${path}`));
+            }
+        });
+    });
+}
+
+export function exists(path: string) {
+    return new Promise<boolean>((resolve, reject) => {
+        fs.exists(path, exists => {
+            if (exists) {
+                resolve(true);
+            }
+            else {
+                resolve(false);
+            }
+        })
+    })
+}
+
+export function mkdir(directoryPath: string) {
+    return new Promise<boolean>((resolve, reject) => {
+        fs.mkdir(directoryPath, err => {
+            if (!err) {
+                resolve(true);
+            }
+            else {
+                reject(err);
+            }
+        })
+    })
+}


### PR DESCRIPTION
The OmniSharp server may targetting solution file (in the case of MSBuild) or simply a folder (in the case of project.json). If it targeted a folder, we would end up stripping off the innermost folder name when attempting to locate/create the .vscode folder.

cc @chuckries, @gregg-miskelly