### PR TITLE
Fixing sourceFileMaps inner type

### DIFF
--- a/package.json
+++ b/package.json
@@ -560,6 +560,9 @@
               "sourceFileMap": {
                 "type": "object",
                 "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "default": {
                   "<source-path>": "<target-path>"
                 }
@@ -807,6 +810,9 @@
               "sourceFileMap": {
                 "type": "object",
                 "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "default": {
                   "<source-path>": "<target-path>"
                 }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -281,6 +281,9 @@
                 "sourceFileMap": {
                     "type": "object",
                     "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
                     "default": {
                         "<source-path>": "<target-path>"
                     }
@@ -344,6 +347,9 @@
                 "sourceFileMap": {
                     "type": "object",
                     "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
                     "default": {
                         "<source-path>": "<target-path>"
                     }


### PR DESCRIPTION
SourceFileMaps are restricted to be strings, adding this so that the
hints will show that it needs to be a string type.