### PR TITLE
Adding support for Remote .NET Attach and tsc fix on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -685,7 +685,7 @@
                   },
                   "debuggerPath" : {
                     "type" : "string",
-                    "description" : "The full path to the debugger",
+                    "description" : "The full path to the debugger on the target machine.",
                     "default" : "~/clrdbg/clrdbg"
                   },
                   "pipeEnv": {

--- a/package.json
+++ b/package.json
@@ -413,7 +413,7 @@
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
                   "pipeArgs": [],
-                  "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                  "debuggerPath" : "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -436,7 +436,7 @@
                   },
                   "debuggerPath" : {
                     "type" : "string",
-                    "description" : "The full path to the debugger",
+                    "description" : "The full path to the debugger on the target machine.",
                     "default" : "~/clrdbg/clrdbg"
                   },
                   "pipeEnv": {
@@ -453,8 +453,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "Please enter the debugger path here, for example c:\\clrdbg\\clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -475,11 +474,6 @@
                         },
                         "default": []
                       },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "c:/clrdbg/clrdbg"
-                      },
                       "pipeEnv": {
                         "type": "object",
                         "additionalProperties": {
@@ -496,8 +490,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -517,11 +510,6 @@
                           "type": "string"
                         },
                         "default": []
-                      },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",
@@ -539,8 +527,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -560,11 +547,6 @@
                           "type": "string"
                         },
                         "default": []
-                      },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",
@@ -672,6 +654,9 @@
               },
               "pipeTransport": {
                 "type": "object",
+                "required": [
+                    "debuggerPath"
+                ],
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
                 "default": {
                   "pipeCwd": "${workspaceRoot}",
@@ -717,8 +702,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -739,11 +723,6 @@
                         },
                         "default": []
                       },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "~/clrdbg/clrdbg"
-                      },
                       "pipeEnv": {
                         "type": "object",
                         "additionalProperties": {
@@ -760,8 +739,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -781,11 +759,6 @@
                           "type": "string"
                         },
                         "default": []
-                      },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",
@@ -803,8 +776,7 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": [],
-                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                      "pipeArgs": []
                     },
                     "properties": {
                       "pipeCwd": {
@@ -824,11 +796,6 @@
                           "type": "string"
                         },
                         "default": []
-                      },
-                      "debuggerPath" : {
-                        "type" : "string",
-                        "description" : "The full path to the debugger",
-                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "onCommand:dotnet.restore",
     "onCommand:csharp.downloadDebugger",
     "onCommand:csharp.listProcess",
+    "onCommand:csharp.listRemoteProcess",
     "workspaceContains:project.json"
   ],
   "contributes": {
@@ -153,6 +154,11 @@
         "command": "csharp.listProcess",
         "title": "List process for attach",
         "category": "CSharp"
+      },
+      {
+        "command" : "csharp.listRemoteProcess",
+        "title" : "List processes on remote connection for attach",
+        "category": "CSharp"
       }
     ],
     "keybindings": [
@@ -193,12 +199,11 @@
             "razor"
           ]
         },
-        "runtime": "node",
         "runtimeArgs": [],
         "variables": {
-          "pickProcess": "csharp.listProcess"
+          "pickProcess": "csharp.listProcess",
+          "pickRemoteProcess": "csharp.listRemoteProcess"
         },
-        "program": "./out/src/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {
@@ -405,7 +410,8 @@
                 "default": {
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
-                  "pipeArgs": []
+                  "pipeArgs": [],
+                  "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -426,6 +432,11 @@
                     },
                     "default": []
                   },
