### PR TITLE
escape "&" when launching omnisharp on windows

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -202,7 +202,7 @@ function launchWindows(launchPath: string, cwd: string, args: string[]): LaunchR
         const hasSpaceWithoutQuotes = /^[^"].* .*[^"]/;
         return hasSpaceWithoutQuotes.test(arg)
             ? `"${arg}"`
-            : arg;
+            : arg.replace("&","^&");
     }
 
     let argsCopy = args.slice(0); // create copy of args


### PR DESCRIPTION
This PR ensures that when passing the non-quoted arguments to OmniSharp process, `&` is escaped on Windows.

At the moment if I have a C# project in a folder called `{root}\foo&bar`, OmniSharp will fail to start on Windows as it will only see the `-s` argument as `{root}\foo`. The bug doesn't affect other platforms. It manifests itself via the `-s` argument but potentially other arguments could be affected too, so the fix just escapes every non-quote arg.

Fixes https://github.com/OmniSharp/omnisharp-roslyn/issues/515