### PR TITLE
Improve error handling for 'isOnPath'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -200,25 +200,29 @@ function isOnPath(command : string) : boolean {
         return false;
     }
     let fileName = command;
-    let seperatorChar = ':';
     if (process.platform == 'win32') {
         // on Windows, add a '.exe', and the path is semi-colon seperatode
         fileName = fileName + ".exe";
-        seperatorChar = ';';   
     }
-    
-    let pathSegments: string[] = pathValue.split(seperatorChar);
+
+    let pathSegments: string[] = pathValue.split(path.delimiter);
     for (let segment of pathSegments) {
         if (segment.length === 0 || !path.isAbsolute(segment)) {
             continue;
         }
-        
+
         const segmentPath = path.join(segment, fileName);
-        if (CoreClrDebugUtil.existsSync(segmentPath)) {
-            return true;
+
+        try {
+            if (CoreClrDebugUtil.existsSync(segmentPath)) {
+                return true;
+            }
+        } catch (err) {
+            // any error from existsSync can be treated as the command not being on the path
+            continue;
         }
     }
-    
+
     return false;
 }
 

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -83,7 +83,7 @@ export default class CoreClrDebugUtil
             fs.accessSync(path, fs.F_OK);
             return true;
         } catch (err) {
-            if (err.code === 'ENOENT') {
+            if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
                 return false;
             } else {
                 throw Error(err.code);


### PR DESCRIPTION
isOnPath calls existsSync, which was not handling ENOTDIR. This can arise
if a portion of a path is not a directory, such as
/dir1/dir2/<executable>/foo/bar. existsSync should return false in these
cases. Additionally, this adds a try/catch to isOnPath that should catch
all other errors from existsSync and treat them as basic failures for that
particular path segment.