### PR TITLE
Fixing tsc error TS1252 in platform.ts

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,6 +20,28 @@ export enum Platform {
     Ubuntu16
 }
 
+function getValue(name: string, lines: string[]) {
+    for (let line of lines) {
+        line = line.trim();
+        if (line.startsWith(name)) {
+            const equalsIndex = line.indexOf('=');
+            if (equalsIndex >= 0) {
+                let value = line.substring(equalsIndex + 1);
+
+                // Strip double quotes if necessary
+                if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+                    value = value.substring(1, value.length - 1);
+                }
+
+                return value;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+
 export function getCurrentPlatform() {
     if (process.platform === 'win32') {
         return Platform.Windows;
@@ -34,33 +56,12 @@ export function getCurrentPlatform() {
         const text = child_process.execSync('cat /etc/os-release').toString();
         const lines = text.split('\n');
 
-        function getValue(name: string) {
-            for (let line of lines) {
-                line = line.trim();
-                if (line.startsWith(name)) {
-                    const equalsIndex = line.indexOf('=');
-                    if (equalsIndex >= 0) {
-                        let value = line.substring(equalsIndex + 1);
-
-                        // Strip double quotes if necessary
-                        if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-                            value = value.substring(1, value.length - 1);
-                        }
-
-                        return value;
-                    }
-                }
-            }
-
-            return undefined;
-        }
-
-        const id = getValue("ID");
+        const id = getValue("ID", lines);
 
         switch (id)
         {
             case 'ubuntu':
-                const versionId = getValue("VERSION_ID");
+                const versionId = getValue("VERSION_ID", lines);
                 if (versionId.startsWith("14")) {
                     // This also works for Linux Mint
                     return Platform.Ubuntu14;
@@ -84,7 +85,7 @@ export function getCurrentPlatform() {
                 // Oracle Linux is binary compatible with CentOS
                 return Platform.CentOS;
             case 'elementary OS':
-                const eOSVersionId = getValue("VERSION_ID");
+                const eOSVersionId = getValue("VERSION_ID", lines);
                 if (eOSVersionId.startsWith("0.3")) {
                     // Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04
                     return Platform.Ubuntu14;
@@ -96,7 +97,7 @@ export function getCurrentPlatform() {
 
                 break;
             case 'linuxmint':
-                const lmVersionId = getValue("VERSION_ID");
+                const lmVersionId = getValue("VERSION_ID", lines);
                 if (lmVersionId.startsWith("18")) {
                     // Linux Mint 18 is binary compatible with Ubuntu 16.04
                     return Platform.Ubuntu16;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,25 +20,29 @@ export enum Platform {
     Ubuntu16
 }
 
-function getValue(name: string, lines: string[]) {
+function convertOSReleaseTextToMap(text : string) : Map<string, string> {
+    let ret: Map<string, string> = new Map<string, string>();
+    const lines: string[] = text.split('\n');
+
     for (let line of lines) {
         line = line.trim();
-        if (line.startsWith(name)) {
-            const equalsIndex = line.indexOf('=');
-            if (equalsIndex >= 0) {
-                let value = line.substring(equalsIndex + 1);
 
-                // Strip double quotes if necessary
-                if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-                    value = value.substring(1, value.length - 1);
-                }
+        let equalsIndex = line.indexOf('=');
+        let key = line.substring(0, equalsIndex);
 
-                return value;
+        if (equalsIndex >= 0) {
+            let value = line.substring(equalsIndex + 1);
+
+            // Strip double quotes if necessary
+            if (value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+                value = value.substring(1, value.length - 1);
             }
+
+            ret.set(key, value);
         }
     }
 
-    return undefined;
+    return ret;
 }
 
 
@@ -54,14 +58,14 @@ export function getCurrentPlatform() {
         // For details: https://www.freedesktop.org/software/systemd/man/os-release.html
         // When any new distro or version is added, please update GetClrDbg.sh in MIEngine or inform the contributers of MIEngine.
         const text = child_process.execSync('cat /etc/os-release').toString();
-        const lines = text.split('\n');
+        const osReleaseMap = convertOSReleaseTextToMap(text);
 
-        const id = getValue("ID", lines);
+        const id = osReleaseMap.get("ID");
 
         switch (id)
         {
             case 'ubuntu':
-                const versionId = getValue("VERSION_ID", lines);
+                const versionId = osReleaseMap.get("VERSION_ID");
                 if (versionId.startsWith("14")) {
                     // This also works for Linux Mint
                     return Platform.Ubuntu14;
@@ -85,7 +89,7 @@ export function getCurrentPlatform() {
                 // Oracle Linux is binary compatible with CentOS
                 return Platform.CentOS;
             case 'elementary OS':
-                const eOSVersionId = getValue("VERSION_ID", lines);
+                const eOSVersionId = osReleaseMap.get("VERSION_ID");
                 if (eOSVersionId.startsWith("0.3")) {
                     // Elementary OS 0.3 Freya is binary compatible with Ubuntu 14.04
                     return Platform.Ubuntu14;
@@ -97,7 +101,7 @@ export function getCurrentPlatform() {
 
                 break;
             case 'linuxmint':
-                const lmVersionId = getValue("VERSION_ID", lines);
+                const lmVersionId = osReleaseMap.get("VERSION_ID");
                 if (lmVersionId.startsWith("18")) {
                     // Linux Mint 18 is binary compatible with Ubuntu 16.04
                     return Platform.Ubuntu16;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -28,9 +28,8 @@ function convertOSReleaseTextToMap(text : string) : Map<string, string> {
         line = line.trim();
 
         let equalsIndex = line.indexOf('=');
-        let key = line.substring(0, equalsIndex);
-
         if (equalsIndex >= 0) {
+            let key = line.substring(0, equalsIndex);
             let value = line.substring(equalsIndex + 1);
 
             // Strip double quotes if necessary


### PR DESCRIPTION
I am getting an error message when I run `tsc` after` npm i`.

**Error Message:**
> src/platform.ts(37,18): error TS1252: Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'. Modules are automatically in strict mode.

**Fix:**
Moved the getValue function within getCurrentPlatform function outside
of function scope. Added string array parameter to getValue function
because lines was originally a local variable within the getCurrentPlatform function.

**Versions:**
tsc version: 2.0.3 (installed via `npm install -g typescript`, also tried 1.5.3 but there are more errors)
npm version: 3.10.3
node version: 6.7.0
Windows version: Windows 10 Enterprise 