### PR TITLE
Move project.json dependency completion & hover to vscode-omnisharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "./out/omnisharpMain",
   "scripts": {
-    "postinstall": "tsc"
+    "postinstall": "node ./node_modules/vscode/bin/install && tsc"
   },
   "dependencies": {
     "decompress": "^3.0.0",
@@ -24,6 +24,8 @@
     "github-releases": "^0.3.0",
     "run-in-terminal": "*",
     "semver": "*",
+    "request-light": "^0.1.0",
+    "jsonc-parser": "^0.2.0",
     "vscode-debugprotocol": "^1.6.1",
     "vscode-extension-telemetry": "0.0.4",
     "tmp": "0.0.28",
@@ -34,8 +36,8 @@
     "gulp-tslint": "^4.3.0",
     "tslint": "^3.3.0",
     "tslint-microsoft-contrib": "^2.0.0",
-    "typescript": "^1.7.3",
-    "vscode": "^0.10.1",
+    "typescript": "^1.8.9",
+    "vscode": "^0.11.0",
     "vsce": "^1.3.0"
   },
   "engines": {
@@ -43,6 +45,7 @@
   },
   "activationEvents": [
     "onLanguage:csharp",
+    "onLanguage:json",
     "onCommand:o.restart",
     "onCommand:o.pickProjectAndStart",
     "onCommand:o.showOutput",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "activationEvents": [
     "onLanguage:csharp",
-    "onLanguage:json",
     "onCommand:o.restart",
     "onCommand:o.pickProjectAndStart",
     "onCommand:o.showOutput",

--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import {Location, getLocation, createScanner, SyntaxKind} from 'jsonc-parser';
+import {basename} from 'path';
+import {ProjectJSONContribution} from './projectJSONContribution';
+import {XHRRequest, configure as configureXHR, xhr} from 'request-light';
+
+import {CompletionItem, CompletionItemProvider, CompletionList, TextDocument, Position, Hover, HoverProvider,
+		CancellationToken, Range, TextEdit, MarkedString, DocumentSelector, languages, workspace, Disposable} from 'vscode';
+
+export interface ISuggestionsCollector {
+	add(suggestion: CompletionItem): void;
+	error(message:string): void;
+	log(message:string): void;
+	setAsIncomplete(): void;
+}
+
+export interface IJSONContribution {
+	getDocumentSelector(): DocumentSelector;
+	getInfoContribution(fileName: string, location: Location) : Thenable<MarkedString[]>;
+	collectPropertySuggestions(fileName: string, location: Location, currentWord: string, addValue: boolean, isLast:boolean, result: ISuggestionsCollector) : Thenable<any>;
+	collectValueSuggestions(fileName: string, location: Location, result: ISuggestionsCollector): Thenable<any>;
+	collectDefaultSuggestions(fileName: string, result: ISuggestionsCollector): Thenable<any>;
+	resolveSuggestion?(item: CompletionItem): Thenable<CompletionItem>;
+}
+
+export function addJSONProviders() : Disposable {
+	let subscriptions : Disposable[] = [];
+	
+	// configure the XHR library with the latest proxy settings
+	function configureHttpRequest() {
+		let httpSettings = workspace.getConfiguration('http');
+		configureXHR(httpSettings.get<string>('proxy'), httpSettings.get<boolean>('proxyStrictSSL'));
+	}		
+	
+	configureHttpRequest();
+	subscriptions.push(workspace.onDidChangeConfiguration(e => configureHttpRequest()));
+	
+	// register completion and hove providers for JSON setting file(s)
+	let contributions = [ new ProjectJSONContribution(xhr) ];
+	contributions.forEach(contribution => {
+		let selector = contribution.getDocumentSelector();
+		subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution)));
+		subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
+	});
+	
+	return Disposable.from(...subscriptions);
+}
+
+export class JSONHoverProvider implements HoverProvider {
+
+	constructor(private jsonContribution: IJSONContribution) {
+	}
+
+	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
+		let fileName = basename(document.fileName);
+		let offset = document.offsetAt(position);
+		let location = getLocation(document.getText(), offset);
+		let node = location.previousNode;
+		if (node && node.offset <= offset && offset <= node.offset + node.length) {
+			let promise = this.jsonContribution.getInfoContribution(fileName, location);
+			if (promise) {
+				return promise.then(htmlContent => {
+					let range = new Range(document.positionAt(node.offset), document.positionAt(node.offset + node.length));
+					let result: Hover = {
+						contents: htmlContent,
+						range: range
+					};
+					return result;
+				});
+			}
+		}
+		return null;
+	}
+}
+
+export class JSONCompletionItemProvider implements CompletionItemProvider {
+
+	constructor(private jsonContribution: IJSONContribution) {
+	}
+
+	public resolveCompletionItem(item: CompletionItem, token: CancellationToken) : Thenable<CompletionItem> {
+		if (this.jsonContribution.resolveSuggestion) {
+			let resolver = this.jsonContribution.resolveSuggestion(item);
+			if (resolver) {
+				return resolver;
+			}
+		}
+		return Promise.resolve(item);
+	}
+
+	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Thenable<CompletionList> {
+
+		let fileName = basename(document.fileName);
+
+		let currentWord = this.getCurrentWord(document, position);
+		let overwriteRange = null;
+		let items: CompletionItem[] = [];
+		let isIncomplete = false;
+
+		let offset = document.offsetAt(position);
+		let location = getLocation(document.getText(), offset);
+
+		let node = location.previousNode;
+		if (node && node.offset <= offset && offset <= node.offset + node.length && (node.type === 'property' || node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'null')) {
+			overwriteRange = new Range(document.positionAt(node.offset), document.positionAt(node.offset + node.length));
+		} else {
+			overwriteRange = new Range(document.positionAt(offset - currentWord.length), position);
+		}
+
+		let proposed: { [key: string]: boolean } = {};
+		let collector: ISuggestionsCollector = {
+			add: (suggestion: CompletionItem) => {
+				if (!proposed[suggestion.label]) {
+					proposed[suggestion.label] = true;
+					if (overwriteRange) {
+						suggestion.textEdit = TextEdit.replace(overwriteRange, suggestion.insertText);
+					}
+
+					items.push(suggestion);
+				}
+			},
+			setAsIncomplete: () => isIncomplete = true,
+			error: (message: string) => console.error(message),
+			log: (message: string) => console.log(message)
+		};
+
+		let collectPromise : Thenable<any> = null;
+
+		if (location.isAtPropertyKey) {
+			let addValue = !location.previousNode || !location.previousNode.columnOffset && (offset == (location.previousNode.offset + location.previousNode.length));
+			let scanner = createScanner(document.getText(), true);
+			scanner.setPosition(offset);
+			scanner.scan();
+			let isLast = scanner.getToken() === SyntaxKind.CloseBraceToken || scanner.getToken() === SyntaxKind.EOF;
+			collectPromise = this.jsonContribution.collectPropertySuggestions(fileName, location, currentWord, addValue, isLast, collector);
+		} else {
+			if (location.path.length === 0) {
+				collectPromise = this.jsonContribution.collectDefaultSuggestions(fileName, collector);
+			} else {
+				collectPromise = this.jsonContribution.collectValueSuggestions(fileName, location, collector);
+			}
+		}
+		if (collectPromise) {
+			return collectPromise.then(() => {
+				if (items.length > 0) {
+					return new CompletionList(items, isIncomplete);
+				}
+				return null;
+			});
+		}
+		return null;
+	}
+
+	private getCurrentWord(document: TextDocument, position: Position) {
+		var i = position.character - 1;
+		var text = document.lineAt(position.line).text;
+		while (i >= 0 && ' \t\n\r\v":{[,'.indexOf(text.charAt(i)) === -1) {
+			i--;
+		}
+		return text.substring(i+1, position.character);
+	}
+}

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -1,0 +1,236 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import {MarkedString, CompletionItemKind, CompletionItem, DocumentSelector} from 'vscode';
+import {XHRRequest, XHRResponse, getErrorStatusDescription} from 'request-light';
+import {IJSONContribution, ISuggestionsCollector} from './jsonContributions';
+import {Location} from 'jsonc-parser';
+
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
+const FEED_INDEX_URL = 'https://api.nuget.org/v3/index.json';
+const LIMIT = 30;
+const RESOLVE_ID = 'ProjectJSONContribution-';
+
+interface NugetServices {
+	'SearchQueryService'?: string;
+	'SearchAutocompleteService'?: string;
+	'PackageBaseAddress/3.0.0'?: string;
+	[key: string]: string;
+}
+
+export class ProjectJSONContribution implements IJSONContribution {
+
+	private nugetIndexPromise: Thenable<NugetServices>;
+
+	public constructor(private requestService: XHRRequest) {
+	}
+
+	public getDocumentSelector(): DocumentSelector {
+		return  [{ language: 'json', pattern: '**/project.json' }];
+	}
+	
+	private getNugetIndex() : Thenable<NugetServices> {
+		if (!this.nugetIndexPromise) {
+			this.nugetIndexPromise = this.makeJSONRequest<any>(FEED_INDEX_URL).then(indexContent => {
+				let services : NugetServices = {};
+				if (indexContent && Array.isArray(indexContent.resources)) {
+					let resources = <any[]>  indexContent.resources;
+					for (let i = resources.length - 1; i >= 0; i--) {
+						let type = resources[i]['@type'];
+						let id = resources[i]['@id'];
+						if (type && id) {
+							services[type] = id;
+						}
+					}
+				}
+				return services;
+			});
+		}
+		return this.nugetIndexPromise;
+	}
+
+	private getNugetService(serviceType: string) : Thenable<string> {
+		return this.getNugetIndex().then(services => {
+			let serviceURL = services[serviceType];
+			if (!serviceURL) {
+				return Promise.reject<string>(localize('json.nugget.error.missingservice', 'NuGet index document is missing service {0}', serviceType));
+			}
+			return serviceURL;
+		});
+	}
+
+	private makeJSONRequest<T>(url: string) : Thenable<T> {
+		return this.requestService({
+			url : url
+		}).then(success => {
+			if (success.status === 200) {
+				try {
+					return <T> JSON.parse(success.responseText);
+				} catch (e) {
+					return Promise.reject<T>(localize('json.nugget.error.invalidformat', '{0} is not a valid JSON document', url));
+				}
+			}
+			return Promise.reject<T>(localize('json.nugget.error.indexaccess', 'Request to {0} failed: {1}', url, success.responseText));
+		}, (error: XHRResponse) => {
+			return Promise.reject<T>(localize('json.nugget.error.access', 'Request to {0} failed: {1}', url, getErrorStatusDescription(error.status)));
+		});
+	}
+	
+	public collectPropertySuggestions(resource: string, location: Location, currentWord: string, addValue: boolean, isLast:boolean, result: ISuggestionsCollector) : Thenable<any> {
+		if ((location.matches(['dependencies']) || location.matches(['frameworks', '*', 'dependencies']) || location.matches(['frameworks', '*', 'frameworkAssemblies']))) {
+
+			return this.getNugetService('SearchAutocompleteService').then(service => {
+				let queryUrl : string;
+				if (currentWord.length > 0) {
+					queryUrl = service + '?q=' + encodeURIComponent(currentWord) +'&take=' + LIMIT;
+				} else {
+					queryUrl = service + '?take=' + LIMIT;
+				}
+				return this.makeJSONRequest<any>(queryUrl).then(resultObj => {
+					if (Array.isArray(resultObj.data)) {
+						let results = <any[]> resultObj.data;
+						for (let i = 0; i < results.length; i++) {
+							let name = results[i];
+							let insertText = JSON.stringify(name);
+							if (addValue) {
+								insertText += ': "{{}}"';
+								if (!isLast) {
+									insertText += ',';
+								}
+							}
+							let proposal = new CompletionItem(name);
+							proposal.kind = CompletionItemKind.Property;
+							proposal.insertText = insertText;
+							result.add(proposal);
+						}
+						if (results.length === LIMIT) {
+							result.setAsIncomplete();
+						}
+					}
+				}, error => {
+					result.error(error);
+				});
+			}, error => {
+				result.error(error);
+			});
+		};
+		return null;
+	}
+
+	public collectValueSuggestions(resource: string, location: Location, result: ISuggestionsCollector): Thenable<any> {
+		if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
+			return this.getNugetService('PackageBaseAddress/3.0.0').then(service => {
+				let currentKey = location.path[location.path.length - 1];
+				if (typeof currentKey === 'string') {
+					let queryUrl = service + currentKey + '/index.json';
+					return this.makeJSONRequest<any>(queryUrl).then(obj => {
+						if (Array.isArray(obj.versions)) {
+							let results = <any[]> obj.versions;
+							for (let i = 0; i < results.length; i++) {
+								let curr = results[i];
+								let name = JSON.stringify(curr);
+								let proposal = new CompletionItem(name);
+								proposal.kind = CompletionItemKind.Class;
+								proposal.insertText = name;
+								proposal.documentation = '';
+								result.add(proposal);
+							}
+							if (results.length === LIMIT) {
+								result.setAsIncomplete();
+							}
+						}
+					}, error => {
+						result.error(error);
+					});
+				}
+			}, error => {
+				result.error(error);
+			});
+		}
+		return null;
+	}
+	
+	public collectDefaultSuggestions(resource: string, result: ISuggestionsCollector): Thenable<any> {
+		let defaultValue = {
+			'version': '{{1.0.0-*}}',
+			'dependencies': {},
+			'frameworks': {
+				'dnx451': {},
+				'dnxcore50': {}
+			}
+		};
+		let proposal = new CompletionItem(localize('json.project.default', 'Default project.json'));
+		proposal.kind = CompletionItemKind.Module;
+		proposal.insertText = JSON.stringify(defaultValue, null, '\t');
+		result.add(proposal);
+		return null;
+	}
+	
+	public resolveSuggestion(item: CompletionItem) : Thenable<CompletionItem> {
+		if (item.kind === CompletionItemKind.Property) {
+			let pack = item.label
+			return this.getInfo(pack).then(info => {
+				if (info.description) {
+					item.documentation = info.description;
+				}
+				if (info.version) {
+					item.detail = info.version;
+					item.insertText = item.insertText.replace(/\{\{\}\}/, '{{' + info.version + '}}');
+				}
+				return item;
+			});
+		}
+		return null;
+	}	
+	
+	private getInfo(pack:string): Thenable<{ description?: string; version?: string}>{
+		return this.getNugetService('SearchQueryService').then(service => {
+			let queryUrl = service + '?q=' + encodeURIComponent(pack) +'&take=' + 5;
+			return this.makeJSONRequest<any>(queryUrl).then(resultObj => {
+				if (Array.isArray(resultObj.data)) {
+					let results = <any[]> resultObj.data;
+					let info : { description?: string; version?: string} = {};
+					for (let i = 0; i < results.length; i++) {
+						let res = results[i];
+						if (res.id === pack) {
+							info.description = res.description;
+							info.version = localize('json.nugget.version.hover', 'Latest version: {0}', res.version);
+						}
+					}
+					return info;
+				}
+				return null;
+			}, (error) => {
+				return null;
+			});
+		}, (error) => {
+			return null;
+		});
+	}
+	
+
+	public getInfoContribution(resource: string, location: Location): Thenable<MarkedString[]> {
+		if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
+			let pack = location.path[location.path.length - 1];
+			if (typeof pack === 'string') {
+				return this.getInfo(pack).then(info => {
+					let htmlContent : MarkedString[] = [];
+					htmlContent.push(localize('json.nugget.package.hover', '{0}', pack));
+					if (info.description) {
+						htmlContent.push(info.description);
+					}
+					if (info.version) {
+						htmlContent.push(info.version);
+					}
+					return htmlContent;
+				});
+			}
+		}
+		return null;
+	}
+}

