### PR TITLE
Update licenses for the C# extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ coreclr-debug/bin/**
 coreclr-debug/obj/**
 coreclr-debug/project.lock.json
 coreclr-debug/install.log
++RuntimeLicenses/dependencies/*

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ To **run and develop** do the following:
 * Open in Visual Studio Code (`code .`)
 * *Optional:* run `tsc -w`, make code changes (on Windows, try `start node ".\node_modules\typescript\bin\tsc -w"`)
 * Press F5 to debug
+
+## License  
+The Microsoft C# extension is subject to [these license terms](RuntimeLicenses/license.txt).  
+The source code to this extension is available on [https://github.com/OmniSharp/omnisharp-vscode](https://github.com/OmniSharp/omnisharp-vscode) and licensed under the [MIT license](LICENSE.txt).  

--- a/RuntimeLicenses/dependencies/OpenDebugAD7-License.txt
+++ b/RuntimeLicenses/dependencies/OpenDebugAD7-License.txt
@@ -1,0 +1,120 @@
+﻿MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
+
+MICROSOFT OPENDEBUGAD7 EXTENSION FOR VISUAL STUDIO CODE
+
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you.
+They apply to the pre-release software named above. The terms also apply to any Microsoft services or updates for the software,
+except to the extent those have additional terms.
+
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+
+1. INSTALLATION AND USE RIGHTS. 
+You may install and use any number of copies of the software to develop and test your applications. 
+
+2. TERMS FOR SPECIFIC COMPONENTS. 
+a. Third Party components. The software may include third party components with separate legal notices or governed by other 
+agreements, as described in the ThirdPartyNotices file accompanying the software. Even if such components are governed by other
+agreements, the disclaimers and the limitations on and exclusions of damages below also apply.
+
+3. DATA.  The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may
+use this information to provide services and improve our products and services.  You may opt-out of many of these scenarios, but
+not all, as described in the product documentation.  There are also some features in the software that may enable you to collect
+data from users of your applications. If you use these features to enable data collection in your applications, you must comply 
+with applicable law, including providing appropriate notices to users of your applications. You can learn more about data 
+collection and use in the help documentation and the privacy statement at http://go.microsoft.com/fwlink/?LinkID=528096. Your
+use of the software operates as your consent to these practices.
+
+4. PRE-RELEASE SOFTWARE. This software is a pre-release version. It may not work the way a final version of the software will. 
+We may change it for the final, commercial version. We also may not release a commercial version.
+
+5. FEEDBACK. If you give feedback about the software to Microsoft, you give to Microsoft, without charge, the right to use, 
+share and commercialize your feedback in any way and for any purpose. You will not give feedback that is subject to a license
+that requires Microsoft to license its software or documentation to third parties because we include your feedback in them. 
+These rights survive this agreement.
+
+6. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. 
+Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the 
+software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the 
+software that only allow you to use it in certain ways. For more information, see www.microsoft.com/licensing/userights. You 
+may not
+* work around any technical limitations in the software;
+* reverse engineer, decompile or disassemble the software, or attempt to do so, except and only to the extent required by third
+party licensing terms governing use of certain open-source components that may be included with the software;
+* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
+* use the software in any way that is against the law; or
+* share, publish, rent, or lease the software, or provide the software as a stand-alone hosted as solution for others to use.
+
+7. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the 
+software, which include restrictions on destinations, end users and end use.  For further information on export restrictions, 
+visit (aka.ms/exporting).
+
+8. SUPPORT SERVICES. Because this software is “as is,” we may not provide support services for it.
+
+9. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that 
+you use, are the entire agreement for the software and support services.
+
+10. APPLICABLE LAW.  If you acquired the software in the United States, Washington law applies to interpretation of and claims 
+for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software 
+in any other country, its laws apply.
+
+11. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including 
+consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may 
+also have rights with respect to the party from which you acquired the software. This agreement does not change those other 
+rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the
+below regions, or mandatory country law applies, then the following provisions apply to you:
+a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to 
+affect those rights.
+b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature,
+disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume 
+checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to 
+turn off updates for your specific device or software.
+c. Germany and Austria.
+(i) Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany 
+the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
+(ii) Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as 
+well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
+Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such 
+material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of 
+which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called
+"cardinal obligations"). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
+
+12. LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You 
+may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights
+under the laws of your country if the laws of your country do not permit it to do so.
+
+13. DISCLAIMER OF WARRANTY. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS-IS.” YOU BEAR THE RISK OF USING IT. MICROSOFT
+GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. 
+
+14. LIMITATION ON AND EXCLUSION OF DAMAGES. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS 
+SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS,
+SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet
+sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict
+liability, negligence, or other tort to the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or
+exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or
+other damages.
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in
+French.
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en
+français.
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre
+seule risque et péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en
+vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le
+droit locale, les garanties implicites de qualité marchande, d’adéquation à un usage particulier et d’absence de contrefaçon
+sont exclues.
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses
+fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune
+indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices.
+Cette limitation concerne:
+·     tout ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou
+dans des programmes tiers ; et
+·     les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou 
+d’une autre faute dans la limite autorisée par la loi en vigueur.
+Elle s’applique également, même si Microsoft connaissait ou devrait connaître l’éventualité d’un tel dommage. Si votre pays
+n’autorise pas l’exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que
+ce soit, il se peut que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre égard.
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d’autres droits prévus par les lois
+de votre pays. Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le
+permettent pas.

--- a/RuntimeLicenses/license.txt
+++ b/RuntimeLicenses/license.txt
@@ -1,0 +1,120 @@
+﻿MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
+
+MICROSOFT C# EXTENSION FOR VISUAL STUDIO CODE
+
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you.
+They apply to the pre-release software named above. The terms also apply to any Microsoft services or updates for the software,
+except to the extent those have additional terms.
+
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+
+1. INSTALLATION AND USE RIGHTS. 
+You may install and use any number of copies of the software to develop and test your applications. 
+
+2. TERMS FOR SPECIFIC COMPONENTS. 
+a. Third Party components. The software may include third party components with separate legal notices or governed by other 
+agreements, as described in the ThirdPartyNotices file accompanying the software. Even if such components are governed by other
+agreements, the disclaimers and the limitations on and exclusions of damages below also apply.
+
+3. DATA.  The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may
+use this information to provide services and improve our products and services.  You may opt-out of many of these scenarios, but
+not all, as described in the product documentation.  There are also some features in the software that may enable you to collect
+data from users of your applications. If you use these features to enable data collection in your applications, you must comply 
+with applicable law, including providing appropriate notices to users of your applications. You can learn more about data 
+collection and use in the help documentation and the privacy statement at http://go.microsoft.com/fwlink/?LinkID=528096. Your
+use of the software operates as your consent to these practices.
+
+4. PRE-RELEASE SOFTWARE. This software is a pre-release version. It may not work the way a final version of the software will. 
+We may change it for the final, commercial version. We also may not release a commercial version.
+
+5. FEEDBACK. If you give feedback about the software to Microsoft, you give to Microsoft, without charge, the right to use, 
+share and commercialize your feedback in any way and for any purpose. You will not give feedback that is subject to a license
+that requires Microsoft to license its software or documentation to third parties because we include your feedback in them. 
+These rights survive this agreement.
+
+6. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. 
+Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the 
+software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the 
+software that only allow you to use it in certain ways. For more information, see www.microsoft.com/licensing/userights. You 
+may not
+* work around any technical limitations in the software;
+* reverse engineer, decompile or disassemble the software, or attempt to do so, except and only to the extent required by third
+party licensing terms governing use of certain open-source components that may be included with the software;
+* remove, minimize, block or modify any notices of Microsoft or its suppliers in the software; 
+* use the software in any way that is against the law; or
+* share, publish, rent, or lease the software, or provide the software as a stand-alone hosted as solution for others to use.
+
+7. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the 
+software, which include restrictions on destinations, end users and end use.  For further information on export restrictions, 
+visit (aka.ms/exporting).
+
+8. SUPPORT SERVICES. Because this software is “as is,” we may not provide support services for it.
+
+9. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that 
+you use, are the entire agreement for the software and support services.
+
+10. APPLICABLE LAW.  If you acquired the software in the United States, Washington law applies to interpretation of and claims 
+for breach of this agreement, and the laws of the state where you live apply to all other claims. If you acquired the software 
+in any other country, its laws apply.
+
+11. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including 
+consumer rights, under the laws of your state or country. Separate and apart from your relationship with Microsoft, you may 
+also have rights with respect to the party from which you acquired the software. This agreement does not change those other 
+rights if the laws of your state or country do not permit it to do so. For example, if you acquired the software in one of the
+below regions, or mandatory country law applies, then the following provisions apply to you:
+a. Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to 
+affect those rights.
+b. Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature,
+disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume 
+checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to 
+turn off updates for your specific device or software.
+c. Germany and Austria.
+(i) Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany 
+the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
+(ii) Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as 
+well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
+Subject to the foregoing clause (ii), Microsoft will only be liable for slight negligence if Microsoft is in breach of such 
+material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of 
+which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called
+"cardinal obligations"). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
+
+12. LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You 
+may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights
+under the laws of your country if the laws of your country do not permit it to do so.
+
+13. DISCLAIMER OF WARRANTY. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS-IS.” YOU BEAR THE RISK OF USING IT. MICROSOFT
+GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. 
+
+14. LIMITATION ON AND EXCLUSION OF DAMAGES. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS 
+SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS,
+SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet
+sites, or third party applications; and (b) claims for breach of contract, breach of warranty, guarantee or condition, strict
+liability, negligence, or other tort to the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or
+exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or
+other damages.
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in
+French.
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en
+français.
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre
+seule risque et péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en
+vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le
+droit locale, les garanties implicites de qualité marchande, d’adéquation à un usage particulier et d’absence de contrefaçon
+sont exclues.
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses
+fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune
+indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices.
+Cette limitation concerne:
+·     tout ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou
+dans des programmes tiers ; et
+·     les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou 
+d’une autre faute dans la limite autorisée par la loi en vigueur.
+Elle s’applique également, même si Microsoft connaissait ou devrait connaître l’éventualité d’un tel dommage. Si votre pays
+n’autorise pas l’exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que
+ce soit, il se peut que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre égard.
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d’autres droits prévus par les lois
+de votre pays. Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le
+permettent pas.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "C# for Visual Studio Code (powered by OmniSharp).",
     "displayName": "C#",
     "author": "Microsoft Corporation",
-    "license": "MIT",
+    "license": "SEE LICENSE IN RuntimeLicenses/license.txt",
     "main": "./out/omnisharpMain",
     "scripts": {
         "postinstall": "gulp omnisharp && tsc"


### PR DESCRIPTION
This commit addresses issue #42 and other licensing concerns --
1. Update the readme to reference licensing
2. Change the package.json to reference the EULA rather than the source license.
3. Checkin the OpenDebugAD7 license so that it has a home on the web. Needed for its nuget package.