+                  "debuggerPath" : {
+                    "type" : "string",
+                    "description" : "The full path to the debugger",
+                    "default" : "~/clrdbg/clrdbg"
+                  },
                   "pipeEnv": {
                     "type": "object",
                     "additionalProperties": {
@@ -440,7 +451,8 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
-                      "pipeArgs": []
+                      "pipeArgs": [],
+                      "debuggerPath" : "Please enter the debugger path here, for example c:\\clrdbg\\clrdbg"
                     },
                     "properties": {
                       "pipeCwd": {
@@ -461,6 +473,11 @@
                         },
                         "default": []
                       },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "c:/clrdbg/clrdbg"
+                      },
                       "pipeEnv": {
                         "type": "object",
                         "additionalProperties": {
@@ -477,7 +494,8 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": []
+                      "pipeArgs": [],
+                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
                     },
                     "properties": {
                       "pipeCwd": {
@@ -497,6 +515,11 @@
                           "type": "string"
                         },
                         "default": []
+                      },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",
@@ -514,7 +537,8 @@
                     "default": {
                       "pipeCwd": "${workspaceRoot}",
                       "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                      "pipeArgs": []
+                      "pipeArgs": [],
+                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
                     },
                     "properties": {
                       "pipeCwd": {
@@ -534,6 +558,11 @@
                           "type": "string"
                         },
                         "default": []
+                      },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "~/clrdbg/clrdbg"
                       },
                       "pipeEnv": {
                         "type": "object",
@@ -636,6 +665,178 @@
                     "type": "boolean",
                     "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
                     "default": false
+                  }
+                }
+              },
+              "pipeTransport": {
+                "type": "object",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
+                "default": {
+                  "pipeCwd": "${workspaceRoot}",
+                  "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
+                  "pipeArgs": [],
+                  "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                },
+                "properties": {
+                  "pipeCwd": {
+                    "type": "string",
+                    "description": "The fully qualified path to the working directory for the pipe program.",
+                    "default": "${workspaceRoot}"
+                  },
+                  "pipeProgram": {
+                    "type": "string",
+                    "description": "The fully qualified pipe command to execute.",
+                    "default": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'"
+                  },
+                  "pipeArgs": {
+                    "type": "array",
+                    "description": "Command line arguments passed to the pipe program.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
+                  },
+                  "debuggerPath" : {
+                    "type" : "string",
+                    "description" : "The full path to the debugger",
+                    "default" : "~/clrdbg/clrdbg"
+                  },
+                  "pipeEnv": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Environment variables passed to the pipe program.",
+                    "default": {}
+                  },
+                  "windows": {
+                    "type": "object",
+                    "description": "Windows-specific pipe launch configuration options",
+                    "default": {
+                      "pipeCwd": "${workspaceRoot}",
+                      "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
+                      "pipeArgs": [],
+                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                    },
+                    "properties": {
+                      "pipeCwd": {
+                        "type": "string",
+                        "description": "The fully qualified path to the working directory for the pipe program.",
+                        "default": "${workspaceRoot}"
+                      },
+                      "pipeProgram": {
+                        "type": "string",
+                        "description": "The fully qualified pipe command to execute.",
+                        "default": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'"
+                      },
+                      "pipeArgs": {
+                        "type": "array",
+                        "description": "Command line arguments passed to the pipe program.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "~/clrdbg/clrdbg"
+                      },
+                      "pipeEnv": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Environment variables passed to the pipe program.",
+                        "default": {}
+                      }
+                    }
+                  },
+                  "osx": {
+                    "type": "object",
+                    "description": "OSX-specific pipe launch configuration options",
+                    "default": {
+                      "pipeCwd": "${workspaceRoot}",
+                      "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+                      "pipeArgs": [],
+                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                    },
+                    "properties": {
+                      "pipeCwd": {
+                        "type": "string",
+                        "description": "The fully qualified path to the working directory for the pipe program.",
+                        "default": "${workspaceRoot}"
+                      },
+                      "pipeProgram": {
+                        "type": "string",
+                        "description": "The fully qualified pipe command to execute.",
+                        "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
+                      },
+                      "pipeArgs": {
+                        "type": "array",
+                        "description": "Command line arguments passed to the pipe program.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "~/clrdbg/clrdbg"
+                      },
+                      "pipeEnv": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Environment variables passed to the pipe program.",
+                        "default": {}
+                      }
+                    }
+                  },
+                  "linux": {
+                    "type": "object",
+                    "description": "Linux-specific pipe launch configuration options",
+                    "default": {
+                      "pipeCwd": "${workspaceRoot}",
+                      "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+                      "pipeArgs": [],
+                      "debuggerPath" : "enter the path for the debugger, for example ~/clrdbg/clrdbg"
+                    },
+                    "properties": {
+                      "pipeCwd": {
+                        "type": "string",
+                        "description": "The fully qualified path to the working directory for the pipe program.",
+                        "default": "${workspaceRoot}"
+                      },
+                      "pipeProgram": {
+                        "type": "string",
+                        "description": "The fully qualified pipe command to execute.",
+                        "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
+                      },
+                      "pipeArgs": {
+                        "type": "array",
+                        "description": "Command line arguments passed to the pipe program.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "debuggerPath" : {
+                        "type" : "string",
+                        "description" : "The full path to the debugger",
+                        "default" : "~/clrdbg/clrdbg"
+                      },
+                      "pipeEnv": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Environment variables passed to the pipe program.",
+                        "default": {}
+                      }
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -199,11 +199,13 @@
             "razor"
           ]
         },
