### PR TITLE
Add razor support to configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
         "label": ".NET Core",
         "enableBreakpointsFor": {
           "languageIds": [
-            "csharp"
+            "csharp",
+            "razor"
           ]
         },
         "runtime": "node",
@@ -623,6 +624,9 @@
             },
             "env": {
               "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceRoot}/Views"
             }
           },
           {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -17,6 +17,7 @@ interface DebugConfiguration {
     name: string,
     type: string,
     request: string,
+    sourceFileMap?: any,
 }
 
 interface ConsoleLaunchConfiguration extends DebugConfiguration {
@@ -170,6 +171,9 @@ function createWebLaunchConfiguration(targetFramework: string, executableName: s
         },
         env: {
             ASPNETCORE_ENVIRONMENT: "Development"
+        },
+        sourceFileMap: {
+            "/Views": "${workspaceRoot}/Views"
         }
     }
 }


### PR DESCRIPTION
- Enable breakpoints in razor files
- Add default source map for relative paths (workaround for [aspnet/razor #803](https://github.com/aspnet/Razor/issues/803))