### PR TITLE
Syntax highlighting improvements and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ trim_trailing_whitespace = true
 [{.travis.yml},package.json]
 indent_style = space
 indent_size = 2
+
+[syntaxes/csharp.json]
+indent_style = space
+indent_size = 2

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -123,6 +123,43 @@
         }
       ]
     },
+    "genericConstraints": {
+      "begin": "(where)\\s*(\\w+)\\s*:",
+      "end": "(?={)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.cs"
+        },
+        "2": {
+          "name": "storage.type.cs"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\b(class|struct)\\b",
+          "name": "keyword.other.cs"
+        },
+        {
+          "match": "(new)\\s*\\(\\s*\\)",
+          "captures": {
+            "1": {
+              "name": "keyword.other.cs"
+            }
+          }
+        },
+        {
+          "match": "([\\w<>]+)\\s*(?=,|where|{)",
+          "captures": {
+            "1": {
+              "name": "storage.type.cs"
+            }
+          }
+        },
+        {
+          "include": "#genericConstraints"
+        }
+      ]
+    },
     "class": {
       "begin": "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)",
       "end": "}",
@@ -153,17 +190,20 @@
         },
         {
           "begin": ":",
-          "end": "(?={)",
+          "end": "(?={|where)",
           "patterns": [
             {
+              "match": "([\\w<>]+)\\s*",
               "captures": {
                 "1": {
                   "name": "storage.type.cs"
                 }
-              },
-              "match": "\\s*,?([A-Za-z_]\\w*)\\b"
+              }
             }
           ]
+        },
+        {
+          "include": "#genericConstraints"
         },
         {
           "begin": "{",

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -160,9 +160,31 @@
         }
       ]
     },
