### PR TITLE
Add logModuleLoadEvents launch option configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,21 @@
                       "type": "boolean",
                       "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
                       "default": true
+                  },
+                  "engineLogging": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+                      "default": false
+                  },
+                  "trace": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the output window.",
+                      "default": false
+                  },
+                  "traceResponse": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
+                      "default": false
                   }
                 }
               },
@@ -522,6 +537,21 @@
                       "type": "boolean",
                       "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
                       "default": true
+                  },
+                  "engineLogging": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+                      "default": false
+                  },
+                  "trace": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the output window.",
+                      "default": false
+                  },
+                  "traceResponse": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
+                      "default": false
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -299,6 +299,11 @@
                 "description": "Optional flag to require current source code to match the pdb.",
                 "default": true
               },
+              "logModuleLoadEvents": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                  "default": true
+              },
               "pipeTransport": {
                 "type": "object",
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",

--- a/package.json
+++ b/package.json
@@ -299,10 +299,28 @@
                 "description": "Optional flag to require current source code to match the pdb.",
                 "default": true
               },
-              "logModuleLoadEvents": {
-                  "type": "boolean",
-                  "description": "Optional flag to determine whether module load events should be logged to the output window.",
-                  "default": true
+              "logging": {
+                "type": "object",
+                "required": [],
+                "default": {},
+                "description": "Optional flags to determine what types of messages should be logged to the output window.",
+                "properties": {
+                  "exceptions": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+                      "default": true
+                  },
+                  "moduleLoad": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                      "default": true
+                  },
+                  "programOutput": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+                      "default": true
+                  }
+                }
               },
               "pipeTransport": {
                 "type": "object",
@@ -477,12 +495,35 @@
                 "items": {
                   "type": "string"
                 },
+                "default": []
+              },
               "requireExactSource": {
                 "type": "boolean",
                 "description": "Optional flag to require current source code to match the pdb.",
                 "default": true
               },
-                "default": []
+              "logging": {
+                "type": "object",
+                "required": [],
+                "default": [],
+                "description": "Optional flags to determine what types of messages should be logged to the output window.",
+                "properties": {
+                  "exceptions": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+                      "default": true
+                  },
+                  "moduleLoad": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                      "default": true
+                  },
+                  "programOutput": {
+                      "type": "boolean",
+                      "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+                      "default": true
+                  }
+                }
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -505,7 +505,7 @@
               "logging": {
                 "type": "object",
                 "required": [],
-                "default": [],
+                "default": {},
                 "description": "Optional flags to determine what types of messages should be logged to the output window.",
                 "properties": {
                   "exceptions": {


### PR DESCRIPTION
Add flag to disable logging module load events to the console. Since everything (including debuggee output) is logged to the debug output window in normal scenarios, module load events can cause the log to become cluttered fairly quickly. Setting this flag to false in launch.json will remove the module load events from the log.