### PR TITLE
Fix handling of unknown Linux distributions

### DIFF
--- a/src/packages.ts
+++ b/src/packages.ts
@@ -92,8 +92,10 @@ export class PackageManager {
         return this.GetAllPackages()
             .then(list => {
                 return list.filter(pkg => {
-                    if (pkg.runtimeIds && this.platformInfo.runtimeId && pkg.runtimeIds.indexOf(this.platformInfo.runtimeId) === -1) {
-                        return false;
+                    if (pkg.runtimeIds) {
+                        if (!this.platformInfo.runtimeId || pkg.runtimeIds.indexOf(this.platformInfo.runtimeId) === -1) {
+                            return false;
+                        }
                     }
 
                     if (pkg.architectures && pkg.architectures.indexOf(this.platformInfo.architecture) === -1) {


### PR DESCRIPTION
This checkin fixes the behavior of the C# extension if we are on a Linux distribution that we don't understand or support. Before we would attempt to download every different x64 package, and then show a very generic error message.