### PR TITLE
Make extension more resilient against the .NET Core-based OmniSharp

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -216,6 +216,7 @@ export interface ProjectInformationResponse {
 export interface WorkspaceInformationResponse {
 	MsBuild: MsBuildWorkspaceInformation;
 	Dnx: DnxWorkspaceInformation;
+    DotNet: DotNetWorkspaceInformation;
 	ScriptCs: ScriptCsContext;
 }
 
@@ -262,6 +263,15 @@ export interface DnxFramework {
 	Name: string;
 	FriendlyName: string;
 	ShortName: string;
+}
+
+export interface DotNetWorkspaceInformation {
+	Projects: DotNetProject[];
+}
+
+export interface DotNetProject {
+	Path: string;
+	SourceFiles: string[];
 }
 
 export interface RenameRequest extends Request {


### PR DESCRIPTION
The OmniSharp protocol will be changing a bit for .NET Core. Notably, 'MSBuild' is no longer part of the workspace information and 'DotNet' replaces 'Dnx'. This change should handle either variation of the protocol and the extension will no longer error when properties are missing.

cc @gregg-miskelly, @chuckries 