### PR TITLE
Add dotnet restore error recording

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -60,8 +60,7 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
             installStage = "completeSuccess";
             statusBarMessage.dispose();
             vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.');
-        })
-            .catch((error: debugInstall.InstallError) => {
+        }).catch((error: debugInstall.InstallError) => {
                 const viewLogMessage = "View Log";
                 vscode.window.showErrorMessage('Error while installing .NET Core Debugger.', viewLogMessage).then(value => {
                     if (value === viewLogMessage) {

--- a/src/coreclr-debug/install.ts
+++ b/src/coreclr-debug/install.ts
@@ -12,46 +12,92 @@ import * as fs_extra from 'fs-extra-promise';
 
 export class InstallError extends Error {
     public installStage: string;
-    public installError: string;
 
-    constructor(stage: string, error: string) {
-        super("Error during installation.");
-        this.installStage = stage;
-        this.installError = error;
+    private _errorMessage: string;
+    private _hasMoreErrors: boolean;
+
+    public get hasMoreErrors(): boolean {
+        return this._hasMoreErrors;
+    }
+
+    public get errorMessage(): string {
+        return this._errorMessage;
+    }
+
+    public set errorMessage(message: string) {
+        if (this._errorMessage !== null) {
+            // Take note that we're overwriting a previous error.
+            this._hasMoreErrors = true;
+        }
+        this._errorMessage = message;
+    }
+
+    constructor() {
+        super('Error during installation.');
+        this._errorMessage = null;
+        this._hasMoreErrors = false;
+    }
+
+    public setHasMoreErrors(): void {
+        this._hasMoreErrors = true;
     }
 }
 
-export class DebugInstaller
-{
+export class DebugInstaller {
     private _util: CoreClrDebugUtil = null;
     private _isOffline;
-    
+
     constructor(util: CoreClrDebugUtil, isOffline?: boolean) {
         this._util = util;
         this._isOffline = isOffline || false;
     }
 
     public install(runtimeId: string): Promise<void> {
-        let installStage = 'writeProjectJson';
+        var errorBuilder: InstallError = new InstallError();
+        errorBuilder.installStage = 'writeProjectJson';
+
         return this.writeProjectJson(runtimeId).then(() => {
-            installStage = 'dotnetRestore';
-            return this.spawnChildProcess('dotnet', ['--verbose', 'restore', '--configfile', 'NuGet.config'], this._util.coreClrDebugDir());
+            errorBuilder.installStage = 'dotnetRestore';
+            return this._util.spawnChildProcess('dotnet', ['--verbose', 'restore', '--configfile', 'NuGet.config'], this._util.coreClrDebugDir(),
+                (data: Buffer) => {
+                    var text: string = data.toString();
+                    this._util.log(text);
+
+                    // Certain errors are only logged to stdout. Detect these and make a note of the kind of error.
+                    DebugInstaller.parseRestoreErrors(text, errorBuilder);
+                },
+                (data: Buffer) => {
+                    // Reference errors are sent to stderr at the end of restore.
+                    DebugInstaller.parseReferenceErrors(data.toString(), errorBuilder);
+                });
         }).then(() => {
-            installStage = "dotnetPublish";
-            return this.spawnChildProcess('dotnet', ['--verbose', 'publish', '-r', runtimeId, '-o', this._util.debugAdapterDir()], this._util.coreClrDebugDir());
+            errorBuilder.installStage = 'dotnetPublish';
+            return this._util.spawnChildProcess('dotnet', ['--verbose', 'publish', '-r', runtimeId, '-o', this._util.debugAdapterDir()], this._util.coreClrDebugDir(),
+                (data: Buffer) => {
+                    var text: string = data.toString();
+                    this._util.log(text);
+
+                    DebugInstaller.parsePublishErrors(text, errorBuilder);
+            });
         }).then(() => {
-            installStage = "ensureAd7";
+            errorBuilder.installStage = 'ensureAd7';
             return this.ensureAd7EngineExists(this._util.debugAdapterDir());
         }).then(() => {
-            installStage = "renameDummyEntrypoint";
+            errorBuilder.installStage = 'renameDummyEntrypoint';
             return this.renameDummyEntrypoint();
         }).then(() => {
-            installStage = "rewriteManifest";
+            errorBuilder.installStage = 'rewriteManifest';
             this.rewriteManifest();
-            installStage = "writeCompletionFile";
+            errorBuilder.installStage = 'writeCompletionFile';
             return this.writeCompletionFile();
-        }).catch((error) => {
-           throw new InstallError(installStage, error.toString()); 
+        }).catch((e) => {
+            if (errorBuilder.errorMessage === null) {
+                // Only give the error message if we don't have any better info,
+                // as this is usually something similar to "Error: 1".
+                errorBuilder.errorMessage = e;
+            }
+
+            throw errorBuilder;
         });
     }
 
@@ -60,8 +106,8 @@ export class DebugInstaller
 
         cleanItems.push(this._util.debugAdapterDir());
         cleanItems.push(this._util.installLogPath());
-        cleanItems.push(path.join(this._util.coreClrDebugDir(), "bin"));
-        cleanItems.push(path.join(this._util.coreClrDebugDir(), "obj"));
+        cleanItems.push(path.join(this._util.coreClrDebugDir(), 'bin'));
+        cleanItems.push(path.join(this._util.coreClrDebugDir(), 'obj'));
         cleanItems.push(path.join(this._util.coreClrDebugDir(), 'project.json'));
         cleanItems.push(path.join(this._util.coreClrDebugDir(), 'project.lock.json'));
 
@@ -73,7 +119,7 @@ export class DebugInstaller
         });
     }
 
-    private rewriteManifest() : void {
+    private rewriteManifest(): void {
         const manifestPath = path.join(this._util.extensionDir(), 'package.json');
         let manifestString = fs.readFileSync(manifestPath, 'utf8');
         let manifestObject = JSON.parse(manifestString);
@@ -89,11 +135,11 @@ export class DebugInstaller
         fs.writeFileSync(manifestPath, manifestString);
     }
 
-    private writeCompletionFile() : Promise<void> {
+    private writeCompletionFile(): Promise<void> {
         return CoreClrDebugUtil.writeEmptyFile(this._util.installCompleteFilePath());
     }
 
-    private renameDummyEntrypoint() : Promise<void> {
+    private renameDummyEntrypoint(): Promise<void> {
         let src = path.join(this._util.debugAdapterDir(), 'dummy');
         let dest = path.join(this._util.debugAdapterDir(), 'OpenDebugAD7');
 
@@ -113,12 +159,12 @@ export class DebugInstaller
                 }
             });
         });
-        
+
         return promise;
     }
 
-    private ensureAd7EngineExists(outputDirectory: string) : Promise<void> {
-        let filePath = path.join(outputDirectory, "coreclr.ad7Engine.json");
+    private ensureAd7EngineExists(outputDirectory: string): Promise<void> {
+        let filePath = path.join(outputDirectory, 'coreclr.ad7Engine.json');
         return new Promise<void>((resolve, reject) => {
             fs.exists(filePath, (exists) => {
                 if (exists) {
@@ -126,10 +172,9 @@ export class DebugInstaller
                 } else {
                     this._util.log(`${filePath} does not exist.`);
                     this._util.log('');
-                    // NOTE: The minimum build number is actually less than 1584, but this is the minimum
-                    // build that I have tested.
+                    // NOTE: The minimum build number is actually less than 1584, but this is the minimum tested build.
                     this._util.log("Error: The .NET CLI did not correctly restore debugger files. Ensure that you have .NET CLI version 1.0.0 build #001584 or newer. You can check your .NET CLI version using 'dotnet --version'.");
-                    return reject("The .NET CLI did not correctly restore debugger files.");
+                    return reject('The .NET CLI did not correctly restore debugger files.');
                 }
             });
         });
@@ -142,7 +187,7 @@ export class DebugInstaller
 
             const projectJson = this.createProjectJson(runtimeId);
 
-            fs.writeFile(projectJsonPath, JSON.stringify(projectJson, null, 2), {encoding: 'utf8'}, (err) => {
+            fs.writeFile(projectJsonPath, JSON.stringify(projectJson, null, 2), { encoding: 'utf8' }, (err) => {
                 if (err) {
                     this._util.log('Error: Unable to write to project.json: ' + err.message);
                     reject(err.code);
@@ -154,8 +199,7 @@ export class DebugInstaller
         });
     }
 
-    private createProjectJson(targetRuntime: string): any
-    {
+    private createProjectJson(targetRuntime: string): any {
         let projectJson = {
             name: "dummy",
             buildOptions: {
@@ -168,26 +212,26 @@ export class DebugInstaller
                 "NETStandard.Library": "1.6.0",
                 "Newtonsoft.Json": "7.0.1",
                 "Microsoft.VisualStudio.Debugger.Interop.Portable": "1.0.1",
-                "System.Collections.Specialized":  "4.0.1",
-                "System.Collections.Immutable": "1.2.0", 
-                "System.Diagnostics.Process" : "4.1.0",
+                "System.Collections.Specialized": "4.0.1",
+                "System.Collections.Immutable": "1.2.0",
+                "System.Diagnostics.Process": "4.1.0",
                 "System.Dynamic.Runtime": "4.0.11",
                 "Microsoft.CSharp": "4.0.1",
                 "System.Threading.Tasks.Dataflow": "4.6.0",
-                "System.Threading.Thread": "4.0.0", 
+                "System.Threading.Thread": "4.0.0",
                 "System.Xml.XDocument": "4.0.11",
-                "System.Xml.XmlDocument": "4.0.1",  
+                "System.Xml.XmlDocument": "4.0.1",
                 "System.Xml.XmlSerializer": "4.0.11",
-                "System.ComponentModel":  "4.0.1",  
-                "System.ComponentModel.Annotations":  "4.1.0",  
-                "System.ComponentModel.EventBasedAsync":  "4.0.11",
+                "System.ComponentModel": "4.0.1",
+                "System.ComponentModel.Annotations": "4.1.0",
+                "System.ComponentModel.EventBasedAsync": "4.0.11",
                 "System.Runtime.Serialization.Primitives": "4.1.1",
-                "System.Net.Http":  "4.1.0"
+                "System.Net.Http": "4.1.0"
             },
             frameworks: {
                 "netcoreapp1.0": {
-                    imports: [ "dnxcore50", "portable-net45+win8" ]
-                 }
+                    imports: ["dnxcore50", "portable-net45+win8"]
+                }
             },
             runtimes: {
             }
@@ -202,29 +246,65 @@ export class DebugInstaller
         return projectJson;
     }
 
-    private spawnChildProcess(process: string, args: string[], workingDirectory: string) : Promise<void> {
-        const promise = new Promise<void>((resolve, reject) => {
-            const child = child_process.spawn(process, args, {cwd: workingDirectory});
-
-            child.stdout.on('data', (data) => {
-                this._util.log(`${data}`);
-            });
-
-            child.stderr.on('data', (data) => {
-                this._util.log(`Error: ${data}`);
-            });
-
-            child.on('close', (code: number) => {
-                if (code != 0) {
-                    this._util.log(`${process} exited with error code ${code}`);
-                    reject(new Error(code.toString()));    
+    private static parseRestoreErrors(output: string, errorBuilder: InstallError): void {
+        var lines: string[] = output.replace(/\r/mg, '').split('\n');
+        lines.forEach(line => {
+            if (line.startsWith('error')) {
+                const connectionError: string = 'The server name or address could not be resolved';
+                if (line.indexOf(connectionError) !== -1) {
+                    errorBuilder.errorMessage = connectionError;
                 }
-                else {
-                    resolve();
+
+                const parseVersionError: RegExp = /Error reading '.*' at line [0-9]+ column [0-9+]: '.*' is not a valid version string/;
+                if (parseVersionError.test(line)) {
+                    errorBuilder.errorMessage = 'Invalid version string';
                 }
-            });
+            }
         });
+    }
 
-        return promise;
+    private static parseReferenceErrors(output: string, errorBuilder: InstallError): void {
+        // Reference errors are restated at the end of the output. Find this section first.
+        var errorRegionRegExp: RegExp = /^Errors in .*project\.json$/gm
+        var beginIndex: number = output.search(errorRegionRegExp);
+        var errorBlock: string = output.slice(beginIndex);
+
+        var lines: string[] = errorBlock.replace(/\r/mg, '').split('\n');
+        lines.forEach(line => {
+            var referenceRegExp: RegExp = /^(?:\t|\ \ \ \ )Unable to resolve '([^']+)'/g
+            var match: RegExpMatchArray;
+            while (match = referenceRegExp.exec(line)) {
+                var reference: string = match[1];
+                if (reference.startsWith('Microsoft') ||
+                    reference.startsWith('System') ||
+                    reference.startsWith('NETStandard') ||
+                    reference.startsWith('Newtonsoft')) {
+                    errorBuilder.errorMessage = `Unable to restore reference '${reference}'`;
+                } else {
+                    errorBuilder.errorMessage = 'Error(s) encountered restoring private references';
+                }
+            }
+        });
+    }
+
+    private static parsePublishErrors(output: string, errorBuilder: InstallError): void {
+        var lines: string[] = output.replace(/\r/mg, '').split('\n');
+        lines.forEach(line => {
+            var errorTypeRegExp: RegExp = /^([\w\.]+Exception)/g
+            var typeMatch: RegExpMatchArray;
+            while (typeMatch = errorTypeRegExp.exec(line)) {
+                var type: string = typeMatch[1];
+                if (type === 'System.IO.IOException') {
+                    var ioExceptionRegExp: RegExp = /System\.IO\.IOException: The process cannot access the file '(.*)' because it is being used by another process./g
+                    var ioMatch: RegExpMatchArray;
+                    if (ioMatch = ioExceptionRegExp.exec(line)) {
+                        // Remove path as it may contain user information.
+                        errorBuilder.errorMessage = `System.IO.IOException: unable to access '${path.basename(ioMatch[1])}'`;
+                    }
+                } else {
+                    errorBuilder.errorMessage = type;
+                }
+            }
+        });
     }
 }

--- a/src/coreclr-debug/install.ts
+++ b/src/coreclr-debug/install.ts
@@ -61,21 +61,25 @@ export class DebugInstaller {
             return this._util.spawnChildProcess('dotnet', ['--verbose', 'restore', '--configfile', 'NuGet.config'], this._util.coreClrDebugDir(),
                 (data: Buffer) => {
                     var text: string = data.toString();
-                    this._util.log(text);
+                    this._util.logRaw(text);
 
-                    // Certain errors are only logged to stdout. Detect these and make a note of the kind of error.
+                    // Certain errors are only logged to stdout.
+                    // Detect these and make a note of the kind of error.
                     DebugInstaller.parseRestoreErrors(text, errorBuilder);
                 },
                 (data: Buffer) => {
+                    var text: string = data.toString();
+                    this._util.logRaw(text);
+
                     // Reference errors are sent to stderr at the end of restore.
-                    DebugInstaller.parseReferenceErrors(data.toString(), errorBuilder);
+                    DebugInstaller.parseReferenceErrors(text, errorBuilder);
                 });
         }).then(() => {
             errorBuilder.installStage = 'dotnetPublish';
             return this._util.spawnChildProcess('dotnet', ['--verbose', 'publish', '-r', runtimeId, '-o', this._util.debugAdapterDir()], this._util.coreClrDebugDir(),
                 (data: Buffer) => {
                     var text: string = data.toString();
-                    this._util.log(text);
+                    this._util.logRaw(text);
 
                     DebugInstaller.parsePublishErrors(text, errorBuilder);
             });
@@ -173,7 +177,9 @@ export class DebugInstaller {
                     this._util.log(`${filePath} does not exist.`);
                     this._util.log('');
                     // NOTE: The minimum build number is actually less than 1584, but this is the minimum tested build.
-                    this._util.log("Error: The .NET CLI did not correctly restore debugger files. Ensure that you have .NET CLI version 1.0.0 build #001584 or newer. You can check your .NET CLI version using 'dotnet --version'.");
+                    this._util.log('Error: The .NET CLI did not correctly restore debugger files. ' +
+                        'Ensure that you have .NET CLI version 1.0.0 build #001584 or newer. ' +
+                        "You can check your .NET CLI version using 'dotnet --version'.");
                     return reject('The .NET CLI did not correctly restore debugger files.');
                 }
             });
@@ -255,7 +261,7 @@ export class DebugInstaller {
                     errorBuilder.errorMessage = connectionError;
                 }
 
-                const parseVersionError: RegExp = /Error reading '.*' at line [0-9]+ column [0-9+]: '.*' is not a valid version string/;
+                const parseVersionError: RegExp = /Error reading '.*' at line [0-9]+ column [0-9]+: '.*' is not a valid version string/;
                 if (parseVersionError.test(line)) {
                     errorBuilder.errorMessage = 'Invalid version string';
                 }

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -87,6 +87,18 @@ export class CoreClrDebugUtil
         }
     }
 
+    logRaw(message: string): void {
+        console.log(message);
+
+        if (this._installLog != null) {
+            this._installLog.write(message);
+        }
+
+        if (this._channel != null) {
+            this._channel.append(message);
+        }
+    }
+
     log(message: string): void {
         console.log(message);
 
@@ -116,14 +128,15 @@ export class CoreClrDebugUtil
             const child = child_process.spawn(process, args, { cwd: workingDirectory });
 
             if (!onStdout) {
-                onStdout = (data) => { this.log(`${data}`); };
+                onStdout = (data) => { this.logRaw(`${data}`); };
             }
             child.stdout.on('data', onStdout);
 
             if (!onStderr) {
-                onStderr = (data) => { this.log(`${data}`); };
+                onStderr = (data) => { this.logRaw(`${data}`); };
             }
             child.stderr.on('data', onStderr);
+
             child.on('close', (code: number) => {
                 if (code != 0) {
                     this.log(`${process} exited with error code ${code}`);;
@@ -133,6 +146,10 @@ export class CoreClrDebugUtil
                     resolve();
                 }
             });
+
+            child.on('error', (error: Error) => {
+                reject(error);
+            })
         });
 
         return promise;

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import * as child_process from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -20,7 +21,7 @@ export class CoreClrDebugUtil
 
     private _installLog: fs.WriteStream = null;
     private _channel: vscode.OutputChannel = null;
-    
+
     constructor(extensionDir: string, channel?: vscode.OutputChannel) {
         this._extensionDir = extensionDir;
         this._coreClrDebugDir = path.join(this._extensionDir, 'coreclr-debug');
@@ -31,7 +32,7 @@ export class CoreClrDebugUtil
 
         this._channel = channel;
     }
-        
+
     extensionDir(): string {
         if (this._extensionDir === '')
         {
@@ -109,7 +110,34 @@ export class CoreClrDebugUtil
             });
         });
     }
- 
+
+    public spawnChildProcess(process: string, args: string[], workingDirectory: string, onStdout?: (data: Buffer) => void, onStderr?: (data: Buffer) => void): Promise<void> {
+        const promise = new Promise<void>((resolve, reject) => {
+            const child = child_process.spawn(process, args, { cwd: workingDirectory });
+
+            if (!onStdout) {
+                onStdout = (data) => { this.log(`${data}`); };
+            }
+            child.stdout.on('data', onStdout);
+
+            if (!onStderr) {
+                onStderr = (data) => { this.log(`${data}`); };
+            }
+            child.stderr.on('data', onStderr);
+            child.on('close', (code: number) => {
+                if (code != 0) {
+                    this.log(`${process} exited with error code ${code}`);;
+                    reject(new Error(code.toString()));
+                }
+                else {
+                    resolve();
+                }
+            });
+        });
+
+        return promise;
+    }
+
     static existsSync(path: string) : boolean {
         try {
             fs.accessSync(path, fs.F_OK);
@@ -122,7 +150,7 @@ export class CoreClrDebugUtil
             }
         }
     }
-    
+
     static getPlatformExeExtension() : string {
         if (process.platform === 'win32') {
             return '.exe';
@@ -143,7 +171,7 @@ export class CoreClrDebugUtil
                 throw Error('Unsupported platform ' + process.platform);
         }
     }
-    
+
     /** Used for diagnostics only */
     logToFile(message: string): void {
         let logFolder = path.resolve(this.coreClrDebugDir(), "extension.log");


### PR DESCRIPTION
- Add error output parsing to dotnet restore and dotnet publish so that we get more information than "Error: 1"
- Add basic platform data to telemetry properties (dotnet version, OS platform/runtime id)

@gregg-miskelly @caslan @rajkumar42 @chuckries