### PR TITLE
Add warning when x86 windows is used

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -23,8 +23,12 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
     if (!CoreClrDebugUtil.existsSync(_debugUtil.debugAdapterDir())) {
         PlatformInformation.GetCurrent().then((info) => {
             if (info.runtimeId) {
-                logger.appendLine("[ERROR]: C# Extension failed to install the debugger package");
-                showInstallErrorMessage(channel);
+                if (info.runtimeId === 'win7-x86') {
+                    logger.appendLine(`[WARNING]: x86 Windows is not currently supported by the .NET Core debugger. Debugging will not be available.`);
+                } else {
+                    logger.appendLine("[ERROR]: C# Extension failed to install the debugger package");
+                    showInstallErrorMessage(channel);
+                }
             } else {
                 if (info.isLinux) { 
                     logger.appendLine(`[WARNING]: The current Linux distribution '${info.distribution.name}' version '${info.distribution.version}' is not currently supported by the .NET Core debugger. Debugging will not be available.`);


### PR DESCRIPTION
Previously the debugger would add an error to the install log when installing on x86 Windows. With this change we instead add a warning.

This code should be removed once https://github.com/OmniSharp/omnisharp-vscode/issues/844 is fixed.