### PR TITLE
Configurable project list cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
         },
         "omnisharp.maxProjectResults": {
           "type": "number",
-          "default": 100,
+          "default": 250,
           "description": "The amount of projects to be shown in the 'Select Project' dropdown, discovered in the descendant folders of the working folder. Once the limit is reached, the extension will stop searching for projects."
         }
       }

--- a/package.json
+++ b/package.json
@@ -314,6 +314,11 @@
           "type": "number",
           "default": 60,
           "description": "The time Visual Studio Code will wait for the OmniSharp server to start. Time is expressed in seconds."
+        },
+        "omnisharp.maxProjectResults": {
+          "type": "number",
+          "default": 100,
+          "description": "The amount of projects to be shown in the 'Select Project' dropdown, discovered in the descendant folders of the working folder. Once the limit is reached, the extension will stop searching for projects."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
         "omnisharp.maxProjectResults": {
           "type": "number",
           "default": 250,
-          "description": "The amount of projects to be shown in the 'Select Project' dropdown, discovered in the descendant folders of the working folder. Once the limit is reached, the extension will stop searching for projects."
+          "description": "The maximum number of projects to be shown in the 'Select Project' dropdown (maximum 250)."
         }
       }
     },

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -41,10 +41,12 @@ export function findLaunchTargets(): Thenable<LaunchTarget[]> {
         return Promise.resolve([]);
     }
 
+    const options = Options.Read();
+
     return vscode.workspace.findFiles(
         /*include*/ '{**/*.sln,**/*.csproj,**/project.json}', 
         /*exclude*/ '{**/node_modules/**,**/.git/**,**/bower_components/**}',
-        /*maxResults*/ 100)
+        /*maxResults*/ options.maxProjectResults)
     .then(resources => {
         return select(resources, vscode.workspace.rootPath);
     });

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -36,7 +36,7 @@ export class Options {
         const autoStart = omnisharpConfig.get<boolean>('autoStart', true);
 
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
-        const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 100);
+        const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
 
         return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults);
     }

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -11,7 +11,8 @@ export class Options {
         public useMono?: boolean,
         public loggingLevel?: string,
         public autoStart?: boolean,
-        public projectLoadTimeout?: number) { }
+        public projectLoadTimeout?: number,
+        public maxProjectResults?: number) { }
 
     public static Read(): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -35,7 +36,8 @@ export class Options {
         const autoStart = omnisharpConfig.get<boolean>('autoStart', true);
 
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
+        const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 100);
 
-        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout);
+        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults);
     }
 }


### PR DESCRIPTION
Fixes #875 

Introduces a new setting `omnisharp.maxProjectResults` with a default value of `100` in place of the old hardcoded `100`. User can now set the value to whatever seems fit for their workflow.

Naturally, larger value i.e. `5000` would mean longer start up time.