### PR TITLE
Update README.md to mention Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The C# extension now supports basic debugging capabilities! See http://aka.ms/vs
 First install:
 * Node.js (newer than 4.3.1)
 * Npm (newer 2.14.12)
+* Python 2.7
 
 In case you get a *node-gyp* error [follow the instrutions here](https://github.com/nodejs/node-gyp/blob/master/README.md) to fix it. The *vscode-textmate* package pulls in a native node dependency and those instructions will set up the node build tool which deals with those.
 


### PR DESCRIPTION
Python 2.7 is required on Windows to install dependencies. I am assuming it is required on other platforms too, but since npm itself requires it on Linux, and I don't have a spare Mac to verify, I can't say for sure.