### PR TITLE
Highlight "string[]", "string []", "string[,]", "string [,]", "string…

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -502,7 +502,7 @@
       ]
     },
     "parameters": {
-      "begin": "\\b(ref|params|out)?\\s*\\b([\\w?\\[\\]]+(?:\\s*<.*?>)?)\\s+(\\w+)\\s*(=)?",
+      "begin": "\\b(ref|params|out)?\\s*\\b([\\w?]+(?:\\s*\\[\\s*,?\\s*\\])?(?:\\s*<.*?>)?)\\s+(\\w+)\\s*(=)?",
       "beginCaptures": {
         "1": {
           "name": "storage.type.modifier.cs"


### PR DESCRIPTION
Highlight "string[]", "string []", "string[,]", "string [,]", "string[ , ]", etc properly inside method parameter list.

Fixes #657

### Before:
![before](https://cloud.githubusercontent.com/assets/79742/17731601/d94addc4-6465-11e6-826f-565210b7825b.png)


### After:

![after](https://cloud.githubusercontent.com/assets/79742/17731610/e0a9ccd8-6465-11e6-87d3-51a2e4a08f2a.png)
