### PR TITLE
Fix typo in dotnet restore

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -70,7 +70,7 @@ export function dotnetRestoreAllProjects(server: OmnisharpServer) {
         if ('DotNet' in info && info.DotNet.Projects.length > 0) {
             for (let project of info.DotNet.Projects) {
                 commands.push({
-                    label: `dotnet restor - (${project.Name || path.basename(project.Path)})`,
+                    label: `dotnet restore - (${project.Name || path.basename(project.Path)})`,
                     description: path.dirname(project.Path),
                     execute() {
                         return runInTerminal('dotnet', ['restore'], {


### PR DESCRIPTION
Adds missing `e` in dotnet restore command

![screenshot 2016-04-13 13 32 15](https://cloud.githubusercontent.com/assets/737093/14491975/61d3df26-017c-11e6-975e-42e4efb14743.png)
