### PR TITLE
Improve parameter type matching regex

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -502,7 +502,7 @@
       ]
     },
     "parameters": {
-      "begin": "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(\\w+)\\s*(=)?",
+      "begin": "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*(=)?",
       "beginCaptures": {
         "1": {
           "name": "storage.type.modifier.cs"

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -502,7 +502,7 @@
       ]
     },
     "parameters": {
-      "begin": "\\b(ref|params|out)?\\s*\\b([\\w?]+(?:\\s*\\[\\s*,?\\s*\\])?(?:\\s*<.*?>)?)\\s+(\\w+)\\s*(=)?",
+      "begin": "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(\\w+)\\s*(=)?",
       "beginCaptures": {
         "1": {
           "name": "storage.type.modifier.cs"


### PR DESCRIPTION
Fixes (again) #657 as well as issues brought up in #670.

- Corrects the order of type, template arguments, nullable type specification and array specifications.
- Ensures array specification support all forms (simple arrays, multi-dimensional arrays, arrays of arrays).