### PR TITLE
Syntax highlighting for field, variable and new expression types

### DIFF
--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -209,6 +209,10 @@
           "include": "#constants"
         },
         {
+          "include": "#new-expression"
+        },
+
+        {
           "include": "#storage-modifiers"
         },
         {
@@ -354,6 +358,27 @@
         }
       ]
     },
+    "new-expression": {
+      "patterns": [
+        {
+          "begin": "\\b(new)(?!\\s*(?:\\[|\\{|\\())\\s+(.*?)(?=\\(|{)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.new.cs"
+            },
+            "2": {
+              "name": "storage.type.new.cs"
+            }
+          },
+          "end": "(?={|;)",
+          "patterns": [
+            {
+              "include": "#code"
+            }
+          ]
+        }
+      ]
+    },
     "method": {
       "patterns": [
         {
@@ -369,16 +394,6 @@
             },
             {
               "include": "#builtinTypes"
-            }
-          ]
-        },
-        {
-          "begin": "(?=\\bnew\\s+)(?=[\\w<].*\\s+)(?=[^=]+\\()",
-          "end": "(?={|;)",
-          "name": "meta.new-object.cs",
-          "patterns": [
-            {
-              "include": "#code"
             }
           ]
         },

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -71,6 +71,32 @@
         }
       ]
     },
+    "variable": {
+      "patterns": [
+        {
+          "match": "\\b(var)\\s+(.*?)(?=(=|;))",
+          "captures": {
+            "1": {
+              "name": "keyword.other.var.cs"
+            },
+            "2": {
+              "name": "variable.name.cs"
+            }
+          }
+        },
+        {
+          "match": "\\b(?!var|return|yield|throw)([\\w<>*?\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))",
+          "captures": {
+            "1": {
+              "name": "storage.type.variable.cs"
+            },
+            "2": {
+              "name": "variable.name.cs"
+            }
+          }
+        }
+      ]
+    },
     "block": {
       "patterns": [
         {
@@ -175,6 +201,9 @@
         },
         {
           "include": "#class"
+        },
+        {
+          "include": "#variable"
         },
         {
           "include": "#constants"
@@ -316,12 +345,8 @@
           "name": "keyword.operator.cs"
         },
         {
-          "match": "\\b(event|delegate|fixed|add|remove|set|get|value)\\b",
+          "match": "\\b(event|delegate|fixed|add|remove|set|get|value|var)\\b",
           "name": "keyword.other.cs"
-        },
-        {
-          "match": "\\b(var)\\b",
-          "name": "storage.type.var.cs"
         },
         {
           "match": "[@]\\b(namespace|class|var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof|nameof|when|override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending|if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|internal|public|protected|private|static|const|sealed|abstract|virtual|extern|unsafe|volatile|implicit|explicit|operator|async|partial|bool|byte|sbyte|char|decimal|double|float|int|uint|long|ulong|object|short|ushort|string|void|struct|enum|interface)\\b",


### PR DESCRIPTION
Effectively the result is this:

![image](https://cloud.githubusercontent.com/assets/79742/18004179/17465934-6b8a-11e6-9e11-e5ed2313776c.png)

and in fact matches the TypeScript highlighting:

![image](https://cloud.githubusercontent.com/assets/79742/18004216/566d6472-6b8a-11e6-9c73-3d5baf0645d1.png)

Thoughts?

Closes #687
Relates to #674

### Before

![image](https://cloud.githubusercontent.com/assets/79742/18004382/7f64c478-6b8b-11e6-909c-34d5a62efc33.png)


### After

![image](https://cloud.githubusercontent.com/assets/79742/18004089/b90aae6a-6b89-11e6-9f95-e3d5c457dcbb.png)
