### PR TITLE
Fix respecting a system or user configured proxy.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,15 +9,16 @@ const del = require('del');
 const gulp = require('gulp');
 const tslint = require('gulp-tslint');
 const vsce = require('vsce');
-const omnisharpDownload = require('./out/omnisharpDownload');
+//const omnisharpDownload = require('./out/omnisharpDownload');
 
 gulp.task('omnisharp:clean', () => {
 	return del('.omnisharp');
 });
 
-gulp.task('omnisharp:fetch', ['omnisharp:clean'], () => {
-	return omnisharpDownload.downloadOmnisharp();
-});
+//TODO: decouple omnisharpDownload (specifically proxy.ts) from vscode 
+// gulp.task('omnisharp:fetch', ['omnisharp:clean'], () => {
+// 	return omnisharpDownload.downloadOmnisharp();
+// });
 
 const allTypeScript = [
     'src/**/*.ts',
@@ -45,7 +46,7 @@ gulp.task('tslint', () => {
         }))
 });
 
-gulp.task('omnisharp', ['omnisharp:fetch']);
+// gulp.task('omnisharp', ['omnisharp:fetch']);
 
 gulp.task('package', () => {
     vsce(['', '', 'package']);

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
             "csharp"
           ]
         },
-        "runtime": "",
+        "runtime": "node",
         "runtimeArgs": [],
         "program": "./out/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
         },
         "runtime": "",
         "runtimeArgs": [],
-        "program": "./coreclr-debug/debugAdapters/OpenDebugAD7.exe",
+        "program": "./out/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "decompress": "^3.0.0",
     "del": "^2.0.2",
     "fs-extra-promise": "^0.3.1",
+    "http-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^1.0.0",
+    "open": "*",
     "semver": "*",
-    "vscode-debugprotocol": "^1.6.1",
-    "vscode-extension-telemetry": "0.0.4",
     "tmp": "0.0.28",
-    "open": "*"
+    "vscode-debugprotocol": "^1.6.1",
+    "vscode-extension-telemetry": "0.0.4"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
@@ -139,9 +141,9 @@
             "csharp"
           ]
         },
-        "runtime": "node",
+        "runtime": "",
         "runtimeArgs": [],
-        "program": "./out/coreclr-debug/proxy.js",
+        "program": "./coreclr-debug/debugAdapters/OpenDebugAD7.exe",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {

--- a/src/omnisharpDownload.ts
+++ b/src/omnisharpDownload.ts
@@ -12,6 +12,7 @@ import * as stream from 'stream';
 import * as tmp from 'tmp';
 import {parse} from 'url';
 import {SupportedPlatform, getSupportedPlatform} from './utils';
+import {getProxyAgent} from './proxy';
 
 const Decompress = require('decompress');
 
@@ -48,10 +49,14 @@ function getOmnisharpAssetName(): string {
 
 function download(urlString: string): Promise<stream.Readable> {
     let url = parse(urlString);
+    
+    const agent = getProxyAgent(url);
+    
     let options: https.RequestOptions = {
         host: url.host,
         path: url.path,
-    }
+        agent: agent
+    };
     
     return new Promise<stream.Readable>((resolve, reject) => {
         return https.get(options, res => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { Url, parse as parseUrl } from 'url';
+import HttpProxyAgent = require('http-proxy-agent');
+import HttpsProxyAgent = require('https-proxy-agent');
+import {workspace} from 'vscode';
+
+function getSystemProxyURL(requestURL: Url): string {
+	if (requestURL.protocol === 'http:') {
+		return process.env.HTTP_PROXY || process.env.http_proxy || null;
+	} else if (requestURL.protocol === 'https:') {
+		return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null;
+	}
+
+	return null;
+}
+
+export function getProxyAgent(requestURL: Url): any {
+	const vsConfigProxyUrl = workspace.getConfiguration().get<string>('http.proxy');
+	const proxyURL = vsConfigProxyUrl || getSystemProxyURL(requestURL);
+
+	if (!proxyURL) {
+		return null;
+	}
+	
+	const proxyEndpoint = parseUrl(proxyURL);
+
+	if (!/^https?:$/.test(proxyEndpoint.protocol)) {
+		return null;
+	}
+
+	const strictSSL = workspace.getConfiguration().get('http.proxyStrictSSL', true);
+	const opts = {
+		host: proxyEndpoint.hostname,
+		port: Number(proxyEndpoint.port),
+		auth: proxyEndpoint.auth,
+		rejectUnauthorized: strictSSL
+	};
+
+	return requestURL.protocol === 'http:' ? new HttpProxyAgent(opts) : new HttpsProxyAgent(opts);
+}

--- a/src/typings/http-proxy-agent/http-proxy-agent.d.ts
+++ b/src/typings/http-proxy-agent/http-proxy-agent.d.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'http-proxy-agent' {
+
+	interface IHttpProxyAgentOptions {
+		host: string;
+		port: number;
+		auth?: string;
+	}
+
+	class HttpProxyAgent {
+		constructor(proxy: string);
+		constructor(opts: IHttpProxyAgentOptions);
+	}
+	
+	export = HttpProxyAgent;
+}

--- a/src/typings/https-proxy-agent/https-proxy-agent.d.ts
+++ b/src/typings/https-proxy-agent/https-proxy-agent.d.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'https-proxy-agent' {
+
+	import * as tls from 'tls';
+
+	interface IHttpsProxyAgentOptions extends tls.ConnectionOptions {
+		host: string;
+		port: number;
+		auth?: string;
+		secureProxy?: boolean;
+		secureEndpoint?: boolean;
+	}
+
+	class HttpsProxyAgent {
+		constructor(proxy: string);
+		constructor(opts: IHttpsProxyAgentOptions);
+	}
+	
+	export = HttpsProxyAgent;
+}


### PR DESCRIPTION
Add libraries http-proxy-agent and https-proxy-agent
just like vscode itself does and then use that to
request omnisharp binaries.
Most code is taken from vscode and adapted.

Fixes #349 