### PR TITLE
Update with latest OmniSharp and pick correct version for current Linux distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.0.1-rc2",
+  "version": "1.0.2-rc2",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/omnisharpDownload.ts
+++ b/src/omnisharpDownload.ts
@@ -8,26 +8,39 @@
 import * as fs from 'fs-extra-promise';
 import * as path from 'path';
 import * as tmp from 'tmp';
+import {SupportedPlatform, getSupportedPlatform} from './utils';
 
 const Decompress = require('decompress');
 const Github = require('github-releases');
 
 const OmnisharpRepo = 'OmniSharp/omnisharp-roslyn';
-const OmnisharpVersion = 'v1.9-alpha10';
+const OmnisharpVersion = 'v1.9-alpha13';
 const DefaultInstallLocation = path.join(__dirname, '../.omnisharp');
 
 tmp.setGracefulCleanup();
 
 function getOmnisharpAssetName(): string {
-    switch (process.platform) {
-        case 'win32':
+    switch (getSupportedPlatform()) {
+        case SupportedPlatform.Windows:
             return 'omnisharp-win-x64-net451.zip';
-        case 'darwin':
+        case SupportedPlatform.OSX:
             return 'omnisharp-osx-x64-netcoreapp1.0.tar.gz';
-        case 'linux':
-            return 'omnisharp-linux-x64-netcoreapp1.0.tar.gz';
+        case SupportedPlatform.CentOS:
+            return 'omnisharp-centos-x64-netcoreapp1.0.tar.gz';
+        case SupportedPlatform.Debian:
+            return 'omnisharp-debian-x64-netcoreapp1.0.tar.gz';
+        case SupportedPlatform.RHEL:
+            return 'omnisharp-rhel-x64-netcoreapp1.0.tar.gz';
+        case SupportedPlatform.Ubuntu:
+            return 'omnisharp-ubuntu-x64-netcoreapp1.0.tar.gz';
+            
         default:
-            throw new Error(`Unsupported platform: ${process.platform}`);
+            if (process.platform === 'linux') {
+                throw new Error(`Unsupported linux distribution`);
+            }
+            else {
+                throw new Error(`Unsupported platform: ${process.platform}`);
+            }
     }
 }
 

--- a/src/omnisharpServer.ts
+++ b/src/omnisharpServer.ts
@@ -264,7 +264,7 @@ export abstract class OmnisharpServer {
 		this._fireEvent(Events.StdOut, `[INFO] Starting OmniSharp at '${solutionPath}'...\n`);
 		this._fireEvent(Events.BeforeServerStart, solutionPath);
 
-		return omnisharpLauncher(cwd, argv).then(value => {
+		return omnisharpLauncher(this._channel, cwd, argv).then(value => {
 			this._serverProcess = value.process;
             this._requestDelays = {};
             this._fireEvent(Events.StdOut, `[INFO] Started OmniSharp from '${value.command}' with process id ${value.process.pid}...\n`);

--- a/src/omnisharpServerLauncher.ts
+++ b/src/omnisharpServerLauncher.ts
@@ -7,11 +7,12 @@
 
 import {exists as fileExists} from 'fs';
 import {spawn, ChildProcess} from 'child_process';
-import {workspace} from 'vscode';
+import {workspace, OutputChannel} from 'vscode';
 import {satisfies} from 'semver';
 import {join} from 'path';
 import {getOmnisharpLaunchFilePath} from './omnisharpPath';
 import {downloadOmnisharp} from './omnisharpDownload';
+import {SupportedPlatform, getSupportedPlatform} from './utils';
 
 const isWindows = process.platform === 'win32';
 
@@ -20,20 +21,34 @@ export interface LaunchResult {
     command: string;
 }
 
-export function installOmnisharpIfNeeded(): Promise<string> {
+export function installOmnisharpIfNeeded(output: OutputChannel): Promise<string> {
     return getOmnisharpLaunchFilePath().catch(err => {
+        if (getSupportedPlatform() == SupportedPlatform.None && process.platform === 'linux') {
+            output.appendLine("[ERROR] Could not locate an OmniSharp server that supports your Linux distribution.");
+            output.appendLine("");
+            output.appendLine("OmniSharp provides a richer C# editing experience, with features like IntelliSense and Find All References.");
+            output.appendLine("It is recommend that you download the version of OmniSharp that runs on Mono using the following steps:");
+            output.appendLine("    1. If it's not already installed, download and install Mono (http://www.mono-project.com)");
+            output.appendLine("    2. Download and untar https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.9-alpha13/omnisharp-linux-mono.tar.gz");
+            output.appendLine("    3. In Visual Studio Code, select Preferences->User Settings to open settings.json.");
+            output.appendLine("    4. In settings.json, add a new setting: \"csharp.omnisharp\": \"/path/to/omnisharp/OmniSharp.exe\"");
+            output.appendLine("    5. Restart Visual Studio Code.");
+			output.show();
+            throw err;
+        }
+		
         return downloadOmnisharp().then(_ => {
             return getOmnisharpLaunchFilePath();
         })
     });
 }
 
-export default function launch(cwd: string, args: string[]): Promise<LaunchResult> {
+export default function launch(output: OutputChannel, cwd: string, args: string[]): Promise<LaunchResult> {
 
 	return new Promise<LaunchResult>((resolve, reject) => {
 
 		try {
-			(isWindows ? launchWindows(cwd, args) : launchNix(cwd, args)).then(value => {
+			(isWindows ? launchWindows(output, cwd, args) : launchNix(output, cwd, args)).then(value => {
 
 				// async error - when target not not ENEOT
 				value.process.on('error', reject);
@@ -52,8 +67,8 @@ export default function launch(cwd: string, args: string[]): Promise<LaunchResul
 	});
 }
 
-function launchWindows(cwd: string, args: string[]): Promise<LaunchResult> {
-	return installOmnisharpIfNeeded().then(command => {
+function launchWindows(output: OutputChannel, cwd: string, args: string[]): Promise<LaunchResult> {
+	return installOmnisharpIfNeeded(output).then(command => {
 
 		args = args.slice(0);
 		args.unshift(command);
@@ -77,9 +92,9 @@ function launchWindows(cwd: string, args: string[]): Promise<LaunchResult> {
 	});
 }
 
-function launchNix(cwd: string, args: string[]): Promise<LaunchResult>{
+function launchNix(output: OutputChannel, cwd: string, args: string[]): Promise<LaunchResult>{
     
-    return installOmnisharpIfNeeded().then(command => {
+    return installOmnisharpIfNeeded(output).then(command => {
 		let process = spawn(command, args, {
 			detached: false,
 			// env: details.env,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import * as child_process from 'child_process'
+
+export enum SupportedPlatform {
+    None,
+    Windows,
+    OSX,
+    CentOS,
+    Debian,
+    RHEL,
+    Ubuntu
+}
+
+export function getSupportedPlatform() {
+    if (process.platform === 'win32') {
+        return SupportedPlatform.Windows;
+    }
+    else if (process.platform === 'darwin') {
+        return SupportedPlatform.OSX;
+    }
+    else if (process.platform === 'linux') {
+        // Get the text of /etc/*-release to discover which Linux distribution we're running on.
+        let release = child_process.execSync('cat /etc/*-release').toString().toLowerCase();
+
+        if (release.indexOf('ubuntu') >= 0) {
+            return SupportedPlatform.Ubuntu;
+        }
+        else if (release.indexOf('centos') >= 0) {
+            return SupportedPlatform.CentOS;
+        }
+        else if (release.indexOf('rhel') >= 0) {
+            return SupportedPlatform.RHEL;
+        }
+        else if (release.indexOf('debian') >= 0) {
+            return SupportedPlatform.Debian;
+        }
+    }
+
+    return SupportedPlatform.None;	
+}


### PR DESCRIPTION
We've updated OmniSharp to build releases for each Linux distribution that we currently support: CentOS, Debian, Red Hat (RHEL), and Ubuntu. This change adds code to sniff out which of the supported Linux distros we're running on to determine which flavor of OmniSharp we need to download and install.

cc @gregg-miskelly, @chuckries, @caslan, @Pilchie, @david-driscoll 