### PR TITLE
update clrdbg package reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.4.0-beta1",
+  "version": "1.4.0-beta2",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/coreclr-debug/install.ts
+++ b/src/coreclr-debug/install.ts
@@ -162,7 +162,7 @@ export class DebugInstaller
                 emitEntryPoint: true
             },
             dependencies: {
-                "Microsoft.VisualStudio.clrdbg": "14.0.25520-preview-3139256",
+                "Microsoft.VisualStudio.clrdbg": "15.0.25528-preview-3157812",
                 "Microsoft.VisualStudio.clrdbg.MIEngine": "14.0.30715-preview-1",
                 "Microsoft.VisualStudio.OpenDebugAD7": "1.0.20720-preview-1",
                 "NETStandard.Library": "1.6.0",


### PR DESCRIPTION
This brings in the first set of clrdbg packages that are based on dev15 concord. 