### PR TITLE
Allow multiple simultaneous requests to be sent to OmniSharp server

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs-extra-promise';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as tasks from 'vscode-tasks';
-import {OmnisharpServer} from './omnisharp/server';
+import {OmniSharpServer} from './omnisharp/server';
 import * as serverUtils from './omnisharp/utils';
 import * as protocol from './omnisharp/protocol';
 
@@ -393,7 +393,7 @@ export enum AddAssetResult {
     Cancelled
 }
 
-export function addAssetsIfNecessary(server: OmnisharpServer): Promise<AddAssetResult> {
+export function addAssetsIfNecessary(server: OmniSharpServer): Promise<AddAssetResult> {
     return new Promise<AddAssetResult>((resolve, reject) => {
         if (!vscode.workspace.rootPath) {
             return resolve(AddAssetResult.NotApplicable);
@@ -492,7 +492,7 @@ function shouldGenerateAssets(paths: Paths) {
     });
 }
 
-export function generateAssets(server: OmnisharpServer) {
+export function generateAssets(server: OmniSharpServer) {
     serverUtils.requestWorkspaceInformation(server).then(info => {
         if (info.DotNet && info.DotNet.Projects.length > 0) {
             getOperations().then(operations => {

--- a/src/features/abstractProvider.ts
+++ b/src/features/abstractProvider.ts
@@ -5,15 +5,15 @@
 
 'use strict';
 
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import {Disposable} from 'vscode';
 
 export default class AbstractProvider {
 
-    protected _server: OmnisharpServer;
+    protected _server: OmniSharpServer;
     protected _disposables: Disposable[];
 
-    constructor(server: OmnisharpServer) {
+    constructor(server: OmniSharpServer) {
         this._server = server;
         this._disposables = [];
     }

--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -6,10 +6,10 @@
 'use strict';
 
 import {Disposable, Uri, workspace} from 'vscode';
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
 
-function forwardDocumentChanges(server: OmnisharpServer): Disposable {
+function forwardDocumentChanges(server: OmniSharpServer): Disposable {
 
     return workspace.onDidChangeTextDocument(event => {
 
@@ -29,7 +29,7 @@ function forwardDocumentChanges(server: OmnisharpServer): Disposable {
     });
 }
 
-function forwardFileChanges(server: OmnisharpServer): Disposable {
+function forwardFileChanges(server: OmniSharpServer): Disposable {
 
     function onFileSystemEvent(uri: Uri): void {
         if (!server.isRunning()) {
@@ -52,7 +52,7 @@ function forwardFileChanges(server: OmnisharpServer): Disposable {
     return Disposable.from(watcher, d1, d2, d3);
 }
 
-export default function forwardChanges(server: OmnisharpServer): Disposable {
+export default function forwardChanges(server: OmniSharpServer): Disposable {
 
     // combine file watching and text document watching
     return Disposable.from(

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import {CodeActionProvider, CodeActionContext, Command, CancellationToken, TextDocument, WorkspaceEdit, TextEdit, Range, Uri, workspace, commands} from 'vscode';
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import AbstractProvider from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import {toRange2} from '../omnisharp/typeConvertion';
@@ -17,7 +17,7 @@ export default class OmnisharpCodeActionProvider extends AbstractProvider implem
     private _disabled: boolean;
     private _commandId: string;
 
-    constructor(server: OmnisharpServer) {
+    constructor(server: OmniSharpServer) {
         super(server);
         this._commandId = 'omnisharp.runCodeAction';
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
 import {findLaunchTargets} from '../omnisharp/launcher';
 import * as cp from 'child_process';
@@ -19,7 +19,7 @@ import {generateAssets} from '../assets';
 
 let channel = vscode.window.createOutputChannel('.NET');
 
-export default function registerCommands(server: OmnisharpServer, extensionPath: string) {
+export default function registerCommands(server: OmniSharpServer, extensionPath: string) {
     let d1 = vscode.commands.registerCommand('o.restart', () => restartOmniSharp(server));
     let d2 = vscode.commands.registerCommand('o.pickProjectAndStart', () => pickProjectAndStart(server));
     let d3 = vscode.commands.registerCommand('o.showOutput', () => server.getChannel().show(vscode.ViewColumn.Three));
@@ -44,7 +44,7 @@ export default function registerCommands(server: OmnisharpServer, extensionPath:
     return vscode.Disposable.from(d1, d2, d3, d4, d5, d6, d7, d8, d9);
 }
 
-function restartOmniSharp(server: OmnisharpServer) {
+function restartOmniSharp(server: OmniSharpServer) {
     if (server.isRunning()) {
         server.restart();
     }
@@ -53,7 +53,7 @@ function restartOmniSharp(server: OmnisharpServer) {
     }
 }
 
-function pickProjectAndStart(server: OmnisharpServer) {
+function pickProjectAndStart(server: OmniSharpServer) {
 
     return findLaunchTargets().then(targets => {
 
@@ -103,7 +103,7 @@ function projectsToCommands(projects: protocol.DotNetProject[]): Promise<Command
     });
 }
 
-export function dotnetRestoreAllProjects(server: OmnisharpServer) {
+export function dotnetRestoreAllProjects(server: OmniSharpServer) {
 
     if (!server.isRunning()) {
         return Promise.reject('OmniSharp server is not running.');
@@ -127,7 +127,7 @@ export function dotnetRestoreAllProjects(server: OmnisharpServer) {
     });
 }
 
-export function dotnetRestoreForProject(server: OmnisharpServer, fileName: string) {
+export function dotnetRestoreForProject(server: OmniSharpServer, fileName: string) {
 
     if (!server.isRunning()) {
         return Promise.reject('OmniSharp server is not running.');

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import AbstractSupport from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
@@ -15,11 +15,11 @@ import {Disposable, Uri, CancellationTokenSource, TextDocument, Diagnostic, Diag
 export class Advisor {
 
     private _disposable: Disposable;
-    private _server: OmnisharpServer;
+    private _server: OmniSharpServer;
     private _packageRestoreCounter: number = 0;
     private _projectSourceFileCounts: { [path: string]: number } = Object.create(null);
 
-    constructor(server: OmnisharpServer) {
+    constructor(server: OmniSharpServer) {
         this._server = server;
 
         let d1 = server.onProjectChange(this._onProjectChange, this);
@@ -112,7 +112,7 @@ export class Advisor {
     }
 }
 
-export default function reportDiagnostics(server: OmnisharpServer, advisor: Advisor): Disposable {
+export default function reportDiagnostics(server: OmniSharpServer, advisor: Advisor): Disposable {
     return new DiagnosticsProvider(server, advisor);
 }
 
@@ -124,7 +124,7 @@ class DiagnosticsProvider extends AbstractSupport {
     private _projectValidation: CancellationTokenSource;
     private _diagnostics: DiagnosticCollection;
 
-    constructor(server: OmnisharpServer, validationAdvisor: Advisor) {
+    constructor(server: OmniSharpServer, validationAdvisor: Advisor) {
         super(server);
         this._validationAdvisor = validationAdvisor;
         this._diagnostics = languages.createDiagnosticCollection('csharp');

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import {toRange} from '../omnisharp/typeConvertion';
 import * as vscode from 'vscode';
 import * as serverUtils from "../omnisharp/utils";
@@ -21,20 +21,20 @@ function getTestOutputChannel(): vscode.OutputChannel {
     return _testOutputChannel;
 }
 
-export function registerDotNetTestRunCommand(server: OmnisharpServer): vscode.Disposable {
+export function registerDotNetTestRunCommand(server: OmniSharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.run',
         (testMethod, fileName) => runDotnetTest(testMethod, fileName, server));
 }
 
-export function registerDotNetTestDebugCommand(server: OmnisharpServer): vscode.Disposable {
+export function registerDotNetTestDebugCommand(server: OmniSharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.debug',
         (testMethod, fileName) => debugDotnetTest(testMethod, fileName, server));
 }
 
 // Run test through dotnet-test command. This function can be moved to a separate structure
-export function runDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+export function runDotnetTest(testMethod: string, fileName: string, server: OmniSharpServer) {
     getTestOutputChannel().show();
     getTestOutputChannel().appendLine('Running test ' + testMethod + '...');
     serverUtils
@@ -54,7 +54,7 @@ export function runDotnetTest(testMethod: string, fileName: string, server: Omni
 }
 
 // Run test through dotnet-test command with debugger attached
-export function debugDotnetTest(testMethod: string, fileName: string, server: OmnisharpServer) {
+export function debugDotnetTest(testMethod: string, fileName: string, server: OmniSharpServer) {
     serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod }).then(response => {
         vscode.commands.executeCommand(
             'vscode.startDebug', {

--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import {OmnisharpServer} from '../omnisharp/server';
+import {OmniSharpServer} from '../omnisharp/server';
 import {dotnetRestoreForProject} from './commands';
 import {basename} from 'path';
 import * as protocol from '../omnisharp/protocol';
@@ -13,7 +13,7 @@ import * as serverUtils from '../omnisharp/utils';
 
 const debounce = require('lodash.debounce');
 
-export default function reportStatus(server: OmnisharpServer) {
+export default function reportStatus(server: OmniSharpServer) {
     return vscode.Disposable.from(
         reportServerStatus(server),
         forwardOutput(server),
@@ -41,7 +41,7 @@ class Status {
     }
 }
 
-export function reportDocumentStatus(server: OmnisharpServer): vscode.Disposable {
+export function reportDocumentStatus(server: OmniSharpServer): vscode.Disposable {
 
     let disposables: vscode.Disposable[] = [];
     let localDisposables: vscode.Disposable[];
@@ -202,7 +202,7 @@ export function reportDocumentStatus(server: OmnisharpServer): vscode.Disposable
 
 // ---- server status
 
-export function reportServerStatus(server: OmnisharpServer): vscode.Disposable{
+export function reportServerStatus(server: OmniSharpServer): vscode.Disposable{
 
     function appendLine(value: string = '') {
         server.getChannel().appendLine(value);
@@ -275,7 +275,7 @@ function showMessageSoon() {
 
 // --- mirror output in channel
 
-function forwardOutput(server: OmnisharpServer) {
+function forwardOutput(server: OmniSharpServer) {
 
     const logChannel = server.getChannel();
     const timing200Pattern = /^\[INFORMATION:OmniSharp.Middleware.LoggingMiddleware\] \/\w+: 200 \d+ms/;

--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -278,17 +278,11 @@ function showMessageSoon() {
 function forwardOutput(server: OmniSharpServer) {
 
     const logChannel = server.getChannel();
-    const timing200Pattern = /^\[INFORMATION:OmniSharp.Middleware.LoggingMiddleware\] \/\w+: 200 \d+ms/;
 
     function forward(message: string) {
-        // strip stuff like: /codecheck: 200 339ms
-        if(!timing200Pattern.test(message)) {
-            logChannel.append(message);
-        }
+        logChannel.append(message);
     }
 
     return vscode.Disposable.from(
-        server.onStdout(forward),
         server.onStderr(forward));
 }
-

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -23,7 +23,7 @@ import SignatureHelpProvider from '../features/signatureHelpProvider';
 import registerCommands from '../features/commands';
 import forwardChanges from '../features/changeForwarding';
 import reportStatus from '../features/status';
-import {OmnisharpServer} from './server';
+import {OmniSharpServer} from './server';
 import {Options} from './options';
 import {addAssetsIfNecessary, AddAssetResult} from '../assets';
 
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
         scheme: 'file' // only files from disk
     };
 
-    const server = new OmnisharpServer(reporter);
+    const server = new OmniSharpServer(reporter);
     const advisor = new Advisor(server); // create before server is started
     const disposables: vscode.Disposable[] = [];
     const localDisposables: vscode.Disposable[] = [];

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -23,7 +23,7 @@ import SignatureHelpProvider from '../features/signatureHelpProvider';
 import registerCommands from '../features/commands';
 import forwardChanges from '../features/changeForwarding';
 import reportStatus from '../features/status';
-import {StdioOmnisharpServer} from './server';
+import {OmnisharpServer} from './server';
 import {Options} from './options';
 import {addAssetsIfNecessary, AddAssetResult} from '../assets';
 
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
         scheme: 'file' // only files from disk
     };
 
-    const server = new StdioOmnisharpServer(reporter);
+    const server = new OmnisharpServer(reporter);
     const advisor = new Advisor(server); // create before server is started
     const disposables: vscode.Disposable[] = [];
     const localDisposables: vscode.Disposable[] = [];

--- a/src/omnisharp/prioritization.ts
+++ b/src/omnisharp/prioritization.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as protocol from './protocol';
+
+const priorityCommands = [
+    protocol.Requests.ChangeBuffer,
+    protocol.Requests.FormatAfterKeystroke,
+    protocol.Requests.FormatRange,
+    protocol.Requests.UpdateBuffer
+];
+
+const normalCommands = [
+    protocol.Requests.AutoComplete,
+    protocol.Requests.FilesChanged,
+    protocol.Requests.FindSymbols,
+    protocol.Requests.FindUsages,
+    protocol.Requests.GetCodeActions,
+    protocol.Requests.GoToDefinition,
+    protocol.Requests.RunCodeAction,
+    protocol.Requests.SignatureHelp,
+    protocol.Requests.TypeLookup
+];
+
+const prioritySet = new Set<string>(priorityCommands);
+const normalSet = new Set<string>(normalCommands);
+const deferredSet = new Set<string>();
+
+const nonDeferredSet = new Set<string>();
+
+for (let command of priorityCommands) {
+    nonDeferredSet.add(command);
+}
+
+for (let command of normalCommands) {
+    nonDeferredSet.add(command);
+}
+
+export function isPriorityCommand(command: string) {
+    return prioritySet.has(command);
+}
+
+export function isNormalCommand(command: string) {
+    return normalSet.has(command);
+}
+
+export function isDeferredCommand(command: string) {
+    if (deferredSet.has(command)) {
+        return true;
+    }
+
+    if (nonDeferredSet.has(command)) {
+        return false;
+    }
+
+    deferredSet.add(command);
+    return true;
+}

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -29,6 +29,32 @@ export module Requests {
     export const Metadata = '/metadata';
 }
 
+export namespace WireProtocol {
+    export interface Packet {
+        Type: string;
+        Seq: number;
+    }
+
+    export interface RequestPacket extends Packet {
+        Command: string;
+        Arguments: any;
+    }
+
+    export interface ResponsePacket extends Packet {
+        Command: string;
+        Request_seq: number;
+        Running: boolean;
+        Success: boolean;
+        Message: string;
+        Body: any;
+    }
+
+    export interface EventPacket extends Packet {
+        Event: string;
+        Body: any;
+    }
+}
+
 export interface Request {
     Filename: string;
     Line?: number;

--- a/src/omnisharp/queue.ts
+++ b/src/omnisharp/queue.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Logger } from '../logger';
+import * as protocol from './protocol';
+import * as prioritization from './prioritization';
+
+interface Request {
+    path: string;
+    data?: any;
+    onSuccess(value: any): void;
+    onError(err: any): void;
+}
+
+class RequestQueue {
+    private _pending: Request[] = [];
+    private _requests: Map<number, protocol.WireProtocol.RequestPacket> = new Map<number, protocol.WireProtocol.RequestPacket>();
+
+    public constructor(
+        private _maxSize: number,
+        private _logger: Logger,
+        private _makeRequest: (request: Request) => protocol.WireProtocol.RequestPacket) {
+    }
+
+    public enqueue(request: Request) {
+        this._pending.push(request);
+    }
+
+    public remove(command: string, seq: number) {
+        if (!this._requests.delete(seq)) {
+            this._logger.appendLine(`Received response for ${command} but could not find request.`);
+        }
+    }
+
+    public hasPending() {
+        return this._pending.length === 0;
+    }
+
+    public isFull() {
+        return this._requests.size >= this._maxSize;
+    }
+
+    public drain() {
+        let i = 0;
+        const slots = this._maxSize - this._requests.size;
+
+        do {
+            const item = this._pending.shift();
+            const request = this._makeRequest(item);
+            this._requests.set(request.Seq, request);
+
+            if (this.isFull()) {
+                return;
+            }
+        }
+        while (this._pending.length > 0 && ++i < slots)
+    }
+}
+
+export class Queue {
+    private _isProcessing: boolean;
+    private _priorityQueue: RequestQueue;
+    private _normalQueue: RequestQueue;
+    private _deferredQueue: RequestQueue;
+
+    public constructor(
+        logger: Logger,
+        concurrency: number,
+        makeRequest: (request: Request) => protocol.WireProtocol.RequestPacket
+    ) {
+        this._priorityQueue = new RequestQueue(1, logger, makeRequest);
+        this._normalQueue = new RequestQueue(concurrency, logger, makeRequest);
+        this._deferredQueue = new RequestQueue(Math.max(Math.floor(concurrency / 4), 2), logger, makeRequest);
+    }
+
+    private getQueue(command: string) {
+        if (prioritization.isPriorityCommand(command)) {
+            return this._priorityQueue;
+        }
+        else if (prioritization.isNormalCommand(command)) {
+            return this._normalQueue;
+        }
+        else {
+            return this._deferredQueue;
+        }
+    }
+
+    public enqueue(request: Request) {
+        const queue = this.getQueue(request.path);
+        queue.enqueue(request);
+
+        this.drain();
+    }
+
+    public remove(command: string, seq: number) {
+        const queue = this.getQueue(command);
+        queue.remove(command, seq);
+    }
+
+    private drain() {
+        if (this._isProcessing) {
+            return false;
+        }
+
+        if (this._priorityQueue.isFull()) {
+            return false;
+        }
+
+        if (this._normalQueue.isFull() && this._deferredQueue.isFull()) {
+            return false;
+        }
+
+        if (this._priorityQueue.hasPending()) {
+            this._priorityQueue.drain();
+            this._isProcessing = false;
+            return;
+        }
+
+        if (this._normalQueue.hasPending()) {
+            this._normalQueue.drain();
+        }
+
+        if (this._deferredQueue.hasPending()) {
+            this._deferredQueue.drain();
+        }
+
+        this._isProcessing = false;
+    }
+}

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -35,7 +35,7 @@ class RequestQueue {
      * Enqueue a new request.
      */
     public enqueue(request: Request) {
-        this._logger.appendLine(`Enqueue request for ${request.command}.`);
+        this._logger.appendLine(`Enqueue ${this._name} request for ${request.command}.`);
         this._pending.push(request);
     }
 
@@ -47,7 +47,7 @@ class RequestQueue {
 
         if (request) {
             this._waiting.delete(id);
-            this._logger.appendLine(`Dequeue request for ${request.command}.`);
+            this._logger.appendLine(`Dequeue ${this._name} request for ${request.command} (${id}).`);
         }
 
         return request;
@@ -87,6 +87,9 @@ class RequestQueue {
             return;
         }
 
+        this._logger.appendLine(`Processing ${this._name} queue`);
+        this._logger.increaseIndent();
+
         const slots = this._maxSize - this._waiting.size;
 
         for (let i = 0; i < slots && this._pending.length > 0; i++) {
@@ -97,9 +100,11 @@ class RequestQueue {
             this._waiting.set(id, item);
 
             if (this.isFull()) {
-                return;
+                break;
             }
         }
+
+        this._logger.decreaseIndent();
     }
 }
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -15,6 +15,7 @@ import {Options} from './options';
 import {Logger} from '../logger';
 import {DelayTracker} from './delayTracker';
 import {LaunchTarget, findLaunchTargets} from './launcher';
+import { Queue } from './queue';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import * as vscode from 'vscode';
 
@@ -25,11 +26,10 @@ enum ServerState {
 }
 
 interface Request {
-    path: string;
+    command: string;
     data?: any;
     onSuccess(value: any): void;
     onError(err: any): void;
-    _enqueued: number;
 }
 
 module Events {
@@ -69,8 +69,7 @@ export class OmniSharpServer {
     private static StartupTimeout = 1000 * 60;
 
     private _readLine: ReadLine;
-    private _activeRequests: { [seq: number]: { onSuccess: Function; onError: Function; } } = Object.create(null);
-    private _callOnStop: Function[] = [];
+    private _disposables: vscode.Disposable[] = [];
 
     private _reporter: TelemetryReporter;
     private _delayTrackers: { [requestName: string]: DelayTracker };
@@ -79,8 +78,7 @@ export class OmniSharpServer {
     private _eventBus = new EventEmitter();
     private _state: ServerState = ServerState.Stopped;
     private _launchTarget: LaunchTarget;
-    private _queue: Request[] = [];
-    private _isProcessingQueue = false;
+    private _requestQueue: Queue;
     private _channel: vscode.OutputChannel;
     private _logger: Logger;
 
@@ -94,6 +92,7 @@ export class OmniSharpServer {
 
         this._channel = vscode.window.createOutputChannel('OmniSharp Log');
         this._logger = new Logger(message => this._channel.append(message));
+        this._requestQueue = new Queue(this._logger, 8, request => this._makeRequest(request));
     }
 
     public isRunning(): boolean {
@@ -291,7 +290,7 @@ export class OmniSharpServer {
             // Start telemetry reporting
             this._telemetryIntervalId = setInterval(() => this._reportTelemetry(), TelemetryReportingDelay);
         }).then(() => {
-            this._processQueue();
+            this._requestQueue.drain();
         }).catch(err => {
             this._fireEvent(Events.ServerError, err);
             return this.stop();
@@ -300,9 +299,8 @@ export class OmniSharpServer {
 
     public stop(): Promise<void> {
 
-        while (this._callOnStop.length) {
-            let methodToCall = this._callOnStop.pop();
-            methodToCall();
+        while (this._disposables.length) {
+            this._disposables.pop().dispose();
         }
 
         let cleanupPromise: Promise<void>;
@@ -399,13 +397,13 @@ export class OmniSharpServer {
 
     // --- requests et al
 
-    public makeRequest<TResponse>(path: string, data?: any, token?: vscode.CancellationToken): Promise<TResponse> {
+    public makeRequest<TResponse>(command: string, data?: any, token?: vscode.CancellationToken): Promise<TResponse> {
 
         if (this._getState() !== ServerState.Started) {
             return Promise.reject<TResponse>('server has been stopped or not started');
         }
 
-        console.log(`makeRequest: path=${path}`);
+        console.log(`makeRequest: command=${command}`);
 
         let startTime: number;
         let request: Request;
@@ -414,62 +412,31 @@ export class OmniSharpServer {
             startTime = Date.now();
 
             request = {
-                path,
+                command,
                 data,
                 onSuccess: value => resolve(value),
-                onError: err => reject(err),
-                _enqueued: Date.now()
+                onError: err => reject(err)
             };
 
-            this._queue.push(request);
+            this._requestQueue.enqueue(request);
 
-            if (this._getState() === ServerState.Started && !this._isProcessingQueue) {
-                this._processQueue();
+            if (this._getState() === ServerState.Started) {
+                this._requestQueue.drain();
             }
         });
 
         if (token) {
             token.onCancellationRequested(() => {
-                let idx = this._queue.indexOf(request);
-                if (idx !== -1) {
-                    this._queue.splice(idx, 1);
-                    let err = new Error('Canceled');
-                    err.message = 'Canceled';
-                    request.onError(err);
-                }
+                this._requestQueue.cancelRequest(request);
             });
         }
 
         return promise.then(response => {
             let endTime = Date.now();
             let elapsedTime = endTime - startTime;
-            this._recordRequestDelay(path, elapsedTime);
+            this._recordRequestDelay(command, elapsedTime);
 
             return response;
-        });
-    }
-
-    private _processQueue(): void {
-        if (this._queue.length === 0) {
-            // nothing to do
-            this._isProcessingQueue = false;
-            return;
-        }
-
-        // signal that we are working on it
-        this._isProcessingQueue = true;
-
-        // send next request and recurse when done
-        const thisRequest = this._queue.shift();
-        this._makeNextRequest(thisRequest.path, thisRequest.data).then(value => {
-            thisRequest.onSuccess(value);
-            this._processQueue();
-        }, err => {
-            thisRequest.onError(err);
-            this._processQueue();
-        }).catch(err => {
-            console.error(err);
-            this._processQueue();
         });
     }
 
@@ -485,7 +452,7 @@ export class OmniSharpServer {
             terminal: false
         });
 
-        const p = new Promise<void>((resolve, reject) => {
+        const promise = new Promise<void>((resolve, reject) => {
             let listener: vscode.Disposable;
 
             // Convert the timeout from the seconds to milliseconds, which is required by setTimeout().
@@ -510,105 +477,90 @@ export class OmniSharpServer {
             });
         });
 
-        this._startListening();
+        const lineReceived = this._onLineReceived.bind(this);
 
-        return p;
+        this._readLine.addListener('line', lineReceived);
+
+        this._disposables.push(new vscode.Disposable(() => {
+            this._readLine.removeListener('line', lineReceived);
+        }));
+
+        return promise;
     }
 
-    private _startListening(): void {
-
-        const onLineReceived = (line: string) => {
-            if (line[0] !== '{') {
-                this._logger.appendLine(line);
-                return;
-            }
-
-            let packet: protocol.WireProtocol.Packet;
-            try {
-                packet = JSON.parse(line);
-            }
-            catch (e) {
-                // not json
-                return;
-            }
-
-            if (!packet.Type) {
-                // bogous packet
-                return;
-            }
-
-            switch (packet.Type) {
-                case 'response':
-                    this._handleResponsePacket(<protocol.WireProtocol.ResponsePacket>packet);
-                    break;
-                case 'event':
-                    this._handleEventPacket(<protocol.WireProtocol.EventPacket>packet);
-                    break;
-                default:
-                    console.warn('unknown packet: ', packet);
-                    break;
-            }
-        };
-
-        this._readLine.addListener('line', onLineReceived);
-        this._callOnStop.push(() => this._readLine.removeListener('line', onLineReceived));
-    }
-
-    private _handleResponsePacket(packet: protocol.WireProtocol.ResponsePacket): void {
-
-        const id = packet.Request_seq;
-        const entry = this._activeRequests[id];
-
-        if (!entry) {
-            console.warn('Received a response WITHOUT a request', packet);
+    private _onLineReceived(line: string) {
+        if (line[0] !== '{') {
+            this._logger.appendLine(line);
             return;
         }
 
-        console.log(`Handling response: ${packet.Command} (${id})`);
+        let packet: protocol.WireProtocol.Packet;
+        try {
+            packet = JSON.parse(line);
+        }
+        catch (err) {
+            // This isn't JSON
+            return;
+        }
 
-        delete this._activeRequests[id];
+        if (!packet.Type) {
+            // Bogus packet
+            return;
+        }
+
+        switch (packet.Type) {
+            case 'response':
+                this._handleResponsePacket(<protocol.WireProtocol.ResponsePacket>packet);
+                break;
+            case 'event':
+                this._handleEventPacket(<protocol.WireProtocol.EventPacket>packet);
+                break;
+            default:
+                console.warn(`Unknown packet type: ${packet.Type}`);
+                break;
+        }
+    }
+
+    private _handleResponsePacket(packet: protocol.WireProtocol.ResponsePacket) {
+        if (!this._requestQueue.dequeue(packet.Command, packet.Request_seq)) {
+            this._logger.appendLine(`Received response for ${packet.Command} but could not find request.`);
+            return;
+        }
 
         if (packet.Success) {
-            entry.onSuccess(packet.Body);
-        } else {
-            entry.onError(packet.Message || packet.Body);
+            // Handle success
+        }
+        else {
+            // Handle failure
         }
     }
 
     private _handleEventPacket(packet: protocol.WireProtocol.EventPacket): void {
-
         if (packet.Event === 'log') {
             // handle log events
             const entry = <{ LogLevel: string; Name: string; Message: string; }>packet.Body;
             this._logger.appendLine(`[${entry.LogLevel}:${entry.Name}] ${entry.Message}`);
-            return;
-        } else {
+        } 
+        else {
             // fwd all other events
             this._fireEvent(packet.Event, packet.Body);
         }
     }
 
-    private _makeNextRequest(path: string, data: any): Promise<any> {
-
+    private _makeRequest(request: Request) {
         const id = OmniSharpServer._nextId++;
 
-        const thisRequestPacket: protocol.WireProtocol.RequestPacket = {
+        const requestPacket: protocol.WireProtocol.RequestPacket = {
             Type: 'request',
             Seq: id,
-            Command: path,
-            Arguments: data
+            Command: request.command,
+            Arguments: request.data
         };
 
-        console.log(`Making request: ${path} (${id})`);
+        console.log(`Making request: ${request.command} (${id})`);
 
-        return new Promise<any>((resolve, reject) => {
+        this._serverProcess.stdin.write(JSON.stringify(requestPacket) + '\n');
 
-            this._activeRequests[thisRequestPacket.Seq] = {
-                onSuccess: value => resolve(value),
-                onError: err => reject(err)
-            };
-
-            this._serverProcess.stdin.write(JSON.stringify(thisRequestPacket) + '\n');
-        });
+        return requestPacket;
     }
 }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -3,33 +3,25 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
-import {EventEmitter} from 'events';
-import {ChildProcess, exec} from 'child_process';
-import {dirname} from 'path';
-import {ReadLine, createInterface} from 'readline';
-import {launchOmniSharp} from './launcher';
-import * as protocol from './protocol';
-import {Options} from './options';
-import {Logger} from '../logger';
-import {DelayTracker} from './delayTracker';
-import {LaunchTarget, findLaunchTargets} from './launcher';
-import { Queue } from './queue';
+import { EventEmitter } from 'events';
+import { ChildProcess, exec } from 'child_process';
+import { ReadLine, createInterface } from 'readline';
+import { launchOmniSharp } from './launcher';
+import { Options } from './options';
+import { Logger } from '../logger';
+import { DelayTracker } from './delayTracker';
+import { LaunchTarget, findLaunchTargets } from './launcher';
+import { PlatformInformation } from '../platform';
+import { Request, RequestQueueCollection } from './requestQueue';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import * as path from 'path';
+import * as protocol from './protocol';
 import * as vscode from 'vscode';
 
 enum ServerState {
     Starting,
     Started,
     Stopped
-}
-
-interface Request {
-    command: string;
-    data?: any;
-    onSuccess(value: any): void;
-    onError(err: any): void;
 }
 
 module Events {
@@ -78,7 +70,7 @@ export class OmniSharpServer {
     private _eventBus = new EventEmitter();
     private _state: ServerState = ServerState.Stopped;
     private _launchTarget: LaunchTarget;
-    private _requestQueue: Queue;
+    private _requestQueue: RequestQueueCollection;
     private _channel: vscode.OutputChannel;
     private _logger: Logger;
 
@@ -92,7 +84,7 @@ export class OmniSharpServer {
 
         this._channel = vscode.window.createOutputChannel('OmniSharp Log');
         this._logger = new Logger(message => this._channel.append(message));
-        this._requestQueue = new Queue(this._logger, 8, request => this._makeRequest(request));
+        this._requestQueue = new RequestQueueCollection(this._logger, 8, request => this._makeRequest(request));
     }
 
     public isRunning(): boolean {
@@ -123,9 +115,9 @@ export class OmniSharpServer {
     private _reportTelemetry() {
         const delayTrackers = this._delayTrackers;
 
-        for (const path in delayTrackers) {
-            const tracker = delayTrackers[path];
-            const eventName = 'omnisharp' + path;
+        for (const requestName in delayTrackers) {
+            const tracker = delayTrackers[requestName];
+            const eventName = 'omnisharp' + requestName;
             if (tracker.hasMeasures()) {
                 const measures = tracker.getMeasures();
                 tracker.clearMeasures();
@@ -236,7 +228,7 @@ export class OmniSharpServer {
         this._launchTarget = launchTarget;
 
         const solutionPath = launchTarget.target;
-        const cwd = dirname(solutionPath);
+        const cwd = path.dirname(solutionPath);
         let args = [
             '-s', solutionPath,
             '--hostPID', process.pid.toString(),
@@ -472,6 +464,7 @@ export class OmniSharpServer {
                 if (listener) {
                     listener.dispose();
                 }
+
                 clearTimeout(handle);
                 resolve();
             });
@@ -522,24 +515,25 @@ export class OmniSharpServer {
     }
 
     private _handleResponsePacket(packet: protocol.WireProtocol.ResponsePacket) {
-        if (!this._requestQueue.dequeue(packet.Command, packet.Request_seq)) {
+        const request = this._requestQueue.dequeue(packet.Command, packet.Request_seq);
+
+        if (!request) {
             this._logger.appendLine(`Received response for ${packet.Command} but could not find request.`);
             return;
         }
 
         if (packet.Success) {
-            // Handle success
+            request.onSuccess(packet.Body);
         }
         else {
-            // Handle failure
+            request.onError(packet.Message || packet.Body);
         }
     }
 
     private _handleEventPacket(packet: protocol.WireProtocol.EventPacket): void {
         if (packet.Event === 'log') {
-            // handle log events
             const entry = <{ LogLevel: string; Name: string; Message: string; }>packet.Body;
-            this._logger.appendLine(`[${entry.LogLevel}:${entry.Name}] ${entry.Message}`);
+            this._logOutput(entry.LogLevel, entry.Name, entry.Message);
         } 
         else {
             // fwd all other events
@@ -557,10 +551,21 @@ export class OmniSharpServer {
             Arguments: request.data
         };
 
-        console.log(`Making request: ${request.command} (${id})`);
+        this._logger.appendLine(`Making request: ${request.command} (${id})`);
 
         this._serverProcess.stdin.write(JSON.stringify(requestPacket) + '\n');
 
-        return requestPacket;
+        return id;
+    }
+
+    private _logOutput(logLevel: string, name: string, message: string) {
+        const timing200Pattern = /^\[INFORMATION:OmniSharp.Middleware.LoggingMiddleware\] \/[\/\w]+: 200 \d+ms/;
+
+        const output = `[${logLevel}:${name}] ${message}`;
+        
+        // strip stuff like: /codecheck: 200 339ms
+        if (!timing200Pattern.test(output)) {
+            this._logger.appendLine(output);
+        }
     }
 }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -63,7 +63,7 @@ module Events {
 
 const TelemetryReportingDelay = 2 * 60 * 1000; // two minutes
 
-export class OmnisharpServer {
+export class OmniSharpServer {
 
     private static _nextId = 1;
     private static StartupTimeout = 1000 * 60;
@@ -590,7 +590,7 @@ export class OmnisharpServer {
 
     private _makeNextRequest(path: string, data: any): Promise<any> {
 
-        const id = OmnisharpServer._nextId++;
+        const id = OmniSharpServer._nextId++;
 
         const thisRequestPacket: protocol.WireProtocol.RequestPacket = {
             Type: 'request',

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -5,82 +5,82 @@
 
 'use strict';
 
-import {OmnisharpServer} from './server';
+import {OmniSharpServer} from './server';
 import * as protocol from './protocol';
 import * as vscode from 'vscode';
 
-export function autoComplete(server: OmnisharpServer, request: protocol.AutoCompleteRequest) {
+export function autoComplete(server: OmniSharpServer, request: protocol.AutoCompleteRequest) {
     return server.makeRequest<protocol.AutoCompleteResponse[]>(protocol.Requests.AutoComplete, request);
 }
 
-export function codeCheck(server: OmnisharpServer, request: protocol.Request, token: vscode.CancellationToken) {
+export function codeCheck(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.CodeCheck, request, token);
 }
 
-export function currentFileMembersAsTree(server: OmnisharpServer, request: protocol.Request, token: vscode.CancellationToken) {
+export function currentFileMembersAsTree(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.CurrentFileMembersAsTreeResponse>(protocol.Requests.CurrentFileMembersAsTree, request, token);
 }
 
-export function filesChanged(server: OmnisharpServer, requests: protocol.Request[]) {
+export function filesChanged(server: OmniSharpServer, requests: protocol.Request[]) {
     return server.makeRequest<void>(protocol.Requests.FilesChanged, requests);
 }
 
-export function findSymbols(server: OmnisharpServer, request: protocol.FindSymbolsRequest, token: vscode.CancellationToken) {
+export function findSymbols(server: OmniSharpServer, request: protocol.FindSymbolsRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.FindSymbolsResponse>(protocol.Requests.FindSymbols, request, token);
 }
 
-export function findUsages(server: OmnisharpServer, request: protocol.FindUsagesRequest, token: vscode.CancellationToken) {
+export function findUsages(server: OmniSharpServer, request: protocol.FindUsagesRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.FindUsages, request, token);
 }
 
-export function formatAfterKeystroke(server: OmnisharpServer, request: protocol.FormatAfterKeystrokeRequest, token: vscode.CancellationToken) {
+export function formatAfterKeystroke(server: OmniSharpServer, request: protocol.FormatAfterKeystrokeRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.FormatRangeResponse>(protocol.Requests.FormatAfterKeystroke, request, token);
 }
 
-export function formatRange(server: OmnisharpServer, request: protocol.FormatRangeRequest, token: vscode.CancellationToken) {
+export function formatRange(server: OmniSharpServer, request: protocol.FormatRangeRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.FormatRangeResponse>(protocol.Requests.FormatRange, request, token);
 }
 
-export function getCodeActions(server: OmnisharpServer, request: protocol.V2.GetCodeActionsRequest, token: vscode.CancellationToken) {
+export function getCodeActions(server: OmniSharpServer, request: protocol.V2.GetCodeActionsRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.V2.GetCodeActionsResponse>(protocol.V2.Requests.GetCodeActions, request, token);
 }
 
-export function goToDefinition(server: OmnisharpServer, request: protocol.GoToDefinitionRequest, token: vscode.CancellationToken) {
+export function goToDefinition(server: OmniSharpServer, request: protocol.GoToDefinitionRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.GoToDefinitionResponse>(protocol.Requests.GoToDefinition, request);
 }
 
-export function rename(server: OmnisharpServer, request: protocol.RenameRequest, token: vscode.CancellationToken) {
+export function rename(server: OmniSharpServer, request: protocol.RenameRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.RenameResponse>(protocol.Requests.Rename, request, token);
 }
 
-export function requestWorkspaceInformation(server: OmnisharpServer) {
+export function requestWorkspaceInformation(server: OmniSharpServer) {
     return server.makeRequest<protocol.WorkspaceInformationResponse>(protocol.Requests.Projects);
 }
 
-export function runCodeAction(server: OmnisharpServer, request: protocol.V2.RunCodeActionRequest) {
+export function runCodeAction(server: OmniSharpServer, request: protocol.V2.RunCodeActionRequest) {
     return server.makeRequest<protocol.V2.RunCodeActionResponse>(protocol.V2.Requests.RunCodeAction, request);
 }
 
-export function signatureHelp(server: OmnisharpServer, request: protocol.Request, token: vscode.CancellationToken) {
+export function signatureHelp(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.SignatureHelp>(protocol.Requests.SignatureHelp, request, token);
 }
 
-export function typeLookup(server: OmnisharpServer, request: protocol.TypeLookupRequest, token: vscode.CancellationToken) {
+export function typeLookup(server: OmniSharpServer, request: protocol.TypeLookupRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.TypeLookupResponse>(protocol.Requests.TypeLookup, request, token);
 }
 
-export function updateBuffer(server: OmnisharpServer, request: protocol.UpdateBufferRequest) {
+export function updateBuffer(server: OmniSharpServer, request: protocol.UpdateBufferRequest) {
     return server.makeRequest<boolean>(protocol.Requests.UpdateBuffer, request);
 }
 
-export function getMetadata(server: OmnisharpServer, request: protocol.MetadataRequest) {
+export function getMetadata(server: OmniSharpServer, request: protocol.MetadataRequest) {
     return server.makeRequest<protocol.MetadataResponse>(protocol.Requests.Metadata, request);
 }
 
-export function getTestStartInfo(server: OmnisharpServer, request: protocol.V2.GetTestStartInfoRequest) {
+export function getTestStartInfo(server: OmniSharpServer, request: protocol.V2.GetTestStartInfoRequest) {
     return server.makeRequest<protocol.V2.GetTestStartInfoResponse>(protocol.V2.Requests.GetTestStartInfo, request);
 }
 
-export function runDotNetTest(server: OmnisharpServer, request: protocol.V2.RunDotNetTestRequest) {
+export function runDotNetTest(server: OmniSharpServer, request: protocol.V2.RunDotNetTestRequest) {
     return server.makeRequest<protocol.V2.RunDotNetTestResponse>(protocol.V2.Requests.RunDotNetTest, request);
 }


### PR DESCRIPTION
Communication with the OmniSharp server happens in a very serial fashion: make a request and wait for the response. This is done to ensure that critical communication, such as updating a buffer during typing, is processed quickly. However, that means that we'll wait on extremely long running requests that don't need to happen serially, such as waiting for all diagnostics to be returned for a solution.

This change splits requests into three queues based on the type of request. High priority requests, such as buffer changes, are still handled serially. Most other requests are placed on a queue that is allowed to make up to 8 simultaneous requests at a time. Other requests (especially long-running requests) are placed on a "deferred" queue that allows a much smaller number of simultaneous requests (maximum 2).

cc @david-driscoll 