### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,25 @@
 |:--:|:--:|
 |[![Master Build Status](https://travis-ci.org/OmniSharp/omnisharp-vscode.svg?branch=master)](https://travis-ci.org/OmniSharp/omnisharp-vscode)|[![Dev Build Status](https://travis-ci.org/OmniSharp/omnisharp-vscode.svg?branch=dev)](https://travis-ci.org/OmniSharp/omnisharp-vscode)|
 
-This is a preview of C# support in Visual Studio code. It is designed to work well with [.NET Core 1.0](http://dotnet.github.io/). 
-These new projects are based on project.json and the [.NET CLI](https://dotnet.github.io/getting-started/).
+Welcome to the C# extension for Visual Studio Code! This preview provides the following features inside VS Code:
 
-### Support for .csproj and Mono on OS X and Linux
+* Lightweight development tools for [.NET Core](https://dotnet.github.io).
+* Great C# editing support, including Syntax Highlighting, IntelliSense, Go to Definition, Find All References, etc.
+* Debugging support for .NET Core projects targeting CoreCLR.
+* Support for project.json and csproj projects.
 
-Support for .csproj projects will be improved in future versions of this extension. For now, if you are targeting Mono scenarios (ex: Unity or Xamarin) we suggest instead installing the 'Built-in Omnisharp' extension. Note that the name of the OmniSharp extension is no longer correct - the extension is no longer built into VS Code.
+The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn).
 
-Use the following steps to install the older OmniSharp extension for Mono support:
+### **Important!** Breaking Changes as of 1.0.10
 
-1. Install ASP.NET 5 RC1 (NOTE: Do **NOT** use RC2)
-    * Windows: https://docs.asp.net/en/1.0.0-rc1/getting-started/installing-on-windows.html
-    * OSX: https://docs.asp.net/en/1.0.0-rc1/getting-started/installing-on-mac.html. Follow the instructions for using Mono.
-    * Linux: https://docs.asp.net/en/1.0.0-rc1/getting-started/installing-on-linux.html. Follow the instructions for using Mono.
-2. Bring up the extension list in VS Code by opening the command pallet (F1 key) and type 'ext install'.
-3. After VS Code has downloaded the extension list, type 'omnisharp' and select 'Built-in Omnisharp' from the list.
-4. Open a C# file. If intellisense isn't working, open the output window (View->Toggle Output) and look at the 'OmniSharp Log'.
+* The C# extension now only supports [.NET Core RC2](https://blogs.msdn.microsoft.com/dotnet/2016/05/16/announcing-net-core-rc2/). It no longer supports .NET Core RC1 or ASP .NET 5 RC1.
+* **Support for .csproj projects has been temporarily disabled on OS X and Linux.** This will impact anyone doing .csproj development on OS X or Linux (e.g. Unity, Xamarin, etc.). Rest assured that this will be restored in the near future. However, for now, you can use the [Legacy C# Support extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.omnisharp).
+
+### Found a Bug?
+Please file any issues at https://github.com/OmniSharp/omnisharp-vscode/issues.
 
 ### Debugging
-This version supports basic debugging capabilities.
-See http://aka.ms/vscclrdebugger for details.
+The C# extension now supports basic debugging capabilities! See http://aka.ms/vscclrdebugger for details.
 
 ### Development
 To **run and develop** do the following:
@@ -33,7 +32,6 @@ To **run and develop** do the following:
 * *Optional:* run `tsc -w`, make code changes (on Windows, try `start node ".\node_modules\typescript\bin\tsc -w"`)
 * Press F5 to debug
 
-
-## License  
+### License
 The Microsoft C# extension is subject to [these license terms](RuntimeLicenses/license.txt).  
 The source code to this extension is available on [https://github.com/OmniSharp/omnisharp-vscode](https://github.com/OmniSharp/omnisharp-vscode) and licensed under the [MIT license](LICENSE.txt).  

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to the C# extension for Visual Studio Code! This preview provides the fo
 * Lightweight development tools for [.NET Core](https://dotnet.github.io).
 * Great C# editing support, including Syntax Highlighting, IntelliSense, Go to Definition, Find All References, etc.
 * Debugging support for .NET Core projects targeting CoreCLR.
-* Support for project.json and csproj projects.
+* Support for project.json projects on Windows, OS X and Linux, and csproj projects on Windows.
 
 The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the C# extension for Visual Studio Code! This preview provides the fo
 
 * Lightweight development tools for [.NET Core](https://dotnet.github.io).
 * Great C# editing support, including Syntax Highlighting, IntelliSense, Go to Definition, Find All References, etc.
-* Debugging support for .NET Core projects targeting CoreCLR.
+* Debugging support for .NET Core (CoreCLR). NOTE: Mono and Desktop CLR debugging is not supported.
 * Support for project.json projects on Windows, OS X and Linux, and csproj projects on Windows.
 
 The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "license": "SEE LICENSE IN RuntimeLicenses/license.txt",
   "icon": "images/csharpIcon.png",
   "preview": "true",
+  "bugs": {
+    "url": "https://github.com/OmniSharp/omnisharp-vscode/issues"
+  },
   "categories": [
     "Debuggers",
     "Languages",


### PR DESCRIPTION
cc @staceyhaffner, @gregg-miskelly 

The cleans up the readme for the C# extension a bit. The text that we added to add instructions on using the legacy extension was a bit too prominent, which led some users to think that they need to follow those steps to install the regular extension. The instructions will be moved to the legacy extension's readme.