### PR TITLE
Fix OmniSharp download and improve logging

### DIFF
--- a/src/omnisharpServerLauncher.ts
+++ b/src/omnisharpServerLauncher.ts
@@ -37,7 +37,7 @@ export function installOmnisharpIfNeeded(output: OutputChannel): Promise<string>
             throw err;
         }
 		
-        return downloadOmnisharp().then(_ => {
+        return downloadOmnisharp(output).then(_ => {
             return getOmnisharpLaunchFilePath();
         })
     });


### PR DESCRIPTION
This change fixes the use of the decompress (which changed its API shape in 4.0.0), and passes a VS Code OutputChannel into the downloading logic to surface logging.