### PR TITLE
Add helper to retrieve project info from OmniSharp

### DIFF
--- a/src/features/omnisharpStatus.ts
+++ b/src/features/omnisharpStatus.ts
@@ -9,7 +9,7 @@ import {OmnisharpServer} from '../omnisharpServer';
 import {dnxRestoreForProject} from './commands';
 import {basename} from 'path';
 import * as proto from '../protocol';
-
+import * as serverUtils from '../omnisharpUtils';
 
 export default function reportStatus(server: OmnisharpServer) {
 	return vscode.Disposable.from(
@@ -110,7 +110,7 @@ export function reportDocumentStatus(server: OmnisharpServer): vscode.Disposable
 		render();
 
 		function updateProjectInfo() {
-			server.makeRequest<proto.WorkspaceInformationResponse>(proto.Projects).then(info => {
+			serverUtils.requestWorkspaceInformation(server).then(info => {
                 
                 interface Project {
                     Path: string;

--- a/src/omnisharpUtils.ts
+++ b/src/omnisharpUtils.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import {OmnisharpServer} from './omnisharpServer';
+import * as proto from './protocol';
+
+export function requestWorkspaceInformation(server: OmnisharpServer) {
+    return server.makeRequest<proto.WorkspaceInformationResponse>(proto.Projects)
+} 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -271,6 +271,10 @@ export interface DotNetWorkspaceInformation {
 
 export interface DotNetProject {
 	Path: string;
+    Name: string;
+    CompilationOutputPath: string;
+    CompilationOutputAssemblyFile: string;
+    CompilationOutputPdbFile: string;
 	SourceFiles: string[];
 }
 


### PR DESCRIPTION
Note: This relies on pre-release OmniSharp bits that have not yet been released. To produce these bits, clone https://github.com/OmniSharp/omnisharp-roslyn, sync the "dev" branch and run the build script. The commit that contains the API this change uses is https://github.com/OmniSharp/omnisharp-roslyn/commit/eb70bf952fd72763262bb6a1bfd4cf72b147c71f.