### PR TITLE
Improve generation of tasks.json and launch.json assets

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -329,8 +329,17 @@ function hasWebServerDependency(targetProjectData: TargetProjectData): boolean {
     let projectJson = fs.readFileSync(targetProjectData.projectJsonPath, 'utf8');
     projectJson = projectJson.replace(/^\uFEFF/, '');
 
-    let projectJsonObject = JSON.parse(projectJson);
-    
+    let projectJsonObject: any;
+
+    try {
+        // TODO: This error should be surfaced to the user. If the JSON can't be parsed
+        // (maybe due to a syntax error like an extra comma), the user should be notified
+        // to fix up their project.json.
+        projectJsonObject = JSON.parse(projectJson);
+    } catch (error) {
+        projectJsonObject = null;
+    }
+
     if (projectJsonObject == null) {
         return false;
     }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -372,17 +372,6 @@ export function addAssetsIfNecessary(server: OmnisharpServer) {
         return;
     }
     
-    // If there is no project.json or global.json, we won't bother to prompt the user for tasks.json.		
-    const projectJsonPath = path.join(vscode.workspace.rootPath, 'project.json');
-    const globalJsonPath = path.join(vscode.workspace.rootPath, 'global.json');
-
-    const projectJsonExists = fs.existsSync(projectJsonPath);
-    const globalJsonExists = fs.existsSync(globalJsonPath);
-
-    if (!fs.existsSync(projectJsonPath) && !fs.existsSync(globalJsonPath)) {
-        return;
-    }
-
     return serverUtils.requestWorkspaceInformation(server).then(info => {
         // If there are no .NET Core projects, we won't bother offering to add assets.
         if ('DotNet' in info && info.DotNet.Projects.length > 0) {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -321,9 +321,9 @@ function findExecutableProjects(projects: protocol.DotNetProject[], configName: 
     return result;
 }
 
-function hasWebServerDependency(targetProjectData: TargetProjectData) {
+function hasWebServerDependency(targetProjectData: TargetProjectData): boolean {
     if (!targetProjectData || !targetProjectData.projectJsonPath) {
-        return;
+        return false;
     }
 
     let projectJson = fs.readFileSync(targetProjectData.projectJsonPath, 'utf8');


### PR DESCRIPTION
Fixes #556 and #170

This change allows tasks.json and launch.json to be generated when the workspace root contains a global.json rather than a launch.json. It ensures that appropriate values to the json files to account for the target project being more deeply nested.

cc @gregg-miskelly, @rajkumar42, @caslan, @chuckries 