### PR TITLE
Add back imports to project.json for debugger install

### DIFF
--- a/src/coreclr-debug/install.ts
+++ b/src/coreclr-debug/install.ts
@@ -186,7 +186,9 @@ export class DebugInstaller
                 "System.Net.Http":  "4.1.0"
             },
             frameworks: {
-                "netcoreapp1.0": { }
+                "netcoreapp1.0": {
+                    imports: [ "dnxcore50", "portable-net45+win8" ]
+                 }
             },
             runtimes: {
             }


### PR DESCRIPTION
This is needed for newtonsoft and clrdbg packages. @gregg-miskelly @chuckries @DustinCampbell 
