### PR TITLE
Run OmniSharp on an embedded Mono runtime and add support for MSBuild-based .NET Core projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     {
       "description": "Mono Runtime (Linux / x86)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-4.6.1.zip",
+      "installPath": "./bin",
       "platforms": [
         "linux"
       ],
@@ -62,12 +63,14 @@
         "x86"
       ],
       "binaries": [
-        "./bin/mono.linux-x86"
+        "./mono.linux-x86",
+        "./run"
       ]
     },
     {
       "description": "Mono Runtime (Linux / x64)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-4.6.1.zip",
+      "installPath": "./bin",
       "platforms": [
         "linux"
       ],
@@ -75,23 +78,26 @@
         "x86_64"
       ],
       "binaries": [
-        "./bin/mono.linux-x86_64"
+        "./mono.linux-x86_64",
+        "./run"
       ]
     },
     {
       "description": "Mono Runtime (macOS)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-4.6.1.zip",
+      "installPath": "./bin",
       "platforms": [
         "darwin"
       ],
       "binaries": [
-        "./bin/mono.osx"
+        "./mono.osx",
+        "./run"
       ]
     },
     {
       "description": "Mono Framework Assemblies",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/framework-4.6.1.zip",
-      "installPath": "./bin",
+      "installPath": "./bin/framework",
       "platforms": [
         "darwin",
         "linux"
@@ -99,42 +105,35 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x86-1.9-beta19.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.9-beta19.zip",
+      "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86",
         "32-bit"
-      ],
-      "binaries": [
-        "./bin/run"
       ]
     },
     {
       "description": "OmniSharp (.NET 4.6 / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x64-1.9-beta19.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.9-beta19.zip",
+      "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86_64",
         "64-bit"
-      ],
-      "binaries": [
-        "./bin/run"
       ]
     },
     {
-      "description": "OmniSharp (Mono)",
+      "description": "OmniSharp (Mono 4.6)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.9-beta19.zip",
-      "installPath": "./bin",
+      "installPath": "./bin/omnisharp",
       "platforms": [
         "darwin",
         "linux"
-      ],
-      "binaries": [
-        "./run"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -53,142 +53,79 @@
   },
   "runtimeDependencies": [
     {
-      "description": "OmniSharp (Windows / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-win-x86-net46.zip",
-      "installPath": ".omnisharp-desktop",
-      "runtimeIds": [
-        "win7-x86"
-      ]
-    },
-    {
-      "description": "OmniSharp (Windows / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-win-x64-net46.zip",
-      "installPath": ".omnisharp-desktop",
-      "runtimeIds": [
-        "win7-x64"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Windows / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-win-x86-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "win7-x86"
+      "description": "Mono Runtime (Linux / x86)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-4.6.1.zip",
+      "platforms": [
+        "linux"
       ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Windows / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-win-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "win7-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - macOS / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-osx-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "osx.10.11-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - CentOS / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-centos-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "centos.7-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Debian / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-debian-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "debian.8-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Fedora / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-fedora-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "fedora.23-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - OpenSUSE / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-opensuse-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "opensuse.13.2-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - RHEL / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-rhel-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "rhel.7-x64"
-      ],
-      "binaries": [
-        "./.OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Ubuntu 14 / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-ubuntu14-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "ubuntu.14.04-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (.NET Core - Ubuntu 16 / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-ubuntu16-x64-netcoreapp1.0.zip",
-      "installPath": ".omnisharp-coreclr",
-      "runtimeIds": [
-        "ubuntu.16.04-x64"
-      ],
-      "binaries": [
-        "./OmniSharp"
-      ]
-    },
-    {
-      "description": "OmniSharp (Mono)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-1.9-beta19-mono.zip",
-      "installPath": ".omnisharp-mono",
       "architectures": [
-        "x86",
+        "x86"
+      ],
+      "binaries": [
+        "./bin/mono.linux-x86"
+      ]
+    },
+    {
+      "description": "Mono Runtime (Linux / x64)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-4.6.1.zip",
+      "platforms": [
+        "linux"
+      ],
+      "architectures": [
         "x86_64"
       ],
+      "binaries": [
+        "./bin/mono.linux-x86_64"
+      ]
+    },
+    {
+      "description": "Mono Runtime (macOS)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-4.6.1.zip",
+      "platforms": [
+        "darwin"
+      ],
+      "binaries": [
+        "./bin/mono.osx"
+      ]
+    },
+    {
+      "description": "Mono Framework Assemblies",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/framework-4.6.1.zip",
       "platforms": [
         "darwin",
         "linux"
+      ]
+    },
+    {
+      "description": "OmniSharp (.NET 4.6 / x86)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x86-1.9-beta19.zip",
+      "platforms": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "architectures": [
+        "x86",
+        "32-bit"
+      ],
+      "binaries": [
+        "./bin/run"
+      ]
+    },
+    {
+      "description": "OmniSharp (.NET 4.6 / x64)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x64-1.9-beta19.zip",
+      "platforms": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "architectures": [
+        "x86_64",
+        "64-bit"
+      ],
+      "binaries": [
+        "./bin/run"
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     {
       "description": "Mono Framework Assemblies",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/framework-4.6.1.zip",
+      "installPath": "./bin",
       "platforms": [
         "darwin",
         "linux"
@@ -100,8 +101,6 @@
       "description": "OmniSharp (.NET 4.6 / x86)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x86-1.9-beta19.zip",
       "platforms": [
-        "darwin",
-        "linux",
         "win32"
       ],
       "architectures": [
@@ -116,8 +115,6 @@
       "description": "OmniSharp (.NET 4.6 / x64)",
       "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-x64-1.9-beta19.zip",
       "platforms": [
-        "darwin",
-        "linux",
         "win32"
       ],
       "architectures": [
@@ -126,6 +123,18 @@
       ],
       "binaries": [
         "./bin/run"
+      ]
+    },
+    {
+      "description": "OmniSharp (Mono)",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.9-beta19.zip",
+      "installPath": "./bin",
+      "platforms": [
+        "darwin",
+        "linux"
+      ],
+      "binaries": [
+        "./run"
       ]
     },
     {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -169,12 +169,7 @@ function launch(cwd: string, args: string[]): Promise<LaunchResult> {
             return launchWindows(launchPath, cwd, args);
         }
         else {
-            if (kind === LaunchTargetKind.Solution) {
-                return launchNixMono(launchPath, cwd, args);
-            }
-            else {
-                return launchNix(launchPath, cwd, args);
-            }
+            return launchNix(launchPath, cwd, args);
         }
     });
 }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -257,7 +257,7 @@ export abstract class OmnisharpServer {
 
         this._fireEvent(Events.BeforeServerStart, solutionPath);
 
-        return launchOmniSharp(cwd, args, launchTarget.kind).then(value => {
+        return launchOmniSharp(cwd, args).then(value => {
             if (value.usingMono) {
                 this._logger.appendLine(`OmniSharp server started wth Mono`);
             }


### PR DESCRIPTION
This change does not really do justice to the update since most of the churn is in the packages that are downloaded. Essentially, this switches the C# extension over to using an embedded Mono runtime and framework to run OmniSharp on. It also moves OmniSharp over to the latest MSBuild 15.0 bits which enable MSBuild-based .NET Core projects.

Fixes #881