### PR TITLE
Discover and execute (both run and debug) xunit test in VS Code

### DIFF
--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -8,6 +8,7 @@
 import {CancellationToken, CodeLens, Range, Uri, TextDocument, CodeLensProvider} from 'vscode';
 import {toRange, toLocation} from '../typeConvertion';
 import AbstractSupport from './abstractProvider';
+import {updateCodeLensForTest} from './dotnetTest';
 import * as protocol from '../protocol';
 import * as serverUtils from '../omnisharpUtils';
 
@@ -52,14 +53,7 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
             OmniSharpCodeLensProvider._convertQuickFix(bucket, fileName, child);
         }
 
-        let testFeature = node.Features.find(value => value.startsWith('XunitTestMethod'));
-        if (testFeature) {
-            // this test method has a test feature
-            let testMethod = testFeature.split(':')[1];
-
-            bucket.push(new CodeLens(toRange(node.Location), { title: "run test", command: 'dotnet.test.run', arguments: [testMethod, fileName] }));
-            bucket.push(new CodeLens(toRange(node.Location), { title: "debug test", command: 'dotnet.test.debug', arguments: [testMethod, fileName] }));
-        }
+        updateCodeLensForTest(bucket, fileName, node);
     }
 
     resolveCodeLens(codeLens: CodeLens, token: CancellationToken): Thenable<CodeLens> {

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -32,15 +32,15 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
     };
 
     provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-
+        let request = { Filename: document.fileName };
         return serverUtils.currentFileMembersAsTree(this._server, { Filename: document.fileName }, token).then(tree => {
             let ret: CodeLens[] = [];
-            tree.TopLevelTypeDefinitions.forEach(node => OmniSharpCodeLensProvider._convertQuickFix(ret, document.fileName, node));
+            tree.TopLevelTypeDefinitions.forEach(node => this._convertQuickFix(ret, document.fileName, node));
             return ret;
         });
     }
 
