### PR TITLE
Fix spelling mistake in `dotnet restore` label

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -70,7 +70,7 @@ export function dotnetRestoreAllProjects(server: OmnisharpServer) {
         if ('DotNet' in info && info.DotNet.Projects.length > 0) {
             for (let project of info.DotNet.Projects) {
                 commands.push({
-                    label: `dotnet restor - (${project.Name || path.basename(project.Path)})`,
+                    label: `dotnet restore - (${project.Name || path.basename(project.Path)})`,
                     description: path.dirname(project.Path),
                     execute() {
                         return runInTerminal('dotnet', ['restore'], {


### PR DESCRIPTION
The trailing `e` was missing in the `dotnet restore` command's label. This PR corrects the spelling mistake which appears in Command Palette:

![dotnet_restore](https://cloud.githubusercontent.com/assets/10702007/14943618/5a0fa59c-0fa3-11e6-9199-c88def4631e7.png)
