### PR TITLE
Add 'externalConsole' launch option

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,11 @@
                 "description": "Environment variables passed to the program.",
                 "default": { }
               },
+              "externalConsole": {
+                "type": "boolean",
+                "description": "If 'true' the debugger should launch the target application into a new external console.",
+                "default": true
+              },
               "sourceFileMap": {
                 "type": "object",
                 "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
@@ -428,7 +433,8 @@
             "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
             "args": [],
             "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
+            "stopAtEntry": false,
+            "externalConsole": true
           },
           {
             "name": ".NET Core Launch (web)",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -25,7 +25,8 @@ interface ConsoleLaunchConfiguration extends DebugConfiguration {
     args: string[],
     cwd: string,
     stopAtEntry: boolean,
-    env?: any
+    env?: any,
+    externalConsole?: boolean
 }
 
 interface CommandLine {
@@ -138,6 +139,7 @@ function createLaunchConfiguration(targetFramework: string, executableName: stri
         program: '${workspaceRoot}/bin/Debug/' + targetFramework + '/'+ executableName,
         args: [],
         cwd: '${workspaceRoot}',
+        externalConsole: true,
         stopAtEntry: false
     }
 }

--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -333,7 +333,7 @@ function createProjectJson(targetRuntime: string): any
         },
         dependencies: {
             "Microsoft.VisualStudio.clrdbg": "14.0.25320-preview-3008693",
-            "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30527-preview-1",
+            "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30531-preview-1",
             "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20527-preview-1",
             "NETStandard.Library": "1.5.0-rc2-24027",
             "Newtonsoft.Json": "7.0.1",


### PR DESCRIPTION
With this checkin, we now support an 'externalConsole' launch option.
This option is specified by default for console projects.

This completes the fix for:
https://github.com/OmniSharp/omnisharp-vscode/issues/175