-    private static _convertQuickFix(bucket: CodeLens[], fileName: string, node: protocol.Node): void {
+    private _convertQuickFix(bucket: CodeLens[], fileName: string, node: protocol.Node): void {
 
         if (node.Kind === 'MethodDeclaration' && OmniSharpCodeLensProvider.filteredSymbolNames[node.Location.Text]) {
             return;
@@ -50,10 +50,10 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
         bucket.push(lens);
 
         for (let child of node.ChildNodes) {
-            OmniSharpCodeLensProvider._convertQuickFix(bucket, fileName, child);
+            this._convertQuickFix(bucket, fileName, child);
         }
 
-        updateCodeLensForTest(bucket, fileName, node);
+        updateCodeLensForTest(bucket, fileName, node, this._server.isDebugEnable());
     }
 
     resolveCodeLens(codeLens: CodeLens, token: CancellationToken): Thenable<CodeLens> {

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -13,71 +13,80 @@ import * as serverUtils from '../omnisharpUtils';
 
 class OmniSharpCodeLens extends CodeLens {
 
-	fileName: string;
+    fileName: string;
 
-	constructor(fileName: string, range: Range) {
-		super(range);
-		this.fileName = fileName;
-	}
+    constructor(fileName: string, range: Range) {
+        super(range);
+        this.fileName = fileName;
+    }
 }
 
 export default class OmniSharpCodeLensProvider extends AbstractSupport implements CodeLensProvider {
 
-	private static filteredSymbolNames: { [name: string]: boolean } = {
-		'Equals': true,
-		'Finalize': true,
-		'GetHashCode': true,
-		'ToString': true
-	};
+    private static filteredSymbolNames: { [name: string]: boolean } = {
+        'Equals': true,
+        'Finalize': true,
+        'GetHashCode': true,
+        'ToString': true
+    };
 
-	provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+    provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
 
-		return serverUtils.currentFileMembersAsTree(this._server, { Filename: document.fileName }, token).then(tree => {
-			let ret: CodeLens[] = [];
-			tree.TopLevelTypeDefinitions.forEach(node => OmniSharpCodeLensProvider._convertQuickFix(ret, document.fileName, node));
-			return ret;
-		});
-	}
+        return serverUtils.currentFileMembersAsTree(this._server, { Filename: document.fileName }, token).then(tree => {
+            let ret: CodeLens[] = [];
+            tree.TopLevelTypeDefinitions.forEach(node => OmniSharpCodeLensProvider._convertQuickFix(ret, document.fileName, node));
+            return ret;
+        });
+    }
 
-	private static _convertQuickFix(bucket: CodeLens[], fileName:string, node: protocol.Node): void {
+    private static _convertQuickFix(bucket: CodeLens[], fileName: string, node: protocol.Node): void {
 
-		if (node.Kind === 'MethodDeclaration' && OmniSharpCodeLensProvider.filteredSymbolNames[node.Location.Text]) {
-			return;
-		}
+        if (node.Kind === 'MethodDeclaration' && OmniSharpCodeLensProvider.filteredSymbolNames[node.Location.Text]) {
+            return;
+        }
 
-		let lens = new OmniSharpCodeLens(fileName, toRange(node.Location));
-		bucket.push(lens);
+        let lens = new OmniSharpCodeLens(fileName, toRange(node.Location));
+        bucket.push(lens);
 
-		for (let child of node.ChildNodes) {
-			OmniSharpCodeLensProvider._convertQuickFix(bucket, fileName, child);
-		}
-	}
+        for (let child of node.ChildNodes) {
+            OmniSharpCodeLensProvider._convertQuickFix(bucket, fileName, child);
+        }
 
-	resolveCodeLens(codeLens: CodeLens, token: CancellationToken): Thenable<CodeLens> {
-		if (codeLens instanceof OmniSharpCodeLens) {
+        let testFeature = node.Features.find(value => value.startsWith('XunitTestMethod'));
+        if (testFeature) {
+            // this test method has a test feature
+            let testMethod = testFeature.split(':')[1];
 
-			let req = <protocol.FindUsagesRequest>{
-				Filename: codeLens.fileName,
-				Line: codeLens.range.start.line + 1,
-				Column: codeLens.range.start.character + 1,
-				OnlyThisFile: false,
-				ExcludeDefinition: true
-			};
+            bucket.push(new CodeLens(toRange(node.Location), { title: "run test", command: 'dotnet.test.run', arguments: [testMethod, fileName] }));
+            bucket.push(new CodeLens(toRange(node.Location), { title: "debug test", command: 'dotnet.test.debug', arguments: [testMethod, fileName] }));
+        }
+    }
 
-			return serverUtils.findUsages(this._server, req, token).then(res => {
-				if (!res || !Array.isArray(res.QuickFixes)) {
-					return;
-				}
-                
-				let len = res.QuickFixes.length;
-				codeLens.command = {
-					title: len === 1 ? '1 reference' : `${len} references`,
-					command: 'editor.action.showReferences',
-					arguments: [Uri.file(req.Filename), codeLens.range.start, res.QuickFixes.map(toLocation)]
-				};
+    resolveCodeLens(codeLens: CodeLens, token: CancellationToken): Thenable<CodeLens> {
+        if (codeLens instanceof OmniSharpCodeLens) {
 
-				return codeLens;
-			});
-		}
-	}
+            let req = <protocol.FindUsagesRequest>{
+                Filename: codeLens.fileName,
+                Line: codeLens.range.start.line + 1,
+                Column: codeLens.range.start.character + 1,
+                OnlyThisFile: false,
+                ExcludeDefinition: true
+            };
+
+            return serverUtils.findUsages(this._server, req, token).then(res => {
+                if (!res || !Array.isArray(res.QuickFixes)) {
+                    return;
+                }
+
+                let len = res.QuickFixes.length;
+                codeLens.command = {
+                    title: len === 1 ? '1 reference' : `${len} references`,
+                    command: 'editor.action.showReferences',
+                    arguments: [Uri.file(req.Filename), codeLens.range.start, res.QuickFixes.map(toLocation)]
+                };
+
+                return codeLens;
+            });
+        }
+    }
 }

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -48,7 +48,7 @@ function debugDotnetTest(testMethod: string, fileName: string, server: Omnisharp
                 "type": "coreclr",
                 "request": "launch",
                 "program": response.Executable,
-                "args": [response.Argument],
+                "args": response.Argument.split(' '),
                 "cwd": "${workspaceRoot}",
                 "stopAtEntry": false
             }

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs-extra-promise';
 import * as path from 'path';
 import * as protocol from '../protocol';
 import * as vscode from 'vscode';
+import * as dotnetTest from './dotnetTest'
 
 let channel = vscode.window.createOutputChannel('.NET');
 
@@ -27,37 +28,8 @@ export default function registerCommands(server: OmnisharpServer, extensionPath:
     let d5 = vscode.commands.registerCommand('csharp.downloadDebugger', () => { });
 
     return vscode.Disposable.from(d1, d2, d3, d4, d5,
-        vscode.commands.registerCommand('dotnet.test.run', (testMethod, fileName) => runDotnetTest(testMethod, fileName, server)),
-        vscode.commands.registerCommand('dotnet.test.debug', (testMethod, fileName) => debugDotnetTest(testMethod, fileName, server)));
-}
-
-// Run test through dotnet-test command. This function can be moved to a separate structure
-function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
-    serverUtils.runDotNetTest(server, { FileName: fileName, MethodName: testMethod }).then(response => {
-        if (response.Pass) {
-            vscode.window.showInformationMessage('Test passed');
-        }
-        else {
-            vscode.window.showErrorMessage('Test failed');
-        }
-    });
-}
-
-// Run test through dotnet-test command with debugger attached
-function debugDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
-    serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod }).then(response => {
-        vscode.commands.executeCommand(
-            'vscode.startDebug', {
-                "name": ".NET test launch",
-                "type": "coreclr",
-                "request": "launch",
-                "program": response.Executable,
-                "args": response.Argument.split(' '),
-                "cwd": "${workspaceRoot}",
-                "stopAtEntry": false
-            }
-        );
-    });
+        dotnetTest.registerDotNetTestRunCommand(server),
+        dotnetTest.registerDotNetTestDebugCommand(server));
 }
 
 function pickProjectAndStart(server: OmnisharpServer) {

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -33,9 +33,13 @@ export default function registerCommands(server: OmnisharpServer, extensionPath:
 
 // Run test through dotnet-test command. This function can be moved to a separate structure
 function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
-    vscode.window.showInformationMessage('run test! ' + testMethod + ' at ' + fileName);
     serverUtils.runDotNetTest(server, { FileName: fileName, MethodName: testMethod }).then(response => {
-        vscode.window.showInformationMessage('Test ' + testMethod + response.Pass ? 'Passed' : 'Failed');
+        if (response.Pass) {
+            vscode.window.showInformationMessage('Test passed');
+        }
+        else {
+            vscode.window.showErrorMessage('Test failed');
+        }
     });
 }
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -27,9 +27,11 @@ export default function registerCommands(server: OmnisharpServer, extensionPath:
     // running the command activates the extension, which is all we need for installation to kickoff
     let d5 = vscode.commands.registerCommand('csharp.downloadDebugger', () => { });
 
-    return vscode.Disposable.from(d1, d2, d3, d4, d5,
-        dotnetTest.registerDotNetTestRunCommand(server),
-        dotnetTest.registerDotNetTestDebugCommand(server));
+    // register two commands for running and debugging xunit tests
+    let d6 = dotnetTest.registerDotNetTestRunCommand(server);
+    let d7 = dotnetTest.registerDotNetTestDebugCommand(server);
+
+    return vscode.Disposable.from(d1, d2, d3, d4, d5, d6, d7);
 }
 
 function pickProjectAndStart(server: OmnisharpServer) {

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -17,130 +17,157 @@ import * as vscode from 'vscode';
 let channel = vscode.window.createOutputChannel('.NET');
 
 export default function registerCommands(server: OmnisharpServer, extensionPath: string) {
-	let d1 = vscode.commands.registerCommand('o.restart', () => server.restart());
-	let d2 = vscode.commands.registerCommand('o.pickProjectAndStart', () => pickProjectAndStart(server));
-	let d3 = vscode.commands.registerCommand('o.showOutput', () => server.getChannel().show(vscode.ViewColumn.Three));
-    let d4 = vscode.commands.registerCommand('dotnet.restore', () => dotnetRestoreAllProjects(server)); 
-	
+    let d1 = vscode.commands.registerCommand('o.restart', () => server.restart());
+    let d2 = vscode.commands.registerCommand('o.pickProjectAndStart', () => pickProjectAndStart(server));
+    let d3 = vscode.commands.registerCommand('o.showOutput', () => server.getChannel().show(vscode.ViewColumn.Three));
+    let d4 = vscode.commands.registerCommand('dotnet.restore', () => dotnetRestoreAllProjects(server));
+
     // register empty handler for csharp.installDebugger
     // running the command activates the extension, which is all we need for installation to kickoff
     let d5 = vscode.commands.registerCommand('csharp.downloadDebugger', () => { });
-    
-	return vscode.Disposable.from(d1, d2, d3, d4, d5);
+
+    return vscode.Disposable.from(d1, d2, d3, d4, d5,
+        vscode.commands.registerCommand('dotnet.test.run', (testMethod, fileName) => runDotnetTest(testMethod, fileName, server)),
+        vscode.commands.registerCommand('dotnet.test.debug', (testMethod, fileName) => debugDotnetTest(testMethod, fileName, server)));
+}
+
+// Run test through dotnet-test command. This function can be moved to a separate structure
+function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+    vscode.window.showInformationMessage('run test! ' + testMethod + ' at ' + fileName);
+    serverUtils.runDotNetTest(server, { FileName: fileName, MethodName: testMethod }).then(response => {
+        vscode.window.showInformationMessage('Test ' + testMethod + response.Pass ? 'Passed' : 'Failed');
+    });
+}
+
+// Run test through dotnet-test command with debugger attached
+function debugDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+    serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod }).then(response => {
+        vscode.commands.executeCommand(
+            'vscode.startDebug', {
+                "name": ".NET test launch",
+                "type": "coreclr",
+                "request": "launch",
+                "program": response.Executable,
+                "args": [response.Argument],
+                "cwd": "${workspaceRoot}",
+                "stopAtEntry": false
+            }
+        );
+    });
 }
 
 function pickProjectAndStart(server: OmnisharpServer) {
 
-	return findLaunchTargets().then(targets => {
+    return findLaunchTargets().then(targets => {
 
-		let currentPath = server.getSolutionPathOrFolder();
-		if (currentPath) {
-			for (let target of targets) {
-				if (target.target.fsPath === currentPath) {
-					target.label = `\u2713 ${target.label}`;
-				}
-			}
-		}
+        let currentPath = server.getSolutionPathOrFolder();
+        if (currentPath) {
+            for (let target of targets) {
+                if (target.target.fsPath === currentPath) {
+                    target.label = `\u2713 ${target.label}`;
+                }
+            }
+        }
 
-		return vscode.window.showQuickPick(targets, {
-			matchOnDescription: true,
-			placeHolder: `Select 1 of ${targets.length} projects`
-		}).then(target => {
-			if (target) {
-				return server.restart(target.target.fsPath);
-			}
-		});
-	});
+        return vscode.window.showQuickPick(targets, {
+            matchOnDescription: true,
+            placeHolder: `Select 1 of ${targets.length} projects`
+        }).then(target => {
+            if (target) {
+                return server.restart(target.target.fsPath);
+            }
+        });
+    });
 }
 
 interface Command {
-	label: string;
-	description: string;
-	execute(): Thenable<any>;
+    label: string;
+    description: string;
+    execute(): Thenable<any>;
 }
 
 function projectsToCommands(projects: protocol.DotNetProject[]): Promise<Command>[] {
-	return projects.map(project => {
-		let projectDirectory = project.Path;
+    return projects.map(project => {
+        let projectDirectory = project.Path;
 
-		return fs.lstatAsync(projectDirectory).then(stats => {
-			if (stats.isFile()) {
-				projectDirectory = path.dirname(projectDirectory);
-			}
+        return fs.lstatAsync(projectDirectory).then(stats => {
+            if (stats.isFile()) {
+                projectDirectory = path.dirname(projectDirectory);
+            }
 
-			return {
-				label: `dotnet restore - (${project.Name || path.basename(project.Path)})`,
-				description: projectDirectory,
-				execute() {
-					return runDotnetRestore(projectDirectory);
-				}
-			};
-		});
-	});
+            return {
+                label: `dotnet restore - (${project.Name || path.basename(project.Path)})`,
+                description: projectDirectory,
+                execute() {
+                    return runDotnetRestore(projectDirectory);
+                }
+            };
+        });
+    });
 }
 
 export function dotnetRestoreAllProjects(server: OmnisharpServer) {
 
-	if (!server.isRunning()) {
-		return Promise.reject('OmniSharp server is not running.');
-	}
+    if (!server.isRunning()) {
+        return Promise.reject('OmniSharp server is not running.');
+    }
 
-	return serverUtils.requestWorkspaceInformation(server).then(info => {
+    return serverUtils.requestWorkspaceInformation(server).then(info => {
 
-		if (!('DotNet in info') || info.DotNet.Projects.length < 1) {
-			return Promise.reject("No .NET Core projects found");
-		}
-		
-		let commandPromises = projectsToCommands(info.DotNet.Projects);
-        
-		return Promise.all(commandPromises).then(commands => {
-			return vscode.window.showQuickPick(commands);
-		}).then(command => {
-			if (command) {
-				return command.execute();
-			}
-		});
-	});
+        if (!('DotNet in info') || info.DotNet.Projects.length < 1) {
+            return Promise.reject("No .NET Core projects found");
+        }
+
+        let commandPromises = projectsToCommands(info.DotNet.Projects);
+
+        return Promise.all(commandPromises).then(commands => {
+            return vscode.window.showQuickPick(commands);
+        }).then(command => {
+            if (command) {
+                return command.execute();
+            }
+        });
+    });
 }
 
 export function dotnetRestoreForProject(server: OmnisharpServer, fileName: string) {
 
-	if (!server.isRunning()) {
-		return Promise.reject('OmniSharp server is not running.');
-	}
+    if (!server.isRunning()) {
+        return Promise.reject('OmniSharp server is not running.');
+    }
 
-	return serverUtils.requestWorkspaceInformation(server).then(info => {
+    return serverUtils.requestWorkspaceInformation(server).then(info => {
 
-		if (!('DotNet in info') || info.DotNet.Projects.length < 1) {
-			return Promise.reject("No .NET Core projects found");
-		}
-		
-		let directory = path.dirname(fileName);
-		
-		for (let project of info.DotNet.Projects) {
-			if (project.Path === directory) {
-				return runDotnetRestore(directory, fileName);
-			}
-		}
-	});
+        if (!('DotNet in info') || info.DotNet.Projects.length < 1) {
+            return Promise.reject("No .NET Core projects found");
+        }
+
+        let directory = path.dirname(fileName);
+
+        for (let project of info.DotNet.Projects) {
+            if (project.Path === directory) {
+                return runDotnetRestore(directory, fileName);
+            }
+        }
+    });
 }
 
 function runDotnetRestore(cwd: string, fileName?: string) {
-	return new Promise<cp.ChildProcess>((resolve, reject) => {
-		channel.clear();
-		channel.show();
-		
-		let cmd = 'dotnet restore';
-		if (fileName) {
-			cmd = `${cmd} "${fileName}"`
-		}
-		
-		return cp.exec(cmd, {cwd: cwd, env: process.env}, (err, stdout, stderr) => {
-			channel.append(stdout.toString());
-			channel.append(stderr.toString());
-			if (err) {
-				channel.append('ERROR: ' + err);
-			}
-		});		
-	});
+    return new Promise<cp.ChildProcess>((resolve, reject) => {
+        channel.clear();
+        channel.show();
+
+        let cmd = 'dotnet restore';
+        if (fileName) {
+            cmd = `${cmd} "${fileName}"`
+        }
+
+        return cp.exec(cmd, { cwd: cwd, env: process.env }, (err, stdout, stderr) => {
+            channel.append(stdout.toString());
+            channel.append(stderr.toString());
+            if (err) {
+                channel.append('ERROR: ' + err);
+            }
+        });
+    });
 }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -49,7 +49,7 @@ export function runDotnetTest(testMethod: string, fileName: string, server: Omni
             }
         },
         reason => {
-            vscode.window.showErrorMessage('Fail to run test because ' + reason + '.');
+            vscode.window.showErrorMessage(`Failed to run test because ${reason}.`);
         });
 }
 
