### PR TITLE
Pass editor tab/indentation settings to OmniSharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,6 +365,11 @@
           "type": "number",
           "default": 250,
           "description": "The maximum number of projects to be shown in the 'Select Project' dropdown (maximum 250)."
+        },
+        "omnisharp.useEditorFormattingSettings": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifes whether OmniSharp should use VS Code editor settings for C# code formatting (use of tabs, indentation size)."
         }
       }
     },

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -202,7 +202,7 @@ function launchWindows(launchPath: string, cwd: string, args: string[], envVars:
     }
 
     let argsCopy = args.slice(0); // create copy of args
-    argsCopy.push('--debug');
+    //argsCopy.push('--debug');
     argsCopy.unshift(launchPath);
     argsCopy = [[
         '/s',

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -161,13 +161,14 @@ function launch(cwd: string, args: string[]): Promise<LaunchResult> {
     return PlatformInformation.GetCurrent().then(platformInfo => {
         const options = Options.Read();
 
-        let editorConfig = vscode.workspace.getConfiguration('editor');
-
-        let envVars = {
-            'formattingOptions:useTabs': !editorConfig.get('insertSpaces', true),
-            'formattingOptions:tabSize': editorConfig.get('tabSize', 4),
-            'formattingOptions:indentationSize': editorConfig.get('tabSize', 4)
-        };
+        let envVars = {};
+        if (options.useEditorFormattingSettings) 
+        {
+            let editorConfig = vscode.workspace.getConfiguration('editor');
+            envVars['formattingOptions:useTabs'] = !editorConfig.get('insertSpaces', true);
+            envVars['formattingOptions:tabSize'] = editorConfig.get('tabSize', 4);
+            envVars['formattingOptions:indentationSize'] = editorConfig.get('tabSize', 4);
+        }
 
         if (options.path && options.useMono) {
             return launchNixMono(options.path, cwd, args, envVars);

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -12,7 +12,8 @@ export class Options {
         public loggingLevel?: string,
         public autoStart?: boolean,
         public projectLoadTimeout?: number,
-        public maxProjectResults?: number) { }
+        public maxProjectResults?: number,
+        public useEditorFormattingSettings?: boolean) { }
 
     public static Read(): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -37,7 +38,8 @@ export class Options {
 
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
+        const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
 
-        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults);
+        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings);
     }
 }


### PR DESCRIPTION
This should fix #834 and related issues.

This PR ensures that we pass VS Code `editor.*` settings related to tabs/indentation into OmniSharp (through environment variables, which OmniSharp already supports - no changes needed there). This way, when invoking commands such as `Format Document`, we will respect the user set up in his VS Code, rather than imposing OmniSharp defaults (spaces over tabs, 4 spaces indentation).

This feature can be opt out from by setting `omnisharp.useEditorFormattingSettings` to `false`.

Additionally, OmniSharp has its own tab vs spaces and indentation rules that can be controlled using `omnisharp.json`. If this file is present in the current working directory, it will still take precedence as it was in the past - no change there.