### PR TITLE
Add support for C# 6 keywords

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -293,7 +293,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b",
+          "match": "\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|when)\\b",
           "name": "keyword.control.cs"
         },
         {
@@ -301,7 +301,7 @@
           "name": "keyword.linq.cs"
         },
         {
-          "match": "\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc)\\b",
+          "match": "\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|nameof)\\b",
           "name": "keyword.operator.cs"
         },
         {
@@ -313,7 +313,7 @@
           "name": "storage.type.var.cs"
         },
         {
-          "match": "[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b",
+          "match": "[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof|nameof|when|override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b",
           "name": "meta.class.body.cs"
         }
       ]


### PR DESCRIPTION
C# 6 introduces 2 new keywords, `nameof` and `when`. I've updated the `csharp.json` file to include these keywords among the other ones that are currently recognized, such as `typeof` and `sizeof`.