### PR TITLE
Fixing attach template to show pickProcess by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,12 +505,12 @@
                 "anyOf": [ 
                     {
                       "type": "string",
-                      "description": "The process id to attach to. User \"${command.pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                      "description": "The process id to attach to. Use \"${command.pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
                       "default": "${command.pickProcess}"
                     }, 
                     {
                       "type": "integer",
-                      "description": "The process id to attach to. User \"${command.pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                      "description": "The process id to attach to. Use \"${command.pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
                       "default": 0
                     }
                 ]                

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -47,7 +47,7 @@ interface WebLaunchConfiguration extends ConsoleLaunchConfiguration {
 }
 
 interface AttachConfiguration extends DebugConfiguration {
-    processId: number
+    processId: string
 }
 
 interface Paths {
@@ -179,7 +179,7 @@ function createAttachConfiguration(): AttachConfiguration {
         name: '.NET Core Attach',
         type: 'coreclr',
         request: 'attach',
-        processId: 0
+        processId: "${command.pickProcess}"
     }
 }
 


### PR DESCRIPTION
In a code path, template processId is 0 instead of command.pickProcess. Fixing it.