### PR TITLE
Fixed namespace keyword not getting highlighted (regression)

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -28,7 +28,7 @@
       "end": "\\s*(?:$|;)"
     },
     "namespace": {
-      "begin": "^\\s*[^@]((namespace)\\s+([\\w.]+))",
+      "begin": "^\\s*[^@]?((namespace)\\s+([\\w.]+))",
       "beginCaptures": {
         "1": {
           "name": "meta.namespace.identifier.cs"
@@ -104,7 +104,7 @@
       ]
     },
     "class": {
-      "begin": "(?=\\w?[\\w\\s]*[^@](?:class|struct|interface|enum)\\s+\\w+)",
+      "begin": "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)",
       "end": "}",
       "endCaptures": {
         "0": {


### PR DESCRIPTION
Somehow during rebase of one of my pull requests from today I copy pasted something wrong and the namespaces keywords and lines weren't getting highlighted properly