@@ -68,7 +68,7 @@ export function debugDotnetTest(testMethod: string, fileName: string, server: Om
             }
         ).then(
             response => { },
-            reason => { vscode.window.showErrorMessage('Failed to start debugger on test because ' + reason + '.') });
+            reason => { vscode.window.showErrorMessage(`Failed to start debugger on test because ${reason}.`) });
     });
 }
 

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -6,8 +6,10 @@
 'use strict';
 
 import {OmnisharpServer} from '../omnisharpServer';
+import {toRange} from '../typeConvertion';
 import * as vscode from 'vscode';
 import * as serverUtils from "../omnisharpUtils";
+import * as protocol from '../protocol';
 
 export function registerDotNetTestRunCommand(server: OmnisharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
@@ -54,4 +56,20 @@ export function debugDotnetTest(testMethod: string, fileName: string, server: Om
             }
         ).then(undefined, reason => { vscode.window.showErrorMessage('Failed to debug test because ' + reason + '.') });
     });
+}
+
+export function updateCodeLensForTest(bucket: vscode.CodeLens[], fileName: string, node: protocol.Node) {
+    let testFeature = node.Features.find(value => value.startsWith('XunitTestMethod'));
+    if (testFeature) {
+        // this test method has a test feature
+        let testMethod = testFeature.split(':')[1];
+
+        bucket.push(new vscode.CodeLens(
+            toRange(node.Location),
+            { title: "run test", command: 'dotnet.test.run', arguments: [testMethod, fileName] }));
+
+        bucket.push(new vscode.CodeLens(
+            toRange(node.Location),
+            { title: "debug test", command: 'dotnet.test.debug', arguments: [testMethod, fileName] }));
+    }
 }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import {OmnisharpServer} from '../omnisharpServer';
