### PR TITLE
Adds support for viewing type information for types not in the source 

### DIFF
--- a/src/features/definitionMetadataDocumentProvider.ts
+++ b/src/features/definitionMetadataDocumentProvider.ts
@@ -1,0 +1,46 @@
+import { workspace, Uri, TextDocument, Disposable, TextDocumentContentProvider} from 'vscode';
+import { MetadataResponse } from '../omnisharp/protocol';
+
+export class DefinitionMetadataDocumentProvider implements TextDocumentContentProvider, Disposable {
+    private _scheme = "omnisharp-metadata";
+    private _registration : Disposable;
+    private _documents: Map<string, MetadataResponse>;
+    private _documentClosedSubscription: Disposable;
+
+    constructor() {
+        this._documents = new Map<string, MetadataResponse>();
+        this._documentClosedSubscription = workspace.onDidCloseTextDocument(this.onTextDocumentClosed);
+    }
+
+    private onTextDocumentClosed(document: TextDocument) : void {
+        this._documents.delete(document.uri.toString());
+    }
+
+    public dispose() : void {
+        this._registration.dispose();
+        this._documentClosedSubscription.dispose();
+        this._documents.clear();
+    }
+
+    public addMetadataResponse(metadataResponse: MetadataResponse) : Uri {
+        const uri = this.createUri(metadataResponse);
+
+        this._documents.set(uri.toString(), metadataResponse);
+
+        return uri;
+    }
+
+    public register() : void {
+        this._registration = workspace.registerTextDocumentContentProvider(this._scheme, this);
+    }
+
+    public provideTextDocumentContent(uri : Uri) : string {
+        return this._documents.get(uri.toString()).Source;
+    }
+
+    private createUri(metadataResponse: MetadataResponse) : Uri {
+        return Uri.parse(this._scheme + "://" +
+                         metadataResponse.SourceName.replace(/\\/g, "/")
+                                                    .replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
+    }
+}

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -6,55 +6,47 @@
 'use strict';
 
 import AbstractSupport from './abstractProvider';
-import {MetadataRequest, GoToDefinitionRequest} from '../omnisharp/protocol';
+import {MetadataRequest, GoToDefinitionRequest, MetadataSource} from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
 import {createRequest, toLocation} from '../omnisharp/typeConvertion';
-import {workspace, window, Uri, TextDocument, Position, Location, CancellationToken, DefinitionProvider, Selection, TextEditorRevealType} from 'vscode';
+import {Uri, TextDocument, Position, Location, CancellationToken, DefinitionProvider} from 'vscode';
+import {DefinitionMetadataDocumentProvider} from './definitionMetadataDocumentProvider';
+
 
 export default class CSharpDefinitionProvider extends AbstractSupport implements DefinitionProvider {
+    private _definitionMetadataDocumentProvider: DefinitionMetadataDocumentProvider;
+
+    constructor(server, definitionMetadataDocumentProvider: DefinitionMetadataDocumentProvider) {
+        super(server);
+        this._definitionMetadataDocumentProvider = definitionMetadataDocumentProvider;
+    }
 
 	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Location> {
 
 		let req = <GoToDefinitionRequest>createRequest(document, position);
         req.WantMetadata = true;
 
-		return serverUtils.goToDefinition(this._server, req, token).then(value => {
+		return serverUtils.goToDefinition(this._server, req, token).then(gotoDefinitionResponse => {
 
-			if (value && value.FileName) {
-				return toLocation(value);
-			} else if (value.MetadataSource) {
+			if (gotoDefinitionResponse && gotoDefinitionResponse.FileName) {
+				return toLocation(gotoDefinitionResponse);
+			} else if (gotoDefinitionResponse.MetadataSource) {
+                const metadataSource: MetadataSource = gotoDefinitionResponse.MetadataSource;
 
-                let lineNumber = value.Line;
-                let column = value.Column;
-
-                serverUtils.getMetadata(this._server, <MetadataRequest> {
-                    AssemblyName: value.MetadataSource.AssemblyName,
-                    VersionNumber: value.MetadataSource.VersionNumber,
-                    ProjectName: value.MetadataSource.ProjectName,
-                    Language: value.MetadataSource.Language,
-                    TypeName: value.MetadataSource.TypeName
+                return serverUtils.getMetadata(this._server, <MetadataRequest> {
+                    Timeout: 5000,
+                    AssemblyName: metadataSource.AssemblyName,
+                    VersionNumber: metadataSource.VersionNumber,
+                    ProjectName: metadataSource.ProjectName,
+                    Language: metadataSource.Language,
+                    TypeName: metadataSource.TypeName
                 }).then(metadataResponse => {
                     if (!metadataResponse || !metadataResponse.Source || !metadataResponse.SourceName) {
                         return;
                     }
 
-                    const scheme = "omnisharp-metadata";
-                    let temporaryDocumentContentProviderRegistration = workspace.registerTextDocumentContentProvider(scheme, {
-                        provideTextDocumentContent: function(uri) {
-                            return metadataResponse.Source;
-                        }
-                    });
-
-                    let uri = Uri.parse(scheme + "://" + metadataResponse.SourceName.replace(/\\/g, "/").replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
-                    workspace.openTextDocument(uri).then(document => {
-                        temporaryDocumentContentProviderRegistration.dispose();
-
-                        window.showTextDocument(document, null, false).then(editor => {
-                            let position = new Position(lineNumber - 1, column - 1);
-                            editor.selection = new Selection(position, position);
-                            editor.revealRange(editor.document.lineAt(position.line).range, TextEditorRevealType.InCenter);
-                        });
-                    });
+                    const uri: Uri = this._definitionMetadataDocumentProvider.addMetadataResponse(metadataResponse);
+                    return new Location(uri, new Position(gotoDefinitionResponse.Line - 1, gotoDefinitionResponse.Column - 1));
                 });
             }
 		});

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -6,20 +6,57 @@
 'use strict';
 
 import AbstractSupport from './abstractProvider';
+import {MetadataRequest, GoToDefinitionRequest} from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
 import {createRequest, toLocation} from '../omnisharp/typeConvertion';
-import {TextDocument, Position, Location, CancellationToken, DefinitionProvider} from 'vscode';
+import {workspace, window, Uri, TextDocument, Position, Location, CancellationToken, DefinitionProvider, Selection, TextEditorRevealType} from 'vscode';
 
 export default class CSharpDefinitionProvider extends AbstractSupport implements DefinitionProvider {
 
 	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Location> {
 
-		let req = createRequest(document, position);
+		let req = <GoToDefinitionRequest>createRequest(document, position);
+        req.WantMetadata = true;
 
 		return serverUtils.goToDefinition(this._server, req, token).then(value => {
+
 			if (value && value.FileName) {
 				return toLocation(value);
-			}
+			} else if (value.MetadataSource) {
+
+                let lineNumber = value.Line;
+                let column = value.Column;
+
+                serverUtils.getMetadata(this._server, <MetadataRequest> {
+                    AssemblyName: value.MetadataSource.AssemblyName,
+                    VersionNumber: value.MetadataSource.VersionNumber,
+                    ProjectName: value.MetadataSource.ProjectName,
+                    Language: value.MetadataSource.Language,
+                    TypeName: value.MetadataSource.TypeName
+                }).then(metadataResponse => {
+                    if (!metadataResponse || !metadataResponse.Source || !metadataResponse.SourceName) {
+                        return;
+                    }
+
+                    const scheme = "omnisharp-metadata";
+                    let temporaryDocumentContentProviderRegistration = workspace.registerTextDocumentContentProvider(scheme, {
+                        provideTextDocumentContent: function(uri) {
+                            return metadataResponse.Source;
+                        }
+                    });
+
+                    let uri = Uri.parse(scheme + "://" + metadataResponse.SourceName.replace(/\\/g, "/").replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
+                    workspace.openTextDocument(uri).then(document => {
+                        temporaryDocumentContentProviderRegistration.dispose();
+
+                        window.showTextDocument(document, null, false).then(editor => {
+                            let position = new Position(lineNumber - 1, column - 1);
+                            editor.selection = new Selection(position, position);
+                            editor.revealRange(editor.document.lineAt(position.line).range, TextEditorRevealType.InCenter);
+                        });
+                    });
+                });
+            }
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,11 @@ import * as coreclrdebug from './coreclr-debug/activate';
 import {addAssetsIfNecessary} from './assets';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import {DefinitionMetadataDocumentProvider} from './features/definitionMetadataDocumentProvider';
+
 
 export function activate(context: vscode.ExtensionContext): any {
-    
+
     const extensionId = 'ms-vscode.csharp';
     const extension = vscode.extensions.getExtension(extensionId);
     const extensionVersion = extension.packageJSON.version;
@@ -48,7 +50,11 @@ export function activate(context: vscode.ExtensionContext): any {
 
 	disposables.push(server.onServerStart(() => {
 		// register language feature provider on start
-		localDisposables.push(vscode.languages.registerDefinitionProvider(_selector, new DefinitionProvider(server)));
+        const definitionMetadataDocumentProvider = new DefinitionMetadataDocumentProvider();
+        definitionMetadataDocumentProvider.register();
+        localDisposables.push(definitionMetadataDocumentProvider);
+
+		localDisposables.push(vscode.languages.registerDefinitionProvider(_selector, new DefinitionProvider(server, definitionMetadataDocumentProvider)));
 		localDisposables.push(vscode.languages.registerCodeLensProvider(_selector, new CodeLensProvider(server)));
 		localDisposables.push(vscode.languages.registerDocumentHighlightProvider(_selector, new DocumentHighlightProvider(server)));
 		localDisposables.push(vscode.languages.registerDocumentSymbolProvider(_selector, new DocumentSymbolProvider(server)));
@@ -74,7 +80,7 @@ export function activate(context: vscode.ExtensionContext): any {
 
 	disposables.push(registerCommands(server, context.extensionPath));
 	disposables.push(reportStatus(server));
-    
+
     disposables.push(server.onServerStart(() => {
         // Update or add tasks.json and launch.json
         addAssetsIfNecessary(server);
@@ -89,10 +95,10 @@ export function activate(context: vscode.ExtensionContext): any {
 		advisor.dispose();
 		server.stop();
 	}));
-		
+
     // activate coreclr-debug
     coreclrdebug.activate(context, reporter);
-    
+
 	context.subscriptions.push(...disposables);
 }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -26,6 +26,7 @@ export module Requests {
     export const SignatureHelp = '/signatureHelp';
     export const TypeLookup = '/typelookup';
     export const UpdateBuffer = '/updatebuffer';
+    export const Metadata = '/metadata';
 }
 
 export interface Request {
@@ -36,12 +37,34 @@ export interface Request {
     Changes?: LinePositionSpanTextChange[];
 }
 
+export interface GoToDefinitionRequest extends Request
+{
+    WantMetadata?: boolean;
+}
+
 export interface LinePositionSpanTextChange {
     NewText: string;
     StartLine: number;
     StartColumn: number;
     EndLine: number;
     EndColumn: number;
+}
+
+export interface MetadataSource {
+    AssemblyName: string;
+    ProjectName: string;
+    VersionNumber: string;
+    Language: string;
+    TypeName: string;
+}
+
+export interface MetadataRequest extends MetadataSource {
+    Timeout?: number;
+}
+
+export interface MetadataResponse {
+    SourceName: string;
+    Source: string;
 }
 
 export interface UpdateBufferRequest extends Request {
@@ -117,6 +140,10 @@ export interface ResourceLocation {
     FileName: string;
     Line: number;
     Column: number;
+}
+
+export interface GoToDefinitionResponse extends ResourceLocation {
+    MetadataSource?: MetadataSource;
 }
 
 export interface Error {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -109,7 +109,7 @@ export abstract class OmnisharpServer {
 		return {
 			path: config.get<string>('omnisharp'),
 			usesMono: config.get<boolean>('omnisharpUsesMono')
-		}
+		};
 	}
 
     private _recordRequestDelay(requestName: string, elapsedTime: number) {
@@ -122,7 +122,7 @@ export abstract class OmnisharpServer {
         tracker.reportDelay(elapsedTime);
     }
 
-    private _reportTelemetry() {		
+    private _reportTelemetry() {
 		const delayTrackers = this._delayTrackers;
 
         for (const path in delayTrackers) {
@@ -235,7 +235,7 @@ export abstract class OmnisharpServer {
 
 	private _start(launchTarget: LaunchTarget): Promise<void> {
 		const options = this._readOptions();
-		
+
 		let flavor: omnisharp.Flavor;
 		if (options.path !== undefined && options.usesMono === true) {
 			flavor = omnisharp.Flavor.Mono;
@@ -416,7 +416,7 @@ export abstract class OmnisharpServer {
 
 				throw err;
 			}
-			
+
 			const config = vscode.workspace.getConfiguration();
 			const proxy = config.get<string>('http.proxy');
 			const strictSSL = config.get('http.proxyStrictSSL', true);

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -45,8 +45,8 @@ export function getCodeActions(server: OmnisharpServer, request: protocol.V2.Get
     return server.makeRequest<protocol.V2.GetCodeActionsResponse>(protocol.V2.Requests.GetCodeActions, request, token);
 }
 
-export function goToDefinition(server: OmnisharpServer, request: protocol.Request, token: vscode.CancellationToken) {
-    return server.makeRequest<protocol.ResourceLocation>(protocol.Requests.GoToDefinition, request);
+export function goToDefinition(server: OmnisharpServer, request: protocol.GoToDefinitionRequest, token: vscode.CancellationToken) {
+    return server.makeRequest<protocol.GoToDefinitionResponse>(protocol.Requests.GoToDefinition, request);
 }
 
 export function rename(server: OmnisharpServer, request: protocol.RenameRequest, token: vscode.CancellationToken) {
@@ -71,6 +71,10 @@ export function typeLookup(server: OmnisharpServer, request: protocol.TypeLookup
 
 export function updateBuffer(server: OmnisharpServer, request: protocol.UpdateBufferRequest) {
     return server.makeRequest<boolean>(protocol.Requests.UpdateBuffer, request);
+}
+
+export function getMetadata(server: OmnisharpServer, request: protocol.MetadataRequest) {
+    return server.makeRequest<protocol.MetadataResponse>(protocol.Requests.Metadata, request);
 }
 
 export function getTestStartInfo(server: OmnisharpServer, request: protocol.V2.GetTestStartInfoRequest) {


### PR DESCRIPTION
Adds support for viewing type information for types not in the source by using existing functionality in omnisharp server. Closes #165 . 

### Go To Definition

![2016-08-16_15-23-19](https://cloud.githubusercontent.com/assets/79742/17707971/b607b994-63da-11e6-994c-cae7cb03e43b.gif)

### Peek Definition

![image](https://cloud.githubusercontent.com/assets/79742/17718008/691a9e24-6409-11e6-8fb0-20f730f1ce83.png)
