### PR TITLE
Update to OmniSharp v1.9-beta13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.4.0-beta2",
+  "version": "1.4.0-beta3",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/omnisharp/download.ts
+++ b/src/omnisharp/download.ts
@@ -23,7 +23,7 @@ import {getProxyAgent} from '../proxy';
 const decompress = require('decompress');
 
 const BaseDownloadUrl = 'https://omnisharpdownload.blob.core.windows.net/ext';
-const OmniSharpVersion = '1.9-beta12';
+const OmniSharpVersion = '1.9-beta13';
 
 tmp.setGracefulCleanup();
 


### PR DESCRIPTION
This version of OmniSharp includes an important bug fix that provides more information when Roslyn workspace events are triggered. This helps address a problem with diagnostics where projects were regularly being pulled for diagnostics even when they are particular large.