+import * as vscode from 'vscode';
+import * as serverUtils from "../omnisharpUtils";
+
+export function registerDotNetTestRunCommand(server: OmnisharpServer): vscode.Disposable {
+    return vscode.commands.registerCommand(
+        'dotnet.test.run',
+        (testMethod, fileName) => runDotnetTest(testMethod, fileName, server));
+}
+
+export function registerDotNetTestDebugCommand(server: OmnisharpServer): vscode.Disposable {
+    return vscode.commands.registerCommand(
+        'dotnet.test.debug',
+        (testMethod, fileName) => debugDotnetTest(testMethod, fileName, server));
+}
+
+// Run test through dotnet-test command. This function can be moved to a separate structure
+export function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+    serverUtils
+        .runDotNetTest(server, { FileName: fileName, MethodName: testMethod })
+        .then(
+        response => {
+            if (response.Pass) {
+                vscode.window.showInformationMessage('Test passed');
+            }
+            else {
+                vscode.window.showErrorMessage('Test failed');
+            }
+        },
+        reason => {
+            vscode.window.showErrorMessage('Fail to run test because ' + reason + '.');
+        });
+}
+
+// Run test through dotnet-test command with debugger attached
+export function debugDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+    serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod }).then(response => {
+        vscode.commands.executeCommand(
+            'vscode.startDebug', {
+                "name": ".NET test launch",
+                "type": "coreclr",
+                "request": "launch",
+                "program": response.Executable,
+                "args": response.Argument.split(' '),
+                "cwd": "${workspaceRoot}",
+                "stopAtEntry": false
+            }
+        ).then(undefined, reason => { vscode.window.showErrorMessage('Failed to debug test because ' + reason + '.') });
+    });
+}

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -11,6 +11,15 @@ import * as vscode from 'vscode';
 import * as serverUtils from "../omnisharpUtils";
 import * as protocol from '../protocol';
 
