### PR TITLE
Add csharp.suppressDotnetRestoreNotification setting to allow the 'dotnet restore' notifications to be supressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,11 @@
           "default": false,
           "description": "Suppress the warning that the .NET CLI is not on the path."
         },
+        "csharp.suppressDotnetRestoreNotification": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress the notification window to perform a 'dotnet restore' when dependencies can't be resolved."
+        },
         "omnisharp.path": {
           "type": [
             "string",

--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -243,14 +243,16 @@ export function reportServerStatus(server: OmnisharpServer): vscode.Disposable{
     });
 
     let d3 = server.onUnresolvedDependencies(message => {
+        let csharpConfig = vscode.workspace.getConfiguration('csharp');
+        if (!csharpConfig.get<boolean>('suppressDotnetRestoreNotification')) {
+            let info = `There are unresolved dependencies from '${vscode.workspace.asRelativePath(message.FileName) }'. Please execute the restore command to continue.`;
 
-        let info = `There are unresolved dependencies from '${vscode.workspace.asRelativePath(message.FileName) }'. Please execute the restore command to continue.`;
-
-        return vscode.window.showInformationMessage(info, 'Restore').then(value => {
-            if (value) {
-                dotnetRestoreForProject(server, message.FileName);
-            }
-        });
+            return vscode.window.showInformationMessage(info, 'Restore').then(value => {
+                if (value) {
+                    dotnetRestoreForProject(server, message.FileName);
+                }
+            });
+        }
     });
 
     return vscode.Disposable.from(d0, d1, d2, d3);


### PR DESCRIPTION
Fixes #193
Fixes #257
Fixes #845

cc @shaunluttin, @GuardRex