### PR TITLE
Update launch.json 'program' description

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,8 +172,8 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Path to the program (executable file) to launch. On Windows, a '.exe' suffix is appended if not specified already.",
-                "default": "${workspaceRoot}/bin/Debug/<path-to-program>"
+                "description": "Path to the application dll or .NET Core host executable to launch. Example: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>' where:\n<target-framework>: (example: 'netstandard1.5') This is the name of the framework that the app is being built for. It is set in the project.json file.\n<project-name>: (example: 'MyApp') The name of the project being debugged.",
+                "default": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>"
               },
               "cwd": {
                 "type": "string",
@@ -345,7 +345,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/<path-to-program>",
+            "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false
@@ -355,7 +355,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/<path-to-program>",
+            "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,


### PR DESCRIPTION
With the .NET CLI shared framework changes, 'program' should now be set to the built application dll in most cases. This updates the template and description.