### PR TITLE
Update to OmniSharp v1.9-beta18

### DIFF
--- a/src/omnisharp/download.ts
+++ b/src/omnisharp/download.ts
@@ -24,7 +24,7 @@ import {Logger} from './logger';
 const decompress = require('decompress');
 
 const BaseDownloadUrl = 'https://omnisharpdownload.blob.core.windows.net/ext';
-const OmniSharpVersion = '1.9-beta16';
+const OmniSharpVersion = '1.9-beta18';
 
 tmp.setGracefulCleanup();
 


### PR DESCRIPTION
Fixes #775, #761, #773 

The latest release of OmniSharp is built as a NETCore.App 1.0.1, which should contain the CoreCLR fix for Linux kernal >= 4.6.2