### PR TITLE
Show full URL for downloading file.

### DIFF
--- a/src/omnisharp/download.ts
+++ b/src/omnisharp/download.ts
@@ -119,7 +119,7 @@ export function go(flavor: Flavor, platform: Platform, logger: Logger, proxy?: s
 
         const urlString = `${BaseDownloadUrl}/${fileName}`;
 
-        logger.appendLine(`Attempting to download ${fileName}`);
+        logger.appendLine(`Attempting to download ${urlString}`);
 
         return download(urlString, proxy, strictSSL)
             .then(inStream => {


### PR DESCRIPTION
When using corporate proxy then extension fails to download files inside. In Visual Studio Code into Output we can see file name only and extension hangs. To help investigation what file to download manually and finish extension init we need to know full url which we should download from. This commit shows full url only. 