### PR TITLE
Fix syntax highlighting of several preprocessor keywords to not require a trailing space

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -553,7 +553,7 @@
           "name": "meta.preprocessor.cs"
         },
         {
-          "match": "^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\\/]+)\\s",
+          "match": "^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\\/]+)\\s*",
           "name": "meta.preprocessor.cs"
         }
       ]


### PR DESCRIPTION
Fixes #174

Before:

![image](https://cloud.githubusercontent.com/assets/116161/14726075/9007bff8-07d4-11e6-8d2a-fad21500640b.png)

After:

![image](https://cloud.githubusercontent.com/assets/116161/14726098/a4422f44-07d4-11e6-8521-61a12be6cf94.png)
