### PR TITLE
Fixed typo. This is a blocker bug for RHEL users because this extension can't launch.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function getSupportedPlatform() {
                 return SupportedPlatform.Fedora;
             case 'opensuse':
                 return SupportedPlatform.OpenSUSE;
-            case 'rehl':
+            case 'rhel':
                 return SupportedPlatform.RHEL;
             case 'debian':
                 return SupportedPlatform.Debian;


### PR DESCRIPTION
Red Hat Enterprise Linux.