### PR TITLE
Update to OmniSharp v1.9-alpha6

### DIFF
--- a/src/omnisharpDownload.ts
+++ b/src/omnisharpDownload.ts
@@ -13,7 +13,7 @@ const Decompress = require('decompress');
 const Github = require('github-releases');
 
 const OmnisharpRepo = 'OmniSharp/omnisharp-roslyn';
-const OmnisharpVersion = 'v1.9-alpha3';
+const OmnisharpVersion = 'v1.9-alpha6';
 const DefaultInstallLocation = path.join(__dirname, '../.omnisharp');
 
 tmp.setGracefulCleanup();


### PR DESCRIPTION
This is necessary to take advantage of additional information provided by the DotNetProjectSystem.