### PR TITLE
Don't package .nyc_output or coverage directories in VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,9 @@ src/**
 .vscode/**
 .omnisharp/**
 
+**/.nyc_output/**
+**/coverage/**
+
 coreclr-debug/debugAdapters/**
 coreclr-debug/bin/**
 coreclr-debug/obj/**


### PR DESCRIPTION
For some reason, on @gregg-miskelly is able to produce much smaller VSIXs that I am. Digging into the folder diffs, it turns out that, on my machine(s), a large amount of code coverage data from one of the node modules (readable-stream) is being included in the VSIX package. This change updates the .vscodeignore file to just ignore those.