### PR TITLE
Re-enable the debug console window by default

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -17,6 +17,7 @@ interface DebugConfiguration {
     name: string,
     type: string,
     request: string,
+    internalConsoleOptions?: string,
     sourceFileMap?: any,
 }
 
@@ -158,7 +159,8 @@ function createLaunchConfiguration(projectData: TargetProjectData): ConsoleLaunc
         args: [],
         cwd: '${workspaceRoot}',
         externalConsole: false,
-        stopAtEntry: false
+        stopAtEntry: false,
+        internalConsoleOptions: "openOnSessionStart"
     }
 }
 
@@ -172,6 +174,7 @@ function createWebLaunchConfiguration(projectData: TargetProjectData): WebLaunch
         args: [],
         cwd: '${workspaceRoot}',
         stopAtEntry: false,
+        internalConsoleOptions: "openOnSessionStart",
         launchBrowser: {
             enabled: true,
             args: '${auto-detect-url}',


### PR DESCRIPTION
When the VSCode team added the 'internalConsoleOptions' property to launch.json,
the default they picked was 'openOnFirstSessionStart'. This seems like the wrong default
for C# users as this hides all the messages we send. This changes our template to enable
'openOnSessionStart'.

For reference, here is the VSCode code to use this option --
https://github.com/Microsoft/vscode/blob/ac630b9b38f49fa7d1019cbb3b7ed36653be5240/src/vs/workbench/parts/debug/node/debugAdapter.ts#L113