### PR TITLE
Debugger changes for 1.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The C# extension now supports basic debugging capabilities! See http://aka.ms/vs
 * Automatic web vs. console debugger configuration detection
 * Detach support
 * Fix expression evaluation errors when referencing assemblies which aren't currently loaded
+* Fix expression evaluation on Windows 7
 
 ### Development
 

--- a/debugger.md
+++ b/debugger.md
@@ -131,8 +131,6 @@ Environment variables may be passed to your program using this schema:
     }
 
 #####External console (terminal) window
-The target process can optionally launch into a seperate console window. This is enabled by default for non-ASP.NET applications. But it can be explicitly set with:
+The target process can optionally launch into a seperate console window. You will want this if your console app takes console input (ex: Console.ReadLine). This can be enabled with:
 
     "externalConsole": true
-
-If your console app doesn't take console input (ex: all input comes from the command line), you may want to turn this off.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -272,7 +272,7 @@
               "externalConsole": {
                 "type": "boolean",
                 "description": "If 'true' the debugger should launch the target application into a new external console.",
-                "default": true
+                "default": false
               },
               "sourceFileMap": {
                 "type": "object",
@@ -434,7 +434,7 @@
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
-            "externalConsole": true
+            "externalConsole": false
           },
           {
             "name": ".NET Core Launch (web)",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -139,7 +139,7 @@ function createLaunchConfiguration(targetFramework: string, executableName: stri
         program: '${workspaceRoot}/bin/Debug/' + targetFramework + '/'+ executableName,
         args: [],
         cwd: '${workspaceRoot}',
-        externalConsole: true,
+        externalConsole: false,
         stopAtEntry: false
     }
 }

--- a/src/coreclr-debug/main.ts
+++ b/src/coreclr-debug/main.ts
@@ -336,8 +336,8 @@ function createProjectJson(targetRuntime: string): any
             emitEntryPoint: true
         },
         dependencies: {
-            "Microsoft.VisualStudio.clrdbg": "14.0.25320-preview-3008693",
-            "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30531-preview-1",
+            "Microsoft.VisualStudio.clrdbg": "14.0.25406-preview-3044032",
+            "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30606-preview-1",
             "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20527-preview-1",
             "NETStandard.Library": "1.5.0-rc2-24027",
             "Newtonsoft.Json": "7.0.1",


### PR DESCRIPTION
This updates the clrdbg package to the 25406 build. This includes fixes
for Win7 expression evulation and the System.Task breaking change.
This addresses: https://github.com/OmniSharp/omnisharp-vscode/issues/258

This also the MIEngine to pull in https://github.com/Microsoft/MIEngine/pull/353

Lastly this disables the external console by default. We decided to have it off
by default as we have seen some issues with it on OSX (ex: not always closing
when the target exits), and we are hoping it will be possible soon to use the
new VS Code console window instead. So we decided to turn it off by default, at
least for now.