### PR TITLE
Remove dotnet-core nuget feed

### DIFF
--- a/coreclr-debug/NuGet.config
+++ b/coreclr-debug/NuGet.config
@@ -6,6 +6,5 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <!-- This dependency is not present in the release branch -->
     <add key="coreclrdebug" value="https://www.myget.org/F/coreclr-debug/api/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
System.Reflection.Metadata has been pulished to nuget.org so we no longer
need this feed dependency.