### PR TITLE
Removing unused imports in ProcessPicker.ts

### DIFF
--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -6,8 +6,6 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
 
 export interface AttachItem extends vscode.QuickPickItem {
     id: string;


### PR DESCRIPTION
Accidentally left imports when simplifying the remote process picker.