### PR TITLE
Change default value for 'processId'

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
               "processId": {
                 "type": "integer",
                 "description": "The process id to attach to. If this is used, 'processName' should not be used.",
-                "default": ""
+                "default": 0
               },
               "sourceFileMap": {
                 "type": "object",


### PR DESCRIPTION
If you delete and re-add the "processId" field it would give a default value of:
   "processId": ""

Which might tempt someone to change it to:
   "processId": "1234"

Which is wrong, because processId is an integer rather than a string. But this
distinction is pretty subtle to folks who don't deal with json every day.

The default value to 0 to remove the temptation.