### PR TITLE
Remove myget feed from NuGet.config

### DIFF
--- a/coreclr-debug/NuGet.config
+++ b/coreclr-debug/NuGet.config
@@ -4,7 +4,5 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- This dependency can be commented out once we push packages to nuget for a real release -->
-    <add key="coreclrdebug" value="https://www.myget.org/F/coreclr-debug/api/v3/index.json" />    
   </packageSources>
 </configuration>


### PR DESCRIPTION
When we released the extension, I forgot to remove the myget feed from our NuGet.config,
I was assuming this wouldn't really matter since nuget.org came first in the list, by
the myget folks reported a traffic spike, so I am assuming we should really remove this.