### PR TITLE
Remove myget.org package sources

### DIFF
--- a/coreclr-debug/NuGet.config
+++ b/coreclr-debug/NuGet.config
@@ -3,8 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="coreclr-debug" value="https://www.myget.org/F/coreclr-debug/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Once CoreCLR/FX/debugger package sources are live on nuget.org, this PR will be completed.