### PR TITLE
Add suppressDotnetInstallWarning user setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       }
     ],
     "configuration": {
-      "title": "Omnisharp configuration",
+      "title": "C# configuration",
       "properties": {
         "csharp.suppressDotnetInstallWarning": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,16 @@
         "configuration": "./csharp.configuration.json"
       }
     ],
+    "configuration": {
+      "title": "Omnisharp configuration",
+      "properties": {
+        "csharp.suppressDotnetInstallWarning": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress the warning that the .NET CLI is not on the path."
+        }
+      }
+    },
     "grammars": [
       {
         "language": "csharp",

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -90,14 +90,22 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
                 _util.closeInstallLog();
             });
     }).catch(() => {
-        const getDotNetMessage = "Get .NET CLI tools";
-        vscode.window.showErrorMessage("The .NET CLI tools cannot be located. .NET Core debugging will not be enabled. Make sure .NET CLI tools are installed and are on the path.",
-            getDotNetMessage).then(value => {
-                if (value === getDotNetMessage) {
-                    let open = require('open');
-                    open("https://www.microsoft.com/net/core");
-                }
-            });
+        const config = vscode.workspace.getConfiguration('csharp');
+        if (!config.get('suppressDotnetInstallWarning', false)) {
+            const getDotNetMessage = 'Get .NET CLI tools';
+            const goToSettingsMessage = 'Disable this message in user settings';
+            // Buttons are shown in right-to-left order, with a close button to the right of everything;
+            // getDotNetMessage will be the first button, then goToSettingsMessage, then the close button.
+            vscode.window.showErrorMessage('The .NET CLI tools cannot be located. .NET Core debugging will not be enabled. Make sure .NET CLI tools are installed and are on the path.',
+                goToSettingsMessage, getDotNetMessage).then(value => {
+                    if (value === getDotNetMessage) {
+                        let open = require('open');
+                        open('https://www.microsoft.com/net/core');
+                    } else if (value === goToSettingsMessage) {
+                        vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+                    }
+                });
+        }
     });
 }
 


### PR DESCRIPTION
- Add a user option to suppress the "Get .NET CLI tools" popup that appears when the tools are not found.
- Add a navigation point to the settings page to the popup.

Fix for #603.