### PR TITLE
Add a setting to configure the server load timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,6 +259,11 @@
           "type": "boolean",
           "default": true,
           "description": "Specifies whether the OmniSharp server will be automatically started or not. If false, OmniSharp can be started with the 'Restart OmniSharp' command"
+        },
+        "omnisharp.projectLoadTimeout": {
+          "type": "number",
+          "default": 60,
+          "description": "The time Visual Studio Code will wait for the OmniSharp server to start. Time is expressed in seconds."
         }
       }
     },

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -10,7 +10,8 @@ export class Options {
         public path?: string,
         public useMono?: boolean,
         public loggingLevel?: string,
-        public autoStart?: boolean) { }
+        public autoStart?: boolean,
+        public projectLoadTimeout?: number) { }
 
     public static Read(): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -33,6 +34,8 @@ export class Options {
         const loggingLevel = omnisharpConfig.get<string>('loggingLevel');
         const autoStart = omnisharpConfig.get<boolean>('autoStart', true);
 
-        return new Options(path, useMono, loggingLevel, autoStart);
+        const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
+
+        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout);
     }
 }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -534,7 +534,7 @@ export class StdioOmnisharpServer extends OmnisharpServer {
         const p = new Promise<void>((resolve, reject) => {
             let listener: vscode.Disposable;
 
-            // Convert the timeout from the seconds to microseconds, which is required by setTimeout().
+            // Convert the timeout from the seconds to milliseconds, which is required by setTimeout().
             const timeoutDuration = this._options.projectLoadTimeout * 1000
 
             // timeout logic

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -543,7 +543,7 @@ export class StdioOmnisharpServer extends OmnisharpServer {
                     listener.dispose();
                 }
 
-                reject(new Error('Failed to start OmniSharp'));
+                reject(new Error("OmniSharp server load timed out. Use the 'omnisharp.projectLoadTimeout' setting to override the default delay (one minute)."));
             }, timeoutDuration);
 
             // handle started-event


### PR DESCRIPTION
Does just what it says on the tin. Tested it with a moderately-large solution of mine that times out under the default one-minute interval. After I set `omnisharp.projectLoadTimeout` in my workspace settings file (to a value of 600 seconds), the solution loads fully, without encountering a timeout error.

Fixes #244.