### PR TITLE
Add support for running/debugging NUnit tests

### DIFF
--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -24,21 +24,21 @@ function getTestOutputChannel(): vscode.OutputChannel {
 export function registerDotNetTestRunCommand(server: OmniSharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.run',
-        (testMethod, fileName) => runDotnetTest(testMethod, fileName, server));
+        (testMethod, fileName, testFrameworkName) => runDotnetTest(testMethod, fileName, testFrameworkName, server));
 }
 
 export function registerDotNetTestDebugCommand(server: OmniSharpServer): vscode.Disposable {
     return vscode.commands.registerCommand(
         'dotnet.test.debug',
-        (testMethod, fileName) => debugDotnetTest(testMethod, fileName, server));
+        (testMethod, fileName, testFrameworkName) => debugDotnetTest(testMethod, fileName, testFrameworkName, server));
 }
 
 // Run test through dotnet-test command. This function can be moved to a separate structure
-export function runDotnetTest(testMethod: string, fileName: string, server: OmniSharpServer) {
+export function runDotnetTest(testMethod: string, fileName: string, testFrameworkName: string, server: OmniSharpServer) {
     getTestOutputChannel().show();
     getTestOutputChannel().appendLine('Running test ' + testMethod + '...');
     serverUtils
-        .runDotNetTest(server, { FileName: fileName, MethodName: testMethod })
+        .runDotNetTest(server, { FileName: fileName, MethodName: testMethod, TestFrameworkName: testFrameworkName })
         .then(
         response => {
             if (response.Pass) {
@@ -54,8 +54,8 @@ export function runDotnetTest(testMethod: string, fileName: string, server: Omni
 }
 
 // Run test through dotnet-test command with debugger attached
-export function debugDotnetTest(testMethod: string, fileName: string, server: OmniSharpServer) {
-    serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod }).then(response => {
+export function debugDotnetTest(testMethod: string, fileName: string, testFrameworkName: string, server: OmniSharpServer) {
+    serverUtils.getTestStartInfo(server, { FileName: fileName, MethodName: testMethod, TestFrameworkName: testFrameworkName }).then(response => {
         vscode.commands.executeCommand(
             'vscode.startDebug', {
                 "name": ".NET test launch",
@@ -78,18 +78,18 @@ export function updateCodeLensForTest(bucket: vscode.CodeLens[], fileName: strin
         return;
     }
 
-    let testFeature = node.Features.find(value => value.Name == 'XunitTestMethod');
+    let testFeature = node.Features.find(value => (value.Name == 'XunitTestMethod' || value.Name == 'NUnitTestMethod'));
     if (testFeature) {
         // this test method has a test feature
-
+        let testFrameworkName = testFeature.Name == 'XunitTestMethod' ? 'xunit' : 'nunit';
         bucket.push(new vscode.CodeLens(
             toRange(node.Location),
-            { title: "run test", command: 'dotnet.test.run', arguments: [testFeature.Data, fileName] }));
+            { title: "run test", command: 'dotnet.test.run', arguments: [testFeature.Data, fileName, testFrameworkName] }));
 
         if (isDebugEnable) {
             bucket.push(new vscode.CodeLens(
                 toRange(node.Location),
-                { title: "debug test", command: 'dotnet.test.debug', arguments: [testFeature.Data, fileName] }));
+                { title: "debug test", command: 'dotnet.test.debug', arguments: [testFeature.Data, fileName, testFrameworkName] }));
         }
     }
 }

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -481,6 +481,7 @@ export namespace V2 {
     export interface GetTestStartInfoRequest {
         FileName: string;
         MethodName: string;
+        TestFrameworkName: string;
     }
 
     export interface GetTestStartInfoResponse {
@@ -491,6 +492,7 @@ export namespace V2 {
     export interface RunDotNetTestRequest {
         FileName: string;
         MethodName: string;
+        TestFrameworkName: string;
     }
 
     export interface RunDotNetTestResponse {


### PR DESCRIPTION
For NUnit tests, Omnisharp-Roslyn returns a new feature name
"NUnitTestMethod". When a test is executed, the test framework name must
be set (xunit or nunit). The feature name for xUnit tests did not
change.