--- a/src/omnisharpMain.ts
+++ b/src/omnisharpMain.ts
@@ -19,6 +19,7 @@ import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
 import reportDiagnostics,{Advisor} from './features/diagnosticsProvider';
 import SignatureHelpProvider from './features/signatureHelpProvider';
 import registerCommands from './features/commands';
+import {addJSONProviders} from './features/json/jsonContributions';
 import {StdioOmnisharpServer} from './omnisharpServer';
 import forwardChanges from './features/changeForwarding';
 import reportStatus from './features/omnisharpStatus';
@@ -90,7 +91,10 @@ export function activate(context: vscode.ExtensionContext): any {
 		server.reportAndClearTelemetry();
 		server.stop();
 	}));
-		
+	
+	// register JSON completion & hover providers for project.json
+	context.subscriptions.push(addJSONProviders());
+	
     // install coreclr-debug
     coreclrdebug.activate(context, reporter);
     


### PR DESCRIPTION
Until now the code that drove intellisense for dependencies in project.json was sitting in the JSON extension.
 We want the omnisharp extension to take ownership.
 This pull request implements a completion provider and a hover provider using the newly created 'jsonc-parser' node module that does the JSON file processing.
 It gets nuget packages from the nuget API, but is not aware of any nuget configuration files.

In the future the omnisharp extension can also consider to power the completions and hovers directly from the omnisharp server.

We will remove the project.json completion support from the JSON extension for the coming release (end of April).
