### PR TITLE
Fix highlighting of nested namespaces and using statements.

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -8,16 +8,26 @@
   "foldingStopMarker": "^\\s*#\\s*endregion|^\\s*\\*/|^\\s*\\}",
   "patterns": [
     {
+      "include": "#using"
+    },
+    {
+      "include": "#namespace"
+    },
+    {
+      "include": "#code"
+    }
+  ],
+  "repository": {
+    "using": {
+      "begin": "^\\s*(using)\\b\\s*",
       "captures": {
         "1": {
           "name": "keyword.other.using.cs"
         }
       },
-      "begin": "^\\s*(using)\\b\\s*",
-      "end": "\\s*(?:$|(;))",
-      "name": "meta.keyword.using.cs"
+      "end": "\\s*(?:$|;)"
     },
-    {
+    "namespace": {
       "begin": "^\\s*((namespace)\\s+([\\w.]+))",
       "beginCaptures": {
         "1": {
@@ -49,17 +59,18 @@
           "name": "meta.namespace.body.cs",
           "patterns": [
             {
+              "include": "#using"
+            },
+            {
+              "include": "#namespace"
+            },
+            {
               "include": "#code"
             }
           ]
         }
       ]
     },
-    {
-      "include": "#code"
-    }
-  ],
-  "repository": {
     "block": {
       "patterns": [
         {


### PR DESCRIPTION
Fixes #282, #849, #381

Also the below which are tracked here: #101

https://github.com/Microsoft/vscode/issues/849
https://github.com/Microsoft/vscode/issues/848

### Before

![image](https://cloud.githubusercontent.com/assets/79742/17776067/f18965f2-6552-11e6-8bba-d020c68730cf.png)


### After

![image](https://cloud.githubusercontent.com/assets/79742/17775985/b152016a-6552-11e6-93d6-61c73c6554c8.png)
