### PR TITLE
Use /etc/os-release to determine linux distro #204

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ export function getSupportedPlatform() {
     }
     else if (process.platform === 'linux') {
         // Get the text of /etc/*-release to discover which Linux distribution we're running on.
-        let release = child_process.execSync('cat /etc/*-release').toString().toLowerCase();
+        let release = child_process.execSync('cat /etc/os-release').toString().toLowerCase();
 
         if (release.indexOf('ubuntu') >= 0) {
             return SupportedPlatform.Ubuntu;


### PR DESCRIPTION
Fixes #204

When determine linux distribution use the new configuration file /etc/os-release instead of per-distribution release files /etc/*-release. The majority of the big distributions adopted /etc/os-release.