### PR TITLE
Improve OmniSharp options

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,28 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress the warning that the .NET CLI is not on the path."
+        },
+        "omnisharp.path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Specifies the full path to the OmniSharp server."
+        },
+        "omnisharp.useMono": {
+          "type": "boolean",
+          "default": false,
+          "description": "Launch OmniSharp with Mono."
+        },
+        "omnisharp.loggingLevel": {
+          "type": "string",
+          "default": "default",
+          "enum": [
+            "default",
+            "verbose"
+          ],
+          "description": "Specifies the level of logging output from the OmniSharp server."
         }
       }
     },

--- a/src/omnisharp/omnisharp.ts
+++ b/src/omnisharp/omnisharp.ts
@@ -15,7 +15,8 @@ import * as path from 'path';
 
 export interface Options {
 	path?: string;
-	usesMono?: boolean;
+	useMono?: boolean;
+    loggingLevel?: string;
 }
 
 export enum Flavor {

--- a/src/omnisharp/omnisharp.ts
+++ b/src/omnisharp/omnisharp.ts
@@ -14,8 +14,8 @@ import * as fs from 'fs-extra-promise';
 import * as path from 'path';
 
 export interface Options {
-	path?: string;
-	useMono?: boolean;
+    path?: string;
+    useMono?: boolean;
     loggingLevel?: string;
 }
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -411,7 +411,7 @@ export abstract class OmnisharpServer {
 				return omnisharp.findServerPath(options.path).then(serverPath => {
 					return resolve(serverPath);
 				}).catch(err => {
-					vscode.window.showWarningMessage(`Invalid "csharp.omnisharp" user setting specified ('${options.path}).`);
+					vscode.window.showWarningMessage(`Invalid value specified for "omnisharp.path" ('${options.path}).`);
 					return reject(err);
 				});
 			}
@@ -429,9 +429,9 @@ export abstract class OmnisharpServer {
 				this._channel.appendLine("    1. If it's not already installed, download and install Mono (https://www.mono-project.com)");
 				this._channel.appendLine("    2. Download and untar the latest OmniSharp Mono release from  https://github.com/OmniSharp/omnisharp-roslyn/releases/");
 				this._channel.appendLine("    3. In Visual Studio Code, select Preferences->User Settings to open settings.json.");
-				this._channel.appendLine("    4. In settings.json, add a new setting: \"csharp.omnisharp\": \"/path/to/omnisharp/OmniSharp.exe\"");
-				this._channel.appendLine("    4. In settings.json, add a new setting: \"csharp.omnisharpUsesMono\": true");
-				this._channel.appendLine("    5. Restart Visual Studio Code.");
+				this._channel.appendLine("    4. In settings.json, add a new setting: \"omnisharp.path\": \"/path/to/omnisharp/OmniSharp.exe\"");
+				this._channel.appendLine("    5. In settings.json, add a new setting: \"omnisharp.useMono\": true");
+				this._channel.appendLine("    6. Restart Visual Studio Code.");
 				this._channel.show();
 
 				throw err;


### PR DESCRIPTION
- Add new configuration for OmniSharp-specific options: "omnisharp"
- Rename "csharp.omnisharp" to "omnisharp.path" (legacy option is still supported)
- Rename "csharp.omnisharpUsesMono" to "omnisharp.useMono" (legacy option is still supported)
- Add new option "omnisharp.loggingLevel" which can be set to "verbose". This enables debugging output from the OmniSharp server.