### PR TITLE
Remove System.Diagnostics.StackTrace from debugger install

### DIFF
--- a/src/coreclr-debug/install.ts
+++ b/src/coreclr-debug/install.ts
@@ -171,7 +171,6 @@ export class DebugInstaller
                 "System.Collections.Specialized":  "4.0.1",
                 "System.Collections.Immutable": "1.2.0", 
                 "System.Diagnostics.Process" : "4.1.0",
-                "System.Diagnostics.StackTrace":  "4.0.1",  
                 "System.Dynamic.Runtime": "4.0.11",
                 "Microsoft.CSharp": "4.0.1",
                 "System.Threading.Tasks.Dataflow": "4.6.0",


### PR DESCRIPTION
The debugger was installing System.Diagnostics.StackTrace which it doesn't appear to actually need and, in the dev install scenarios at least, was causing a problem with pulling in the wrong version of System.Reflection.Metadata. This removes it so the dev and shipping code pulls in the same set of assemblies.

Testing: Verified that if I create a .vsix the debugger install still succeeds and resulting debugger works for basic things. Also verified, with private OpenDebugAD7 bits, that exception stack traces still work.