+let enableDebug = false;
+
+// check if debugger start is enable
+vscode.commands.getCommands().then(commands => {
+    if (commands.find(c => c == "vscode.startDebug")) {
+        enableDebug = true;
+    }
+});
+
 export function registerDotNetTestRunCommand(server: OmnisharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.run',
@@ -54,7 +63,11 @@ export function debugDotnetTest(testMethod: string, fileName: string, server: Om
                 "cwd": "${workspaceRoot}",
                 "stopAtEntry": false
             }
-        ).then(undefined, reason => { vscode.window.showErrorMessage('Failed to debug test because ' + reason + '.') });
+        ).then(
+            response => {
+                vscode.window.showInformationMessage('call back from debugger start command')
+            },
+            reason => { vscode.window.showErrorMessage('Failed to debug test because ' + reason + '.') });
     });
 }
 
@@ -68,8 +81,10 @@ export function updateCodeLensForTest(bucket: vscode.CodeLens[], fileName: strin
             toRange(node.Location),
             { title: "run test", command: 'dotnet.test.run', arguments: [testMethod, fileName] }));
 
-        bucket.push(new vscode.CodeLens(
-            toRange(node.Location),
-            { title: "debug test", command: 'dotnet.test.debug', arguments: [testMethod, fileName] }));
+        if (enableDebug) {
+            bucket.push(new vscode.CodeLens(
+                toRange(node.Location),
+                { title: "debug test", command: 'dotnet.test.debug', arguments: [testMethod, fileName] }));
+        }
     }
 }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -11,6 +11,16 @@ import * as vscode from 'vscode';
 import * as serverUtils from "../omnisharpUtils";
 import * as protocol from '../protocol';
 
