### PR TITLE
[Dev] Add 'ASPNETCORE_ENVIRONMENT' to default ASP.NET launch options

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,6 +258,12 @@
                   }
                 }
               },
+              "env": {
+                "type": "object",
+                "additionalProperties": { "type": "string" },
+                "description": "Environment variables passed to the program.",
+                "default": { }
+              },
               "sourceFileMap": {
                 "type": "object",
                 "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
@@ -349,6 +355,9 @@
               "linux": {
                 "command": "xdg-open"
               }
+            },
+            "env": {
+              "ASPNETCORE_ENVIRONMENT": "Development"
             }
           },
           {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -24,7 +24,8 @@ interface ConsoleLaunchConfiguration extends DebugConfiguration {
     program: string,
     args: string[],
     cwd: string,
-    stopAtEntry: boolean
+    stopAtEntry: boolean,
+    env?: any
 }
 
 interface CommandLine {
@@ -164,6 +165,9 @@ function createWebLaunchConfiguration(targetFramework: string, executableName: s
             linux: {
                 command: 'xdg-open'
             }
+        },
+        env: {
+            ASPNETCORE_ENVIRONMENT: "Development"
         }
     }
 }


### PR DESCRIPTION
**NOTE** Need to insert a new post-RC2 OpenDebugAD7 before this PR can be completed. Please review though.

This checkin adds 'env' to the launch.json schema, and it adds a
"ASPNETCORE_ENVIRONMENT=Development" environment variable by default.

This completes the fix for
https://github.com/OmniSharp/omnisharp-vscode/issues/172