### PR TITLE
Update version number to 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.0.7-rc2",
+  "version": "1.0.8",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",


### PR DESCRIPTION
VS Code marketplace didn't support versioning suffixes. Removing.