+        "runtime" : "node",
         "runtimeArgs": [],
         "variables": {
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess"
         },
+        "program": "./out/src/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {
@@ -896,3 +898,4 @@
     ]
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
             "razor"
           ]
         },
-        "runtime" : "node",
+        "runtime": "node",
         "runtimeArgs": [],
         "variables": {
           "pickProcess": "csharp.listProcess",

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
 import * as dotnetTest from './dotnetTest'
-import {DotNetAttachItemsProviderFactory, AttachPicker} from './processPicker'
+import {DotNetAttachItemsProviderFactory, AttachPicker, RemoteAttachPicker} from './processPicker'
 
 let channel = vscode.window.createOutputChannel('.NET');
 
@@ -36,8 +36,9 @@ export default function registerCommands(server: OmnisharpServer, extensionPath:
     let attachItemsProvider = DotNetAttachItemsProviderFactory.Get();
     let attacher = new AttachPicker(attachItemsProvider);
     let d8 = vscode.commands.registerCommand('csharp.listProcess', () => attacher.ShowAttachEntries());
+    let d9 = vscode.commands.registerCommand('csharp.listRemoteProcess', (args) => RemoteAttachPicker.ShowAttachEntries(args));
 
-    return vscode.Disposable.from(d1, d2, d3, d4, d5, d6, d7, d8);
+    return vscode.Disposable.from(d1, d2, d3, d4, d5, d6, d7, d8, d9);
 }
 
 function restartOmniSharp(server: OmnisharpServer) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,6 +20,28 @@ export enum Platform {
     Ubuntu16
 }
 
+function getValue(name: string, lines: string[]) {
+    for (let line of lines) {
+        line = line.trim();
+        if (line.startsWith(name)) {
+            const equalsIndex = line.indexOf('=');
+            if (equalsIndex >= 0) {
+                let value = line.substring(equalsIndex + 1);
+
+                // Strip double quotes if necessary
+                if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+                    value = value.substring(1, value.length - 1);
+                }
+
+                return value;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+
 export function getCurrentPlatform() {
     if (process.platform === 'win32') {
         return Platform.Windows;
@@ -34,33 +56,12 @@ export function getCurrentPlatform() {
         const text = child_process.execSync('cat /etc/os-release').toString();
         const lines = text.split('\n');
 
-        function getValue(name: string) {
-            for (let line of lines) {
-                line = line.trim();
-                if (line.startsWith(name)) {
-                    const equalsIndex = line.indexOf('=');
-                    if (equalsIndex >= 0) {
-                        let value = line.substring(equalsIndex + 1);
-
-                        // Strip double quotes if necessary
-                        if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-                            value = value.substring(1, value.length - 1);
-                        }
-
-                        return value;
-                    }
-                }
-            }
-
-            return undefined;
-        }
-
-        const id = getValue("ID");
+        const id = getValue("ID", lines);
 
         switch (id)
         {
             case 'ubuntu':
-                const versionId = getValue("VERSION_ID");
+                const versionId = getValue("VERSION_ID", lines);
                 if (versionId.startsWith("14")) {
                     // This also works for Linux Mint
                     return Platform.Ubuntu14;
@@ -84,7 +85,7 @@ export function getCurrentPlatform() {
                 // Oracle Linux is binary compatible with CentOS
                 return Platform.CentOS;
             case 'elementary OS':
-                const eOSVersionId = getValue("VERSION_ID");
+                const eOSVersionId = getValue("VERSION_ID", lines);
                 if (eOSVersionId.startsWith("0.3")) {
                     // Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04
                     return Platform.Ubuntu14;
@@ -96,7 +97,7 @@ export function getCurrentPlatform() {
 
                 break;
             case 'linuxmint':
-                const lmVersionId = getValue("VERSION_ID");
+                const lmVersionId = getValue("VERSION_ID", lines);
                 if (lmVersionId.startsWith("18")) {
                     // Linux Mint 18 is binary compatible with Ubuntu 16.04
                     return Platform.Ubuntu16;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,28 +20,6 @@ export enum Platform {
     Ubuntu16
 }
 
-function getValue(name: string, lines: string[]) {
-    for (let line of lines) {
-        line = line.trim();
-        if (line.startsWith(name)) {
-            const equalsIndex = line.indexOf('=');
-            if (equalsIndex >= 0) {
-                let value = line.substring(equalsIndex + 1);
-
-                // Strip double quotes if necessary
-                if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-                    value = value.substring(1, value.length - 1);
-                }
-
-                return value;
-            }
-        }
-    }
-
-    return undefined;
-}
-
-
 export function getCurrentPlatform() {
     if (process.platform === 'win32') {
         return Platform.Windows;
@@ -56,12 +34,33 @@ export function getCurrentPlatform() {
         const text = child_process.execSync('cat /etc/os-release').toString();
         const lines = text.split('\n');
 
-        const id = getValue("ID", lines);
+        function getValue(name: string) {
+            for (let line of lines) {
+                line = line.trim();
+                if (line.startsWith(name)) {
+                    const equalsIndex = line.indexOf('=');
+                    if (equalsIndex >= 0) {
+                        let value = line.substring(equalsIndex + 1);
+
+                        // Strip double quotes if necessary
+                        if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+                            value = value.substring(1, value.length - 1);
+                        }
+
+                        return value;
+                    }
+                }
+            }
+
+            return undefined;
+        }
+
+        const id = getValue("ID");
 
         switch (id)
         {
             case 'ubuntu':
-                const versionId = getValue("VERSION_ID", lines);
+                const versionId = getValue("VERSION_ID");
                 if (versionId.startsWith("14")) {
                     // This also works for Linux Mint
                     return Platform.Ubuntu14;
@@ -85,7 +84,7 @@ export function getCurrentPlatform() {
                 // Oracle Linux is binary compatible with CentOS
                 return Platform.CentOS;
             case 'elementary OS':
-                const eOSVersionId = getValue("VERSION_ID", lines);
+                const eOSVersionId = getValue("VERSION_ID");
                 if (eOSVersionId.startsWith("0.3")) {
                     // Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04
                     return Platform.Ubuntu14;
@@ -97,7 +96,7 @@ export function getCurrentPlatform() {
 
                 break;
             case 'linuxmint':
-                const lmVersionId = getValue("VERSION_ID", lines);
+                const lmVersionId = getValue("VERSION_ID");
                 if (lmVersionId.startsWith("18")) {
                     // Linux Mint 18 is binary compatible with Ubuntu 16.04
                     return Platform.Ubuntu16;


### PR DESCRIPTION
**Feature:**
package.json adds listRemoteProcesses as a command, including debuggerPath into pipeTransport. The
command is registered into commands.ts. processPicker.ts has its process listing parser refactored
and now includes calling process listing to remote processes. Only works on Linux and OSX. Windows
remote attach will result in a rejected promise.

**Fix:**
Fixing tsc error TS1252 in platform.ts.
Moved the getValue function within getCurrentPlatform function outside of function scope. Added string array parameter to getValue function because lines was originally a local variable within the getCurrentPlatform function.
