### PR TITLE
Update to latest version of OmniSharp, which includes MSBuild support for OSX/Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/omnisharpDownload.ts
+++ b/src/omnisharpDownload.ts
@@ -16,9 +16,9 @@ import {getProxyAgent} from './proxy';
 
 const decompress = require('decompress');
 
-const BaseDownloadUrl = 'https://vscodeoscon.blob.core.windows.net/ext';
+const BaseDownloadUrl = 'https://omnisharpdownload.blob.core.windows.net/ext';
 const DefaultInstallLocation = path.join(__dirname, '../.omnisharp');
-export const OmniSharpVersion = '1.9-beta5';
+export const OmniSharpVersion = '1.9-beta10';
 
 tmp.setGracefulCleanup();
 


### PR DESCRIPTION
This change updates to the latest version of OmniSharp, which includes some support for MSBuild projects (i.e. .csproj and .sln) on OSX/Linux. I've tested this with some sample Unity projects and found that IntelliSense, Find All References, Go to Definition, etc. are generally working.

cc @gregg-miskelly, @caslan, @chuckries 

Also, @MattGertz