+let _testOutputChannel: vscode.OutputChannel = undefined;
+
+function getTestOutputChannel(): vscode.OutputChannel {
+    if (_testOutputChannel == undefined) {
+        _testOutputChannel = vscode.window.createOutputChannel(".NET Test Log");
+    }
+
+    return _testOutputChannel;
+}
+
 export function registerDotNetTestRunCommand(server: OmnisharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.run',
@@ -25,15 +35,17 @@ export function registerDotNetTestDebugCommand(server: OmnisharpServer): vscode.
 
 // Run test through dotnet-test command. This function can be moved to a separate structure
 export function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+    getTestOutputChannel().show();
+    getTestOutputChannel().appendLine('Running test ' + testMethod + '...');
     serverUtils
         .runDotNetTest(server, { FileName: fileName, MethodName: testMethod })
         .then(
         response => {
             if (response.Pass) {
-                vscode.window.showInformationMessage('Test passed');
+                getTestOutputChannel().appendLine('Test passed \n');
             }
             else {
-                vscode.window.showErrorMessage('Test failed');
+                getTestOutputChannel().appendLine('Test failed \n');
             }
         },
         reason => {

--- a/src/omnisharpUtils.ts
+++ b/src/omnisharpUtils.ts
@@ -73,3 +73,10 @@ export function updateBuffer(server: OmnisharpServer, request: protocol.UpdateBu
     return server.makeRequest<boolean>(protocol.Requests.UpdateBuffer, request);
 }
 
+export function getTestStartInfo(server: OmnisharpServer, request: protocol.GetTestStartInfoRequest) {
+    return server.makeRequest<protocol.GetTestStartInfoResponse>(protocol.Requests.GetTestStartInfo, request);
+}
+
+export function runDotNetTest(server: OmnisharpServer, request: protocol.RunDotNetTestRequest) {
+    return server.makeRequest<protocol.RunDotNetTestResponse>(protocol.Requests.RunDotNetTest, request);
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -176,11 +176,16 @@ export interface GetCodeActionsResponse {
     CodeActions: string[];
 }
 
+export interface SyntaxFeature {
+    Name: string;
+    Data: string;
+}
+
 export interface Node {
     ChildNodes: Node[];
     Location: QuickFix;
     Kind: string;
-    Features: string[];
+    Features: SyntaxFeature[];
 }
 
 export interface CurrentFileMembersAsTreeResponse {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -27,8 +27,8 @@ export module Requests {
     export const TypeLookup = '/typelookup';
     export const UpdateBuffer = '/updatebuffer';
 
-    export const GetTestStartInfo = '/getteststartinfo';
-    export const RunDotNetTest = '/rundotnettest';
+    export const GetTestStartInfo = '/v2/getteststartinfo';
+    export const RunDotNetTest = '/v2/runtest';
 }
 
 export interface Request {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -23,16 +23,19 @@ export module Requests {
     export const RemoveFromProject = '/removefromproject';
     export const Rename = '/rename';
     export const RunCodeAction = '/runcodeaction';
-    export const SignatureHelp = '/signatureHelp';   
+    export const SignatureHelp = '/signatureHelp';
     export const TypeLookup = '/typelookup';
     export const UpdateBuffer = '/updatebuffer';
+
+    export const GetTestStartInfo = '/getteststartinfo';
+    export const RunDotNetTest = '/rundotnettest';
 }
 
 export interface Request {
-	Filename: string;
-	Line?: number;
-	Column?: number;
-	Buffer?: string;
+    Filename: string;
+    Line?: number;
+    Column?: number;
+    Buffer?: string;
     Changes?: LinePositionSpanTextChange[];
 }
 
@@ -49,394 +52,417 @@ export interface UpdateBufferRequest extends Request {
 }
 
 export interface ChangeBufferRequest {
-	FileName: string;
-	StartLine: number;
-	StartColumn: number;
-	EndLine: number;
-	EndColumn: number;
-	NewText: string;
+    FileName: string;
+    StartLine: number;
+    StartColumn: number;
+    EndLine: number;
+    EndColumn: number;
+    NewText: string;
 }
 
 export interface AddToProjectRequest extends Request {
-	//?
+    //?
 }
 
 export interface RemoveFromProjectRequest extends Request {
-	//?
+    //?
 }
 
 export interface FindUsagesRequest extends Request {
-	//        MaxWidth: number; ?
-	OnlyThisFile: boolean;
-	ExcludeDefinition: boolean;
+    //        MaxWidth: number; ?
+    OnlyThisFile: boolean;
+    ExcludeDefinition: boolean;
 }
 
 export interface FindSymbolsRequest extends Request {
-	Filter: string;
+    Filter: string;
 }
 
 export interface FormatRequest extends Request {
-	ExpandTab: boolean;
+    ExpandTab: boolean;
 }
 
 export interface CodeActionRequest extends Request {
-	CodeAction: number;
-	WantsTextChanges?: boolean;
-	SelectionStartColumn?: number;
-	SelectionStartLine?: number;
-	SelectionEndColumn?: number;
-	SelectionEndLine?: number;
+    CodeAction: number;
+    WantsTextChanges?: boolean;
+    SelectionStartColumn?: number;
+    SelectionStartLine?: number;
+    SelectionEndColumn?: number;
+    SelectionEndLine?: number;
 }
 
 export interface FormatResponse {
-	Buffer: string;
+    Buffer: string;
 }
 
 export interface TextChange {
-	NewText: string;
-	StartLine: number;
-	StartColumn: number;
-	EndLine: number;
-	EndColumn: number;
+    NewText: string;
+    StartLine: number;
+    StartColumn: number;
+    EndLine: number;
+    EndColumn: number;
 }
 
 export interface FormatAfterKeystrokeRequest extends Request {
-	Character: string;
+    Character: string;
 }
 
 export interface FormatRangeRequest extends Request {
-	EndLine: number;
-	EndColumn: number;
+    EndLine: number;
+    EndColumn: number;
 }
 
 export interface FormatRangeResponse {
-	Changes: TextChange[];
+    Changes: TextChange[];
 }
 
 export interface ResourceLocation {
-	FileName: string;
-	Line: number;
-	Column: number;
+    FileName: string;
+    Line: number;
+    Column: number;
 }
 
 export interface Error {
-	Message: string;
-	Line: number;
-	Column: number;
-	EndLine: number;
-	EndColumn: number;
-	FileName: string;
+    Message: string;
+    Line: number;
+    Column: number;
+    EndLine: number;
+    EndColumn: number;
+    FileName: string;
 }
 
 export interface ErrorResponse {
-	Errors: Error[];
+    Errors: Error[];
 }
 
 export interface QuickFix {
-	LogLevel: string;
-	FileName: string;
-	Line: number;
-	Column: number;
-	EndLine: number;
-	EndColumn: number;
-	Text: string;
-	Projects: string[];
+    LogLevel: string;
+    FileName: string;
+    Line: number;
+    Column: number;
+    EndLine: number;
+    EndColumn: number;
+    Text: string;
+    Projects: string[];
 }
 
 export interface SymbolLocation extends QuickFix {
-	Kind: string;
+    Kind: string;
 }
 
 export interface QuickFixResponse {
-	QuickFixes: QuickFix[];
+    QuickFixes: QuickFix[];
 }
 
 export interface FindSymbolsResponse {
-	QuickFixes: SymbolLocation[];
+    QuickFixes: SymbolLocation[];
 }
 
 export interface TypeLookupRequest extends Request {
-	IncludeDocumentation: boolean;
+    IncludeDocumentation: boolean;
 }
 
 export interface TypeLookupResponse {
-	Type: string;
-	Documentation: string;
+    Type: string;
+    Documentation: string;
 }
 
 export interface RunCodeActionResponse {
-	Text: string;
-	Changes: TextChange[];
+    Text: string;
+    Changes: TextChange[];
 }
 
 export interface GetCodeActionsResponse {
-	CodeActions: string[];
+    CodeActions: string[];
 }
 
 export interface Node {
-	ChildNodes: Node[];
-	Location: QuickFix;
-	Kind: string;
+    ChildNodes: Node[];
+    Location: QuickFix;
+    Kind: string;
+    Features: string[];
 }
 
 export interface CurrentFileMembersAsTreeResponse {
-	TopLevelTypeDefinitions: Node[];
+    TopLevelTypeDefinitions: Node[];
 }
 
 export interface AutoCompleteRequest extends Request {
-	WordToComplete: string;
-	WantDocumentationForEveryCompletionResult?: boolean;
-	WantImportableTypes?: boolean;
-	WantMethodHeader?: boolean;
-	WantSnippet?: boolean;
-	WantReturnType?: boolean;
-	WantKind?: boolean;
+    WordToComplete: string;
+    WantDocumentationForEveryCompletionResult?: boolean;
+    WantImportableTypes?: boolean;
+    WantMethodHeader?: boolean;
+    WantSnippet?: boolean;
+    WantReturnType?: boolean;
+    WantKind?: boolean;
 }
 
 export interface AutoCompleteResponse {
-	CompletionText: string;
-	Description: string;
-	DisplayText: string;
-	RequiredNamespaceImport: string;
-	MethodHeader: string;
-	ReturnType: string;
-	Snippet: string;
-	Kind: string;
+    CompletionText: string;
+    Description: string;
+    DisplayText: string;
+    RequiredNamespaceImport: string;
+    MethodHeader: string;
+    ReturnType: string;
+    Snippet: string;
+    Kind: string;
 }
 
 export interface ProjectInformationResponse {
-	MsBuildProject: MSBuildProject;
-	DnxProject: DnxProject;
+    MsBuildProject: MSBuildProject;
+    DnxProject: DnxProject;
 }
 
 export interface WorkspaceInformationResponse {
-	MsBuild: MsBuildWorkspaceInformation;
-	Dnx: DnxWorkspaceInformation;
+    MsBuild: MsBuildWorkspaceInformation;
+    Dnx: DnxWorkspaceInformation;
     DotNet: DotNetWorkspaceInformation;
-	ScriptCs: ScriptCsContext;
+    ScriptCs: ScriptCsContext;
 }
 
 export interface MsBuildWorkspaceInformation {
-	SolutionPath: string;
-	Projects: MSBuildProject[];
+    SolutionPath: string;
+    Projects: MSBuildProject[];
 }
 
 export interface ScriptCsContext {
-	CsxFiles: { [n: string]: string };
-	References: { [n: string]: string };
-	Usings: { [n: string]: string };
-	ScriptPacks: { [n: string]: string };
-	Path: string;
+    CsxFiles: { [n: string]: string };
+    References: { [n: string]: string };
+    Usings: { [n: string]: string };
+    ScriptPacks: { [n: string]: string };
+    Path: string;
 }
 
 export interface MSBuildProject {
-	ProjectGuid: string;
-	Path: string;
-	AssemblyName: string;
-	TargetPath: string;
-	TargetFramework: string;
-	SourceFiles: string[];
+    ProjectGuid: string;
+    Path: string;
+    AssemblyName: string;
+    TargetPath: string;
+    TargetFramework: string;
+    SourceFiles: string[];
 }
 
 export interface DnxWorkspaceInformation {
-	RuntimePath: string;
-	DesignTimeHostPort: number;
-	Projects: DnxProject[];
+    RuntimePath: string;
+    DesignTimeHostPort: number;
+    Projects: DnxProject[];
 }
 
 export interface DnxProject {
-	Path: string;
-	Name: string;
-	Commands: { [name: string]: string; };
-	Configurations: string[];
-	ProjectSearchPaths: string[];
-	Frameworks: DnxFramework[];
-	GlobalJsonPath: string;
-	SourceFiles: string[];
+    Path: string;
+    Name: string;
+    Commands: { [name: string]: string; };
+    Configurations: string[];
+    ProjectSearchPaths: string[];
+    Frameworks: DnxFramework[];
+    GlobalJsonPath: string;
+    SourceFiles: string[];
 }
 
 export interface DnxFramework {
-	Name: string;
-	FriendlyName: string;
-	ShortName: string;
+    Name: string;
+    FriendlyName: string;
+    ShortName: string;
 }
 
 export interface DotNetWorkspaceInformation {
-	Projects: DotNetProject[];
-	RuntimePath: string;
+    Projects: DotNetProject[];
+    RuntimePath: string;
 }
 
 export interface DotNetProject {
-	Path: string;
-	Name: string;
-	ProjectSearchPaths: string[];
-	Configurations: DotNetConfiguration[];
-	Frameworks: DotNetFramework[];
-	SourceFiles: string[];
+    Path: string;
+    Name: string;
+    ProjectSearchPaths: string[];
+    Configurations: DotNetConfiguration[];
+    Frameworks: DotNetFramework[];
+    SourceFiles: string[];
 }
 
 export interface DotNetConfiguration {
-	Name: string;
-	CompilationOutputPath: string;
-	CompilationOutputAssemblyFile: string;
-	CompilationOutputPdbFile: string;
-	EmitEntryPoint?: boolean;
+    Name: string;
+    CompilationOutputPath: string;
+    CompilationOutputAssemblyFile: string;
+    CompilationOutputPdbFile: string;
+    EmitEntryPoint?: boolean;
 }
 
 export interface DotNetFramework {
-	Name: string;
-	FriendlyName: string;
-	ShortName: string;
+    Name: string;
+    FriendlyName: string;
+    ShortName: string;
 }
 
 export interface RenameRequest extends Request {
-	RenameTo: string;
-	WantsTextChanges?: boolean;
+    RenameTo: string;
+    WantsTextChanges?: boolean;
 }
 
 export interface ModifiedFileResponse {
-	FileName: string;
-	Buffer: string;
-	Changes: TextChange[];
+    FileName: string;
+    Buffer: string;
+    Changes: TextChange[];
 }
 
 export interface RenameResponse {
-	Changes: ModifiedFileResponse[];
+    Changes: ModifiedFileResponse[];
 }
 
 export interface SignatureHelp {
-	Signatures: SignatureHelpItem[];
-	ActiveSignature: number;
-	ActiveParameter: number;
+    Signatures: SignatureHelpItem[];
+    ActiveSignature: number;
+    ActiveParameter: number;
 }
 
 export interface SignatureHelpItem {
-	Name: string;
-	Label: string;
-	Documentation: string;
-	Parameters: SignatureHelpParameter[];
+    Name: string;
+    Label: string;
+    Documentation: string;
+    Parameters: SignatureHelpParameter[];
 }
 
 export interface SignatureHelpParameter {
-	Name: string;
-	Label: string;
-	Documentation: string;
+    Name: string;
+    Label: string;
+    Documentation: string;
 }
 
 export interface MSBuildProjectDiagnostics {
-	FileName: string;
-	Warnings: MSBuildDiagnosticsMessage[];
-	Errors: MSBuildDiagnosticsMessage[];
+    FileName: string;
+    Warnings: MSBuildDiagnosticsMessage[];
+    Errors: MSBuildDiagnosticsMessage[];
 }
 
 export interface MSBuildDiagnosticsMessage {
-	LogLevel: string;
-	FileName: string;
-	Text: string;
-	StartLine: number;
-	StartColumn: number;
-	EndLine: number;
-	EndColumn: number;
+    LogLevel: string;
+    FileName: string;
+    Text: string;
+    StartLine: number;
+    StartColumn: number;
+    EndLine: number;
+    EndColumn: number;
 }
 
 export interface ErrorMessage {
-	Text: string;
-	FileName: string;
-	Line: number;
-	Column: number;
+    Text: string;
+    FileName: string;
+    Line: number;
+    Column: number;
 }
 
 export interface PackageRestoreMessage {
-	FileName: string;
-	Succeeded: boolean;
+    FileName: string;
+    Succeeded: boolean;
 }
 
 export interface UnresolvedDependenciesMessage {
-	FileName: string;
-	UnresolvedDependencies: PackageDependency[];
+    FileName: string;
+    UnresolvedDependencies: PackageDependency[];
 }
 
 export interface PackageDependency {
-	Name: string;
-	Version: string;
+    Name: string;
+    Version: string;
 }
 
 export namespace V2 {
-    
+
     export module Requests {
         export const GetCodeActions = '/v2/getcodeactions';
         export const RunCodeAction = '/v2/runcodeaction';
     }
 
-	export interface Point {
-		Line: number;
-		Column: number;
-	}
+    export interface Point {
+        Line: number;
+        Column: number;
+    }
 
-	export interface Range {
-		Start: Point;
-		End: Point;
-	}
+    export interface Range {
+        Start: Point;
+        End: Point;
+    }
 
-	export interface GetCodeActionsRequest extends Request {
-		Selection: Range;
-	}
+    export interface GetCodeActionsRequest extends Request {
+        Selection: Range;
+    }
 
-	export interface OmniSharpCodeAction {
-		Identifier: string;
-		Name: string;
-	}
+    export interface OmniSharpCodeAction {
+        Identifier: string;
+        Name: string;
+    }
 
-	export interface GetCodeActionsResponse {
-		CodeActions: OmniSharpCodeAction[];
-	}
+    export interface GetCodeActionsResponse {
+        CodeActions: OmniSharpCodeAction[];
+    }
 
-	export interface RunCodeActionRequest extends Request {
-		Identifier: string;
-		Selection: Range;
-		WantsTextChanges: boolean;
-	}
+    export interface RunCodeActionRequest extends Request {
+        Identifier: string;
+        Selection: Range;
+        WantsTextChanges: boolean;
+    }
 
-	export interface RunCodeActionResponse {
-		Changes: ModifiedFileResponse[];
-	}
+    export interface RunCodeActionResponse {
+        Changes: ModifiedFileResponse[];
+    }
 
 
-	export interface MSBuildProjectDiagnostics {
-		FileName: string;
-		Warnings: MSBuildDiagnosticsMessage[];
-		Errors: MSBuildDiagnosticsMessage[];
-	}
+    export interface MSBuildProjectDiagnostics {
+        FileName: string;
+        Warnings: MSBuildDiagnosticsMessage[];
+        Errors: MSBuildDiagnosticsMessage[];
+    }
 
-	export interface MSBuildDiagnosticsMessage {
-		LogLevel: string;
-		FileName: string;
-		Text: string;
-		StartLine: number;
-		StartColumn: number;
-		EndLine: number;
-		EndColumn: number;
-	}
+    export interface MSBuildDiagnosticsMessage {
+        LogLevel: string;
+        FileName: string;
+        Text: string;
+        StartLine: number;
+        StartColumn: number;
+        EndLine: number;
+        EndColumn: number;
+    }
 
-	export interface ErrorMessage {
-		Text: string;
-		FileName: string;
-		Line: number;
-		Column: number;
-	}
+    export interface ErrorMessage {
+        Text: string;
+        FileName: string;
+        Line: number;
+        Column: number;
+    }
 
-	export interface PackageRestoreMessage {
-		FileName: string;
-		Succeeded: boolean;
-	}
+    export interface PackageRestoreMessage {
+        FileName: string;
+        Succeeded: boolean;
+    }
 
-	export interface UnresolvedDependenciesMessage {
-		FileName: string;
-		UnresolvedDependencies: PackageDependency[];
-	}
+    export interface UnresolvedDependenciesMessage {
+        FileName: string;
+        UnresolvedDependencies: PackageDependency[];
+    }
 
-	export interface PackageDependency {
-		Name: string;
-		Version: string;
-	}
+    export interface PackageDependency {
+        Name: string;
+        Version: string;
+    }
+}
+
+// dotnet-test endpoints
+
+export interface GetTestStartInfoRequest {
+    FileName: string;
+    MethodName: string;
+}
+
+export interface GetTestStartInfoResponse {
+    Executable: string;
+    Argument: string;
+}
+
+export interface RunDotNetTestRequest {
+    FileName: string;
+    MethodName: string;
+}
+
+export interface RunDotNetTestResponse {
+    Failure: string;
+    Pass: boolean;
 }


### PR DESCRIPTION
### Demo

_it's a gif, may take time to load_
![mn0xdmo - imgur](https://cloud.githubusercontent.com/assets/1329240/15592221/d70dc5b2-2356-11e6-85ab-dd3ab6484c3d.gif)

### Brief
The change relies on a change in [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn/tree/troy/testrunner) which supports test discovery and execution.

It also relies on `startDebug` command from VS Code to start debugger. For earlier version of VS Code, the `debug test` link won't show up on Code Lens.

### Open question
How and where to show test result. Currently, the test result is shown in message box. Could there be a better way to organize and show test results?