### PR TITLE
Add support for new Linux distros in the debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.6.0-beta2",
+  "version": "1.6.0-beta3",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -136,8 +136,8 @@
     },
     {
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-win7-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-win7-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "win7-x64"
@@ -145,8 +145,8 @@
     },
     {
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-osx.10.11-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-osx.10.11-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-osx.10.11-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-osx.10.11-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "osx.10.11-x64"
@@ -158,8 +158,8 @@
     },
     {
       "description": ".NET Core Debugger (CentOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-centos.7-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-centos.7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-centos.7-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-centos.7-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "centos.7-x64"
@@ -171,8 +171,8 @@
     },
     {
       "description": ".NET Core Debugger (Debian / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-debian.8-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-debian.8-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-debian.8-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-debian.8-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "debian.8-x64"
@@ -183,9 +183,9 @@
       ]
     },
     {
-      "description": ".NET Core Debugger (Fedora / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-fedora.23-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-fedora.23-x64.zip",
+      "description": ".NET Core Debugger (Fedora 23 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-fedora.23-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-fedora.23-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "fedora.23-x64"
@@ -196,9 +196,22 @@
       ]
     },
     {
-      "description": ".NET Core Debugger (OpenSUSE / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-opensuse.13.2-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-opensuse.13.2-x64.zip",
+      "description": ".NET Core Debugger (Fedora 24 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-fedora.24-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-fedora.24-x64.zip",
+      "installPath": ".debugger",
+      "runtimeIds": [
+        "fedora.24-x64"
+      ],
+      "binaries": [
+        "./OpenDebugAD7",
+        "./clrdbg"
+      ]
+    },
+    {
+      "description": ".NET Core Debugger (OpenSUSE 13 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-opensuse.13.2-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-opensuse.13.2-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "opensuse.13.2-x64"
@@ -209,9 +222,22 @@
       ]
     },
     {
+      "description": ".NET Core Debugger (OpenSUSE 42 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-opensuse.42.1-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-opensuse.42.1-x64.zip",
+      "installPath": ".debugger",
+      "runtimeIds": [
+        "opensuse.42.1-x64"
+      ],
+      "binaries": [
+        "./OpenDebugAD7",
+        "./clrdbg"
+      ]
+    },
+    {
       "description": ".NET Core Debugger (RHEL / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-rhel.7.2-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-rhel.7.2-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-rhel.7.2-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-rhel.7.2-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "rhel.7-x64"
@@ -222,9 +248,9 @@
       ]
     },
     {
-      "description": ".NET Core Debugger (Ubuntu 14 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-ubuntu.14.04-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-ubuntu.14.04-x64.zip",
+      "description": ".NET Core Debugger (Ubuntu 14.04 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.14.04-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.14.04-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "ubuntu.14.04-x64"
@@ -235,12 +261,25 @@
       ]
     },
     {
-      "description": ".NET Core Debugger (Ubuntu 16 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-5-0/coreclr-debug-ubuntu.16.04-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-5-0/coreclr-debug-ubuntu.16.04-x64.zip",
+      "description": ".NET Core Debugger (Ubuntu 16.04 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.16.04-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.16.04-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "ubuntu.16.04-x64"
+      ],
+      "binaries": [
+        "./OpenDebugAD7",
+        "./clrdbg"
+      ]
+    },
+    {
+      "description": ".NET Core Debugger (Ubuntu 16.10 / x64)",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.16.10-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-6-0/coreclr-debug-ubuntu.16.10-x64.zip",
+      "installPath": ".debugger",
+      "runtimeIds": [
+        "ubuntu.16.10-x64"
       ],
       "binaries": [
         "./OpenDebugAD7",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -269,19 +269,25 @@ export class PlatformInformation {
         const centos_7 = 'centos.7-x64';
         const debian_8 = 'debian.8-x64';
         const fedora_23 = 'fedora.23-x64';
+        const fedora_24 = 'fedora.24-x64';
         const opensuse_13_2 = 'opensuse.13.2-x64';
+        const opensuse_42_1 = 'opensuse.42.1-x64';
         const rhel_7 = 'rhel.7-x64';
         const ubuntu_14_04 = 'ubuntu.14.04-x64';
         const ubuntu_16_04 = 'ubuntu.16.04-x64';
+        const ubuntu_16_10 = 'ubuntu.16.10-x64';
 
         switch (distributionName) {
             case 'ubuntu':
-                if (distributionVersion.startsWith("14")) {
+                if (distributionVersion === "14.04") {
                     // This also works for Linux Mint
                     return ubuntu_14_04;
                 }
-                else if (distributionVersion.startsWith("16")) {
+                else if (distributionVersion === "16.04") {
                     return ubuntu_16_04;
+                }
+                else if (distributionVersion === "16.10") {
+                    return ubuntu_16_10;
                 }
 
                 break;
@@ -309,9 +315,21 @@ export class PlatformInformation {
                 // Oracle Linux is binary compatible with CentOS
                 return centos_7;
             case 'fedora':
-                return fedora_23;
+                if (distributionVersion === "23") {
+                    return fedora_23;
+                } else if (distributionVersion === "24") {
+                    return fedora_24;
+                }
+                break;
+
             case 'opensuse':
-                return opensuse_13_2;
+                if (distributionVersion.startsWith("13.")) {
+                    return opensuse_13_2;
+                } else if (distributionVersion.startsWith("42.")) {
+                    return opensuse_42_1;
+                }
+                break;
+
             case 'rhel':
                 return rhel_7;
             case 'debian':

--- a/test/platform.tests.ts
+++ b/test/platform.tests.ts
@@ -73,6 +73,18 @@ suite("Platform", () => {
         platformInfo.runtimeId.should.equal('ubuntu.14.04-x64');
     })
 
+    test("Compute correct RID for Ubuntu 16.04", () => {
+        const platformInfo = new PlatformInformation('linux', 'x86_64', distro_ubuntu_16_04());
+
+        platformInfo.runtimeId.should.equal('ubuntu.16.04-x64');
+    })
+
+    test("Compute correct RID for Ubuntu 16.10", () => {
+        const platformInfo = new PlatformInformation('linux', 'x86_64', distro_ubuntu_16_10());
+
+        platformInfo.runtimeId.should.equal('ubuntu.16.10-x64');
+    })
+
     test("Compute correct RID for Fedora 23", () => {
         const platformInfo = new PlatformInformation('linux', 'x86_64', distro_fedora_23());
 
@@ -95,6 +107,18 @@ suite("Platform", () => {
         const platformInfo = new PlatformInformation('linux', 'x86_64', distro_kde_neon_5_8());
 
         platformInfo.runtimeId.should.equal('ubuntu.16.04-x64');
+    })
+
+    test("Compute correct RID for openSUSE 13", () => {
+        const platformInfo = new PlatformInformation('linux', 'x86_64', distro_openSUSE_13_2());
+
+        platformInfo.runtimeId.should.equal('opensuse.13.2-x64');
+    })
+
+    test("Compute correct RID for openSUSE 42", () => {
+        const platformInfo = new PlatformInformation('linux', 'x86_64', distro_openSUSE_42_1());
+
+        platformInfo.runtimeId.should.equal('opensuse.42.1-x64');
     })
 
     test("Compute no RID for CentOS 7 with 32-bit architecture", () => {
@@ -122,6 +146,43 @@ VERSION_ID="14.04"
 HOME_URL="http://www.ubuntu.com/"
 SUPPORT_URL="http://help.ubuntu.com/"
 BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`;
+
+    return LinuxDistribution.FromReleaseInfo(input, '\n');
+}
+
+function distro_ubuntu_16_04(): LinuxDistribution {
+    // Copied from /etc/os-release on Ubuntu 16.04 server
+    const input = `
+NAME="Ubuntu"
+VERSION="16.04.1 LTS (Xenial Xerus)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.04.1 LTS"
+VERSION_ID="16.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+VERSION_CODENAME=xenial
+UBUNTU_CODENAME=xenial`;
+
+    return LinuxDistribution.FromReleaseInfo(input, '\n');
+}
+
+function distro_ubuntu_16_10(): LinuxDistribution {
+    // Copied from /etc/os-release on Ubuntu 16.10 server
+    const input = `
+NAME="Ubuntu"
+VERSION="16.10 (Yakkety Yak)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.10"
+VERSION_ID="16.10"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="http://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=yakkety
+UBUNTU_CODENAME=yakkety`;
 
     return LinuxDistribution.FromReleaseInfo(input, '\n');
 }
@@ -200,6 +261,38 @@ SUPPORT_URL="http://neon.kde.org/"
 BUG_REPORT_URL="http://bugs.kde.org/"
 VERSION_CODENAME=xenial
 UBUNTU_CODENAME=xenial`;
+
+    return LinuxDistribution.FromReleaseInfo(input, '\n');
+}
+
+function distro_openSUSE_13_2(): LinuxDistribution {
+    const input = `
+NAME=openSUSE
+VERSION="13.2 (Harlequin)"
+VERSION_ID="13.2"
+PRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:13.2"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"`;
+
+    return LinuxDistribution.FromReleaseInfo(input, '\n');
+}
+
+function distro_openSUSE_42_1(): LinuxDistribution {
+    const input = `
+NAME="openSUSE Leap"
+VERSION="42.1"
+VERSION_ID="42.1"
+PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"`;
 
     return LinuxDistribution.FromReleaseInfo(input, '\n');
 }


### PR DESCRIPTION
This adds support for Ubuntu 16.10, Fedora 24 and openSUSE 42.1. To do this we are moving the debugger packages to .NET Core 1.1.

Testing: Verified this works on Windows, OSX and Ubuntu 14.04.