### PR TITLE
Asset generator should not offer to update tasks.json if there are build tasks

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -397,7 +397,7 @@ function getBuildOperations(tasksJsonPath: string) {
 
                     let buildTasks = getBuildTasks(tasksConfiguration);
 
-                    resolve({ updateTasksJson: (buildTasks.length > 0) });
+                    resolve({ updateTasksJson: buildTasks.length === 0 });
                 });
             }
             else {


### PR DESCRIPTION
This fixes a logic error in the asset generator that causes the prompt to generate assets to appear even if the assets already exist.