### PR TITLE
Fix debugger installation issue on debian

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.0.2-rc2",
+  "version": "1.0.3-rc2",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -263,7 +263,7 @@ function createProjectJson(targetRuntime: string): any
             emitEntryPoint: true
         },
         dependencies: {
-            "Microsoft.VisualStudio.clrdbg": "14.0.25208-preview-2924185",
+            "Microsoft.VisualStudio.clrdbg": "14.0.25214-preview-2934931",
             "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30401-preview-1",
             "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20405-preview-1",
             "NETStandard.Library": "1.5.0-rc2-24008",


### PR DESCRIPTION
Shiproom approved bug fix. Updated the version of clrdbg package used by the extension. Verified with latest debian bits.