### PR TITLE
Fix spelling mistake in 'Successfully'

### DIFF
--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -185,7 +185,7 @@ function removeLibCoreClrTraceProvider() : Promise<void>
                 if (err) {
                     reject(err.code);
                 } else {
-                    _channel.appendLine('Succesfully deleted ' + filePath);
+                    _channel.appendLine('Successfully deleted ' + filePath);
                     resolve();
                 }
             });


### PR DESCRIPTION
This PR corrects a very minor spelling mistake within the `removeLibCoreClrTraceProvider` function of `src\coreclr-debug\main.ts`.