### PR TITLE
fs.readFileSync(filename, 'utf8') doesn't strip BOM markers

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -243,7 +243,7 @@ function addTasksJsonIfNecessary(info: protocol.DotNetWorkspaceInformation, path
 
 function hasWebServerDependency(projectJsonPath: string) {
     let projectJson = fs.readFileSync(projectJsonPath, 'utf8');
-    let projectJsonObject = JSON.parse(projectJson);
+    let projectJsonObject = JSON.parse(projectJson.replace(/^\uFEFF/, ''));
     
     if (projectJsonObject == null) {
         return false;


### PR DESCRIPTION
Taking the workaround specified here https://github.com/nodejs/node-v0.x-archive/issues/1918