### PR TITLE
Update compilationOptions -> buildOptions

### DIFF
--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -328,7 +328,7 @@ function createProjectJson(targetRuntime: string): any
 {
     let projectJson = {
         name: "dummy",
-        compilationOptions: {
+        buildOptions: {
             emitEntryPoint: true
         },
         dependencies: {


### PR DESCRIPTION
The compilationOptions node is deprecated in RC2, buildOptions should be used instead.

See also: aspnet/Templates#548

cc: @DustinCampbell 