### PR TITLE
Fix return value syntax highlighting.

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -371,9 +371,6 @@
               "include": "#storage-modifiers"
             },
             {
-              "include": "#builtinTypes"
-            },
-            {
               "begin": "([\\w]+\\s*(?:<[\\w<>\\s,`?]*>)?)\\s*\\(",
               "beginCaptures": {
                 "1": {


### PR DESCRIPTION
Fixes #33.

![omnisharp-syntaxhighlighting-returntypes-fixed](https://cloud.githubusercontent.com/assets/20533271/17801418/ccaa1ece-659e-11e6-871a-62b2036f4311.PNG)