### PR TITLE
Display the full download URL

### DIFF
--- a/src/omnisharp/download.ts
+++ b/src/omnisharp/download.ts
@@ -121,7 +121,7 @@ export function go(flavor: Flavor, platform: Platform, log?: (message: string) =
 
         const urlString = `${BaseDownloadUrl}/${fileName}`;
 
-        log(`[INFO] Attempting to download ${fileName}...`);
+        log(`[INFO] Attempting to download ${urlString}`);
 
         return download(urlString, proxy, strictSSL)
             .then(inStream => {


### PR DESCRIPTION
This is a very simple change which displays the *full* download URL, to relieve some pain caused by #579. 

I have the same proxy issue, and I'm updating OmniSharp every time by downloading the package manually. Knowing the full download URL obviously helps a lot with that.