### PR TITLE
Fix several issues with diagnostics

### DIFF
--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -165,11 +165,8 @@ export function reportDocumentStatus(server: OmnisharpServer): vscode.Disposable
 					}
 				}
 
-				// show dnx projects if applicable
-                if ('Dnx' in info) {
-                    addDnxOrDotNetProjects(info.Dnx.Projects);
-                }
-                else if ('DotNet' in info) {
+				// show .NET Core projects if applicable
+                if ('DotNet' in info) {
                     addDnxOrDotNetProjects(info.DotNet.Projects);
                 }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -212,12 +212,11 @@ export interface AutoCompleteResponse {
 
 export interface ProjectInformationResponse {
     MsBuildProject: MSBuildProject;
-    DnxProject: DnxProject;
+    DotNetProject: DotNetProject;
 }
 
 export interface WorkspaceInformationResponse {
     MsBuild: MsBuildWorkspaceInformation;
-    Dnx: DnxWorkspaceInformation;
     DotNet: DotNetWorkspaceInformation;
     ScriptCs: ScriptCsContext;
 }
@@ -242,29 +241,6 @@ export interface MSBuildProject {
     TargetPath: string;
     TargetFramework: string;
     SourceFiles: string[];
-}
-
-export interface DnxWorkspaceInformation {
-    RuntimePath: string;
-    DesignTimeHostPort: number;
-    Projects: DnxProject[];
-}
-
-export interface DnxProject {
-    Path: string;
-    Name: string;
-    Commands: { [name: string]: string; };
-    Configurations: string[];
-    ProjectSearchPaths: string[];
-    Frameworks: DnxFramework[];
-    GlobalJsonPath: string;
-    SourceFiles: string[];
-}
-
-export interface DnxFramework {
-    Name: string;
-    FriendlyName: string;
-    ShortName: string;
 }
 
 export interface DotNetWorkspaceInformation {


### PR DESCRIPTION
Fixes #447  and #587

1. The diagnostics provider won't refresh diagnostics while the OmniSharp server is restoring packages. Instead, it waits until it receives an event from OmniSharp afterward. However, that event was only expecting the old DNX protocol, so the diagnostics provider never automatically updated after packages were restored. This change gets rid of the DNX protocol and changes the diagnostic provider to look for .NET Core projects.

2. Hidden diagnostics should have DiagnosticSeverity.Info rather DiagnosticSeverity.Warning.

3. When the processing *all* of the diagnostics (not just those for the current file), the previous diagnostics were not cleared out first. This resulted in new diagnostics being merged with old diagnostics, creating duplicates diagnostics. Now we clear the diagnostics for a file before adding new ones.