+    "type": {
+      "patterns": [
+        {
+          "match": "(\\w+\\s*<(?:[\\w\\s,\\.`\\[\\]\\*]+|\\g<1>)+>(?:\\s*\\[\\s*\\])?)",
+          "comment": "generic type",
+          "captures": {
+            "1": {
+              "name": "storage.type.cs"
+            }
+          }
+        },
+        {
+          "match": "\\b([a-zA-Z]+[\\w]*\\b(?:\\s*\\[\\s*\\])?\\*?)",
+          "comment": "non-generic type",
+          "captures": {
+            "1": {
+              "name": "storage.type.cs"
+            }
+          }
+        }
+      ]
+    },
     "generic-constraints": {
       "begin": "(where)\\s+(\\w+)\\s*:",
-      "end": "(?={)",
+      "end": "(?=where|{|$)",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.cs"
@@ -185,12 +207,7 @@
           }
         },
         {
-          "match": "([\\w<>,\\[\\]]+)\\s*(?=,|where|{)",
-          "captures": {
-            "1": {
-              "name": "storage.type.cs"
-            }
-          }
+          "include": "#type"
         },
         {
           "include": "#generic-constraints"
@@ -214,21 +231,27 @@
           "include": "#comments"
         },
         {
-          "captures": {
+          "begin": "(class|struct|interface|enum)\\s+",
+          "end": "(?={|:|$|where)",
+          "name": "meta.class.identifier.cs",
+          "beginCaptures": {
             "1": {
               "name": "storage.modifier.cs"
-            },
-            "2": {
-              "name": "entity.name.type.class.cs"
             }
           },
-          "match": "(class|struct|interface|enum)\\s+(\\w+)",
-          "name": "meta.class.identifier.cs"
+          "patterns": [
+            {
+              "include": "#type"
+            }
+          ]
         },
         {
           "begin": ":",
           "end": "(?={|where)",
           "patterns": [
+            {
+              "include": "#type"
+            },
             {
               "match": "([\\w<>]+)\\s*",
               "captures": {

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -71,6 +71,43 @@
         }
       ]
     },
+    "field-declaration": {
+      "patterns": [
+        {
+          "begin": "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const)\\s*)*)(?:[\\w\\s,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))",
+          "end": "(?=;)",
+          "patterns": [
+            {
+              "match": "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const)\\s*)*)\\s*([\\w\\s,<>\\[\\]]+?)\\s*([\\w]+)\\s*(?=;|=)",
+              "captures": {
+                "1" : {
+                  "patterns": [
+                    {
+                      "include": "#storage-modifiers"
+                    }
+                  ]
+                },
+                "2" : {
+                  "name": "storage.type.cs"
+                },
+                "3": {
+                  "name": "entity.name.variable.cs"
+                }
+              }
+            },
+            {
+              "begin": "(?==>?)",
+              "end": "(?=;)",
+              "patterns": [
+                {
+                  "include": "#code"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "variable": {
       "patterns": [
         {
@@ -123,8 +160,8 @@
         }
       ]
     },
-    "genericConstraints": {
-      "begin": "(where)\\s*(\\w+)\\s*:",
+    "generic-constraints": {
+      "begin": "(where)\\s+(\\w+)\\s*:",
       "end": "(?={)",
       "beginCaptures": {
         "1": {
@@ -148,7 +185,7 @@
           }
         },
         {
-          "match": "([\\w<>]+)\\s*(?=,|where|{)",
+          "match": "([\\w<>,\\[\\]]+)\\s*(?=,|where|{)",
           "captures": {
             "1": {
               "name": "storage.type.cs"
@@ -156,7 +193,7 @@
           }
         },
         {
-          "include": "#genericConstraints"
+          "include": "#generic-constraints"
         }
       ]
     },
@@ -203,7 +240,7 @@
           ]
         },
         {
-          "include": "#genericConstraints"
+          "include": "#generic-constraints"
         },
         {
           "begin": "{",
@@ -216,12 +253,22 @@
           "name": "meta.class.body.cs",
           "patterns": [
             {
-              "include": "#method"
-            },
-            {
-              "include": "#code"
+              "include": "#type-body"
             }
           ]
+        }
+      ]
+    },
+    "type-body": {
+      "patterns": [
+        {
+          "include": "#field-declaration"
+        },
+        {
+          "include": "#method"
+        },
+        {
+          "include": "#code"
         }
       ]
     },

--- a/syntaxes/csharp.json
+++ b/syntaxes/csharp.json
@@ -78,7 +78,7 @@
           "end": "(?=;)",
           "patterns": [
             {
-              "match": "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const)\\s*)*)\\s*([\\w\\s,<>\\[\\]]+?)\\s*([\\w]+)\\s*(?=;|=)",
+              "match": "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)",
               "captures": {
                 "1" : {
                   "patterns": [
@@ -88,7 +88,11 @@
                   ]
                 },
                 "2" : {
-                  "name": "storage.type.cs"
+                  "patterns": [
+                    {
+                      "include": "#type"
+                    }
+                  ]
                 },
                 "3": {
                   "name": "entity.name.variable.cs"

--- a/test/syntaxes/class.tests.ts
+++ b/test/syntaxes/class.tests.ts
@@ -100,7 +100,7 @@ const input = `
 namespace TestNamespace
 {
     class PublicClass<T> where T : ISomething { }
-    class PublicClass<T, X> : List<T>, ISomething where T : ICar, new() where X : struct { }
+    class PublicClass<T, X> : Dictionary<T, List<string>[]>, ISomething where T : ICar, new() where X : struct { }
 }`;
             let tokens: Token[] = TokenizerUtil.tokenize(input);
 
@@ -112,15 +112,15 @@ namespace TestNamespace
 
             tokens.should.contain(Tokens.ClassKeyword("class", 5, 5));
             tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 5, 11));
-            tokens.should.contain(Tokens.Type("List<T>", 5, 31));
-            tokens.should.contain(Tokens.Type("ISomething", 5, 40));
-            tokens.should.contain(Tokens.Keyword("where", 5, 51));
-            tokens.should.contain(Tokens.Type("T", 5, 57));
-            tokens.should.contain(Tokens.Type("ICar", 5, 61));
-            tokens.should.contain(Tokens.Keyword("new", 5, 67));
+            tokens.should.contain(Tokens.Type("Dictionary<T, List<string>[]>", 5, 31));
+            tokens.should.contain(Tokens.Type("ISomething", 5, 62));
             tokens.should.contain(Tokens.Keyword("where", 5, 73));
-            tokens.should.contain(Tokens.Type("X", 5, 79));
-            tokens.should.contain(Tokens.Keyword("struct", 5, 83));
+            tokens.should.contain(Tokens.Type("T", 5, 79));
+            tokens.should.contain(Tokens.Type("ICar", 5, 83));
+            tokens.should.contain(Tokens.Keyword("new", 5, 89));
+            tokens.should.contain(Tokens.Keyword("where", 5, 95));
+            tokens.should.contain(Tokens.Type("X", 5, 101));
+            tokens.should.contain(Tokens.Keyword("struct", 5, 105));
 
         });
 

--- a/test/syntaxes/class.tests.ts
+++ b/test/syntaxes/class.tests.ts
@@ -8,7 +8,7 @@ describe("Grammar", function() {
     });
 
     describe("Class", function() {
-        it("has a class keyword, a name and optional storage modifiers", function() {
+        it("class keyword and storage modifiers", function() {
 
 const input = `
 namespace TestNamespace
@@ -72,6 +72,58 @@ namespace TestNamespace
             tokens.should.contain(Tokens.ClassIdentifier("DefaultAbstractClass", 20, 30));
 
         });
+
+        it("inheritance", function() {
+
+const input = `
+namespace TestNamespace
+{
+    class PublicClass    : IInterface,    IInterfaceTwo { }
+    class PublicClass<T> : IInterface<T>, IInterfaceTwo { }
+}`;
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.ClassKeyword("class", 4, 5));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 4, 11));
+            tokens.should.contain(Tokens.Type("IInterface", 4, 28));
+            tokens.should.contain(Tokens.Type("IInterfaceTwo", 4, 43));
+
+            tokens.should.contain(Tokens.ClassKeyword("class", 5, 5));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 5, 11));
+            tokens.should.contain(Tokens.Type("IInterface<T>", 5, 28));
+            tokens.should.contain(Tokens.Type("IInterfaceTwo", 5, 43));
+        });
+
+        it("generic constraints", function() {
+
+const input = `
+namespace TestNamespace
+{
+    class PublicClass<T> where T : ISomething { }
+    class PublicClass<T, X> : List<T>, ISomething where T : ICar, new() where X : struct { }
+}`;
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.ClassKeyword("class", 4, 5));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 4, 11));
+            tokens.should.contain(Tokens.Keyword("where", 4, 26));
+            tokens.should.contain(Tokens.Type("T", 4, 32));
+            tokens.should.contain(Tokens.Type("ISomething", 4, 36));
+
+            tokens.should.contain(Tokens.ClassKeyword("class", 5, 5));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 5, 11));
+            tokens.should.contain(Tokens.Type("List<T>", 5, 31));
+            tokens.should.contain(Tokens.Type("ISomething", 5, 40));
+            tokens.should.contain(Tokens.Keyword("where", 5, 51));
+            tokens.should.contain(Tokens.Type("T", 5, 57));
+            tokens.should.contain(Tokens.Type("ICar", 5, 61));
+            tokens.should.contain(Tokens.Keyword("new", 5, 67));
+            tokens.should.contain(Tokens.Keyword("where", 5, 73));
+            tokens.should.contain(Tokens.Type("X", 5, 79));
+            tokens.should.contain(Tokens.Keyword("struct", 5, 83));
+
+        });
+
 
     });
 });

--- a/test/syntaxes/class.tests.ts
+++ b/test/syntaxes/class.tests.ts
@@ -73,6 +73,19 @@ namespace TestNamespace
 
         });
 
+        it("generics in identifier", function () {
+
+            const input = `
+namespace TestNamespace
+{
+    class Dictionary<T, Dictionary<string, string>> { }
+}`;
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.ClassKeyword("class", 4, 5));
+            tokens.should.contain(Tokens.ClassIdentifier("Dictionary<T, Dictionary<string, string>>", 4, 11));
+        });
+
         it("inheritance", function() {
 
 const input = `
@@ -80,6 +93,7 @@ namespace TestNamespace
 {
     class PublicClass    : IInterface,    IInterfaceTwo { }
     class PublicClass<T> : IInterface<T>, IInterfaceTwo { }
+    class PublicClass<T> : Dictionary<T, Dictionary<string, string>>, IMap<T, Dictionary<string, string>> { }
 }`;
             let tokens: Token[] = TokenizerUtil.tokenize(input);
 
@@ -89,9 +103,12 @@ namespace TestNamespace
             tokens.should.contain(Tokens.Type("IInterfaceTwo", 4, 43));
 
             tokens.should.contain(Tokens.ClassKeyword("class", 5, 5));
-            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 5, 11));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass<T>", 5, 11));
             tokens.should.contain(Tokens.Type("IInterface<T>", 5, 28));
             tokens.should.contain(Tokens.Type("IInterfaceTwo", 5, 43));
+
+            tokens.should.contain(Tokens.Type("Dictionary<T, Dictionary<string, string>>", 6, 28));
+            tokens.should.contain(Tokens.Type("IMap<T, Dictionary<string, string>>", 6, 71));
         });
 
         it("generic constraints", function() {
@@ -105,13 +122,13 @@ namespace TestNamespace
             let tokens: Token[] = TokenizerUtil.tokenize(input);
 
             tokens.should.contain(Tokens.ClassKeyword("class", 4, 5));
-            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 4, 11));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass<T>", 4, 11));
             tokens.should.contain(Tokens.Keyword("where", 4, 26));
             tokens.should.contain(Tokens.Type("T", 4, 32));
             tokens.should.contain(Tokens.Type("ISomething", 4, 36));
 
             tokens.should.contain(Tokens.ClassKeyword("class", 5, 5));
-            tokens.should.contain(Tokens.ClassIdentifier("PublicClass", 5, 11));
+            tokens.should.contain(Tokens.ClassIdentifier("PublicClass<T, X>", 5, 11));
             tokens.should.contain(Tokens.Type("Dictionary<T, List<string>[]>", 5, 31));
             tokens.should.contain(Tokens.Type("ISomething", 5, 62));
             tokens.should.contain(Tokens.Keyword("where", 5, 73));

--- a/test/syntaxes/field.tests.ts
+++ b/test/syntaxes/field.tests.ts
@@ -28,6 +28,21 @@ public class Tester
             tokens.should.contain(Tokens.FieldIdentifier("field123", 6, 18));
         });
 
+        it("generic", function () {
+
+            const input = `
+public class Tester
+{
+    private Dictionary< List<T>, Dictionary<T, D>> _field;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("private", 4, 5));
+            tokens.should.contain(Tokens.Type("Dictionary< List<T>, Dictionary<T, D>>", 4, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("_field", 4, 52));
+        });
+
 
         it("modifiers", function() {
 

--- a/test/syntaxes/field.tests.ts
+++ b/test/syntaxes/field.tests.ts
@@ -1,0 +1,114 @@
+import { should } from 'chai';
+import { Tokens, Token } from './utils/tokenizer';
+import { TokenizerUtil } from'./utils/tokenizerUtil';
+
+describe("Grammar", function() {
+    before(function() {
+        should();
+    });
+
+    describe("Field", function() {
+        it("declaration", function() {
+
+const input = `
+public class Tester
+{
+    private List _field;
+    private List field;
+    private List field123;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("private", 4, 5));
+            tokens.should.contain(Tokens.Type("List", 4, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("_field", 4, 18));
+
+            tokens.should.contain(Tokens.FieldIdentifier("field", 5, 18));
+            tokens.should.contain(Tokens.FieldIdentifier("field123", 6, 18));
+        });
+
+
+        it("modifiers", function() {
+
+const input = `
+public class Tester
+{
+    private static readonly List _field;
+    readonly string _field;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("private", 4, 5));
+            tokens.should.contain(Tokens.StorageModifierKeyword("static", 4, 13));
+            tokens.should.contain(Tokens.StorageModifierKeyword("readonly", 4, 20));
+            tokens.should.contain(Tokens.Type("List", 4, 29));
+            tokens.should.contain(Tokens.FieldIdentifier("_field", 4, 34));
+        });
+
+        it("types", function() {
+
+const input = `
+public class Tester
+{
+    string field123;
+    string[] field123;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.Type("string", 4, 5));
+            tokens.should.contain(Tokens.FieldIdentifier("field123", 4, 12));
+
+            tokens.should.contain(Tokens.Type("string[]", 5, 5));
+            tokens.should.contain(Tokens.FieldIdentifier("field123", 5, 14));
+        });
+
+        it("assignment", function() {
+
+const input = `
+public class Tester
+{
+    private string field = "hello";
+    const   bool   field = true;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("private", 4, 5));
+            tokens.should.contain(Tokens.Type("string", 4, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("field", 4, 20));
+            tokens.should.contain(Tokens.StringQuoted("hello", 4, 29));
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("const", 5, 5));
+            tokens.should.contain(Tokens.Type("bool", 5, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("field", 5, 20));
+            tokens.should.contain(Tokens.LanguageConstant("true", 5, 28));
+        });
+
+        it("expression body", function() {
+
+const input = `
+public class Tester
+{
+    private string field => "hello";
+    const   bool   field => true;
+}`;
+
+            let tokens: Token[] = TokenizerUtil.tokenize(input);
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("private", 4, 5));
+            tokens.should.contain(Tokens.Type("string", 4, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("field", 4, 20));
+            tokens.should.contain(Tokens.StringQuoted("hello", 4, 30));
+
+            tokens.should.contain(Tokens.StorageModifierKeyword("const", 5, 5));
+            tokens.should.contain(Tokens.Type("bool", 5, 13));
+            tokens.should.contain(Tokens.FieldIdentifier("field", 5, 20));
+            tokens.should.contain(Tokens.LanguageConstant("true", 5, 29));
+        });
+    });
+});
+
+

--- a/test/syntaxes/utils/tokenizer.ts
+++ b/test/syntaxes/utils/tokenizer.ts
@@ -78,5 +78,13 @@ export namespace Tokens {
 
     export const Keyword = (text: string, line?: number, column?: number) =>
         createToken(text, "keyword.other.cs", line, column);
-}
 
+    export const FieldIdentifier = (text: string, line?: number, column?: number) =>
+        createToken(text, "entity.name.variable.cs", line, column);
+
+    export const StringQuoted = (text: string, line?: number, column?: number) =>
+        createToken(text, "string.quoted.double.cs", line, column);
+
+    export const LanguageConstant = (text: string, line?: number, column?: number) =>
+        createToken(text, "constant.language.cs", line, column);
+}

--- a/test/syntaxes/utils/tokenizer.ts
+++ b/test/syntaxes/utils/tokenizer.ts
@@ -73,5 +73,10 @@ export namespace Tokens {
     export const StorageModifierKeyword = (text: string, line?: number, column?: number) =>
         createToken(text, "storage.modifier.cs", line, column);
 
+    export const Type = (text: string, line?: number, column?: number) =>
+        createToken(text, "storage.type.cs", line, column);
+
+    export const Keyword = (text: string, line?: number, column?: number) =>
+        createToken(text, "keyword.other.cs", line, column);
 }
 

--- a/test/syntaxes/utils/tokenizer.ts
+++ b/test/syntaxes/utils/tokenizer.ts
@@ -68,7 +68,7 @@ export namespace Tokens {
         createToken(text, "storage.modifier.cs", line, column);
 
     export const ClassIdentifier = (text: string, line?: number, column?: number) =>
-        createToken(text, "entity.name.type.class.cs", line, column);
+        createToken(text, "storage.type.cs", line, column);
 
     export const StorageModifierKeyword = (text: string, line?: number, column?: number) =>
         createToken(text, "storage.modifier.cs", line, column);


### PR DESCRIPTION
1. Syntax highlighting support for class/interface generic constrains + tests.
2. Much improved fields syntax highlighting  + tests.

Fixes: #757, #960

## Class Declaration and Inheritance

Screenshots are from before I made the above changes around generics, but you get the gist.

### Before
![image](https://cloud.githubusercontent.com/assets/79742/20925475/16f166de-bbaf-11e6-9839-05e4407220f3.png)

### After
![image](https://cloud.githubusercontent.com/assets/79742/20925486/25db1b72-bbaf-11e6-99a7-4628bda002c3.png)

## Class Generic Constraints

### Before

![image](https://cloud.githubusercontent.com/assets/79742/20866202/fdee5b42-ba1e-11e6-8879-20e5e3629ce3.png)

### After

![image](https://cloud.githubusercontent.com/assets/79742/20866239/2ed87c1e-ba20-11e6-86ec-2032fd430226.png)

## Fields

### Before
![image](https://cloud.githubusercontent.com/assets/79742/20869006/25a132c6-ba61-11e6-8d92-d4c63175d10e.png)

### After

![image](https://cloud.githubusercontent.com/assets/79742/20869021/6a4d3924-ba61-11e6-980d-00721c4082d1.png)
