### PR TITLE
No longer download OmniSharp from GitHub releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -21,7 +21,6 @@
     "decompress": "^3.0.0",
     "del": "^2.0.2",
     "fs-extra-promise": "^0.3.1",
-    "github-releases": "^0.3.0",
     "run-in-terminal": "*",
     "semver": "*",
     "vscode-debugprotocol": "^1.6.1",

--- a/src/omnisharpDownload.ts
+++ b/src/omnisharpDownload.ts
@@ -7,14 +7,15 @@
 
 import * as fs from 'fs-extra-promise';
 import * as path from 'path';
+import * as https from 'https';
+import * as stream from 'stream';
 import * as tmp from 'tmp';
+import {parse} from 'url';
 import {SupportedPlatform, getSupportedPlatform} from './utils';
 
 const Decompress = require('decompress');
-const Github = require('github-releases');
 
-const OmnisharpRepo = 'OmniSharp/omnisharp-roslyn';
-const OmnisharpVersion = 'v1.9-alpha14';
+const BaseDownloadUrl = 'https://vscodeoscon.blob.core.windows.net/ext';
 const DefaultInstallLocation = path.join(__dirname, '../.omnisharp');
 const ApiToken = '18a6f5ecea711220d4f433d4fd41062d479fda1d';
 
@@ -45,46 +46,39 @@ function getOmnisharpAssetName(): string {
     }
 }
 
+function download(urlString: string): Promise<stream.Readable> {
+    let url = parse(urlString);
+    let options: https.RequestOptions = {
+        host: url.host,
+        path: url.path,
+    }
+    
+    return new Promise<stream.Readable>((resolve, reject) => {
+        return https.get(options, res => {
+            // handle redirection
+            if (res.statusCode === 302) {
+                return download(res.headers.location);
+            }
+            else if (res.statusCode !== 200) {
+                return reject(Error(`Download failed with code ${res.statusCode}.`));
+            }
+            
+            return resolve(res);
+        });
+    });
+}
+
 export function downloadOmnisharp(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
         console.log(`[OmniSharp]: Installing to ${DefaultInstallLocation}`);
         
-        const repo = new Github({ repo: OmnisharpRepo, token: ApiToken });
         const assetName = getOmnisharpAssetName();
+        const urlString = `${BaseDownloadUrl}/${assetName}`;
         
-        console.log(`[OmniSharp] Looking for ${OmnisharpVersion}, ${assetName}...`);
-        
-        repo.getReleases({ tag_name: OmnisharpVersion }, (err, releases) => {
-            if (err) {
-                return reject(err);
-            }
-            
-            if (!releases.length) {
-                return reject(new Error(`OmniSharp release ${OmnisharpVersion} not found.`));
-            }
-            
-            // Note: there should only be a single release, but use the first one
-            // if there are ever multiple results. Same thing for assets.
-            let foundAsset = null;
-            
-            for (var asset of releases[0].assets) {
-                if (asset.name === assetName) {
-                    foundAsset = asset;
-                    break;
-                }
-            }
-            
-            if (!foundAsset) {
-                return reject(new Error(`OmniSharp release ${OmnisharpVersion} asset, ${assetName} not found.`));
-            }
-            
-            console.log(`[OmniSharp] Found it!`);
-            
-            repo.downloadAsset(foundAsset, (err, inStream) => {
-                if (err) {
-                    return reject(err);
-                }
-                
+        console.log(`[OmniSharp] Attempting to download ${assetName}...`);
+
+        return download(urlString)
+            .then(inStream => {
                 tmp.file((err, tmpPath, fd, cleanupCallback) => {
                     if (err) {
                         return reject(err);
@@ -106,7 +100,7 @@ export function downloadOmnisharp(): Promise<boolean> {
                             .src(tmpPath)
                             .dest(DefaultInstallLocation);
                             
-                        if (path.extname(foundAsset.name).toLowerCase() === '.zip') {
+                        if (path.extname(assetName).toLowerCase() === '.zip') {
                             decompress = decompress.use(Decompress.zip());
                             console.log(`[OmniSharp] Unzipping...`);
                         }
@@ -129,6 +123,5 @@ export function downloadOmnisharp(): Promise<boolean> {
                     inStream.pipe(outStream);
                 });
             });
-        });
     });
 }


### PR DESCRIPTION
This removes the code that discovers and downloads OmniSharp from the GitHub and switches over to Azure blog storage.

cc @MattGertz, @gregg-miskelly, @caslan, @chuckries, @jaredpar