### PR TITLE
Add detection logic for missing OpenSSL symlinks on macOS

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -15,7 +15,7 @@ let _debugUtil: CoreClrDebugUtil = null;
 let _reporter: TelemetryReporter = null;
 let _logger: Logger = null;
 
-export function activate(context: vscode.ExtensionContext, reporter: TelemetryReporter, logger: Logger) {
+export function activate(context: vscode.ExtensionContext, reporter: TelemetryReporter, logger: Logger, channel: vscode.OutputChannel) {
     _debugUtil = new CoreClrDebugUtil(context.extensionPath, logger);
     _reporter = reporter;
     _logger = logger;
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
         PlatformInformation.GetCurrent().then((info) => {
             if (info.runtimeId) {
                 logger.appendLine("[ERROR]: C# Extension failed to install the debugger package");
-                showInstallErrorMessage();
+                showInstallErrorMessage(channel);
             } else {
                 if (info.isLinux) { 
                     logger.appendLine(`[WARNING]: The current Linux distribution '${info.distribution.name}' version '${info.distribution.version}' is not currently supported by the .NET Core debugger. Debugging will not be available.`);
@@ -35,22 +35,38 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
         }, (err) => {
             // Somehow we couldn't figure out the platform we are on
             logger.appendLine("[ERROR]: C# Extension failed to install the debugger package");
-            showInstallErrorMessage();
+            showInstallErrorMessage(channel);
         });
     } else if (!CoreClrDebugUtil.existsSync(_debugUtil.installCompleteFilePath())) {
         _debugUtil.checkDotNetCli()
             .then((dotnetInfo: DotnetInfo) => {
-                let installer = new debugInstall.DebugInstaller(_debugUtil);
-                installer.finishInstall()
-                    .then(() => {
-                        vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.');
-                    })
-                    .catch((err) => {
-                        logger.appendLine("[ERROR]: An error occured while installing the .NET Core Debugger:");
-                        logger.appendLine(err);
-                        showInstallErrorMessage();
-                        // TODO: log telemetry?
-                    });
+                _debugUtil.checkOpenSSLInstalledIfRequired().then((isInstalled) => {
+                    if (isInstalled) {
+                        let installer = new debugInstall.DebugInstaller(_debugUtil);
+                        installer.finishInstall()
+                            .then(() => {
+                                vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.');
+                            })
+                            .catch((err) => {
+                                logger.appendLine("[ERROR]: An error occured while installing the .NET Core Debugger:");
+                                logger.appendLine(err);
+                                showInstallErrorMessage(channel);
+                                // TODO: log telemetry?
+                            });
+                    } else {
+                        logger.appendLine("[ERROR] The debugger cannot be installed. A required component, OpenSSL, is not correctly configured.");
+                        logger.appendLine("In order to use the debugger, open a terminal window and execute the following instructions.");
+                        logger.appendLine("See https://www.microsoft.com/net/core#macos for more details.");
+                        logger.appendLine();
+                        logger.appendLine("  brew update");
+                        logger.appendLine("  brew install openssl");
+                        logger.appendLine("  mkdir -p /usr/local/lib");
+                        logger.appendLine("  ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/");
+                        logger.appendLine("  ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/");
+                        channel.show();
+                        vscode.window.showErrorMessage("The .NET Core debugger cannot be installed. OpenSSL is not correctly configured. See the C# output channel for details.");
+                    }
+                });
             }, (err) => {
                 // Check for dotnet tools failed. pop the UI
                 // err is a DotNetCliError but use defaults in the unexpected case that it's not
@@ -61,7 +77,8 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
     }
 }
 
-function showInstallErrorMessage() {
+function showInstallErrorMessage(channel: vscode.OutputChannel) {
+    channel.show();
     vscode.window.showErrorMessage("An error occured during installation of the .NET Core Debugger. The C# extension may need to be reinstalled.");
 }
 

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -6,6 +6,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as semver from 'semver';
 import { execChildProcess } from './../common';
 import { Logger } from './../logger';
@@ -73,6 +74,25 @@ export class CoreClrDebugUtil
 
     public defaultDotNetCliErrorMessage(): string {
         return 'Failed to find up to date dotnet cli on the path.';
+    }
+
+    public checkOpenSSLInstalledIfRequired(): Promise<boolean> {
+        if (os.platform() !== "darwin") {
+            // We only need special handling on OSX
+            return Promise.resolve(true);
+        }
+
+        return new Promise<boolean>((resolve, reject) => {
+            fs.access("/usr/local/lib/libcrypto.1.0.0.dylib", (err1) => {
+                if (err1) {
+                    resolve(false);
+                } else {
+                    fs.access("/usr/local/lib/libssl.1.0.0.dylib", (err2) => {
+                        resolve(!err2);
+                    });
+                }
+            });
+        });
     }
 
     // This function checks for the presence of dotnet on the path and ensures the Version

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext): any {
             OmniSharp.activate(context, reporter);
 
             // activate coreclr-debug
-            coreclrdebug.activate(context, reporter, logger);
+            coreclrdebug.activate(context, reporter, logger, _channel);
         });
 }
 


### PR DESCRIPTION
By far our most common EE error is due to folks not having the OpenSSL symlinks created. This checkin adds detection logic so that we will not install the debugger unless they are present.

This resolves https://github.com/OmniSharp/omnisharp-vscode/issues/779

Testing:
1. macOS: Verified we correctly fail if either of the two symlinks are missing
2. macOS: Verified the debug proxy correctly fails if we ignore the problem
3. macOS: Verified the 'channel.open' calls work
4. macOS + Windows: Verified the extension can install when everything is correct
