### PR TITLE
added auto-closing and surrounding pairs configuration

### DIFF
--- a/csharp.configuration.json
+++ b/csharp.configuration.json
@@ -1,11 +1,27 @@
 {
-	"comments": {
-		"lineComment": "//",
-		"blockComment": ["/*", "*/"]
-	},
-	"brackets": [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"]
-	]
+    "comments": {
+        "lineComment": "//",
+        "blockComment": ["/*", "*/"]
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
+        { "open": "/*", "close": " */", "notIn": ["string"] }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"],
+        ["'", "'"],
+        ["\"", "\""]
+    ]
 }


### PR DESCRIPTION
Just a suggestion - automatically closing quotes and braces - just like it's the case in other [curly brace languages](https://github.com/Microsoft/vscode/blob/master/extensions/typescript/language-configuration.json) in VS Code.