### PR TITLE
Fix launch on Windows with forward slashes in program (#143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "0.3.9",
+  "version": "1.0.0-rc2",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -265,7 +265,7 @@ function createProjectJson(targetRuntime: string): any
         dependencies: {
             "Microsoft.VisualStudio.clrdbg": "14.0.25201-preview-2911579",
             "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30401-preview-1",
-            "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20401-preview-1",
+            "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20405-preview-1",
             "NETStandard.Library": "1.5.0-rc2-23931",
             "Newtonsoft.Json": "7.0.1",
             "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",


### PR DESCRIPTION
This checkin updates the version of OpenDebugAD7 used by the C# extension to
the lastest build. This has a fix for #143.

This also updates the package version to 1.0.0-rc2.