### PR TITLE
Don't blindly construct signature help if OmniSharp returns null

### DIFF
--- a/src/features/signatureHelpProvider.ts
+++ b/src/features/signatureHelpProvider.ts
@@ -17,6 +17,10 @@ export default class OmniSharpSignatureHelpProvider extends AbstractSupport impl
 		let req = createRequest(document, position);
 
 		return serverUtils.signatureHelp(this._server, req, token).then(res => {
+            
+            if (!res) {
+                return undefined;
+            }
 
 			let ret = new SignatureHelp();
 			ret.activeSignature = res.ActiveSignature;


### PR DESCRIPTION
This is related to https://github.com/OmniSharp/omnisharp-vscode/issues/64. The PR for the OmniSharp-side of this fix is here: https://github.com/OmniSharp/omnisharp-roslyn/pull/436