### PR TITLE
Cherry pick fix to legacy omnisharp settings

### DIFF
--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -24,13 +24,13 @@ export function readOptions(): Options {
     const omnisharpConfig = vscode.workspace.getConfiguration('omnisharp');
     const csharpConfig = vscode.workspace.getConfiguration('csharp');
 
-    const path = omnisharpConfig.has('path')
-        ? omnisharpConfig.get<string>('path')
-        : csharpConfig.get<string>('omnisharp');
+    const path = csharpConfig.has('omnisharp')
+        ? csharpConfig.get<string>('omnisharp')
+        : omnisharpConfig.get<string>('path');
 
-    const useMono = omnisharpConfig.has('useMono')
-        ? omnisharpConfig.get<boolean>('useMono')
-        : csharpConfig.get<boolean>('omnisharpUsesMono');
+    const useMono = csharpConfig.has('omnisharpUsesMono')
+        ? csharpConfig.get<boolean>('omnisharpUsesMono')
+        : omnisharpConfig.get<boolean>('useMono');
 
     const loggingLevel = omnisharpConfig.get<string>('loggingLevel');
     const autoStart = omnisharpConfig.get<boolean>('autoStart', true);


### PR DESCRIPTION
Because the `omnisharp.path` and `omnisharp.useMono` settings are defined in the package.json with defaults, they are always present and the legacy settings (`csharp.omnisharp` and `csharp.omnisharpUsesMono`) won't ever be used. This fixes that by first checking for the presence of the legacy options and using the new options if they don't exist.