### PR TITLE
Allow configuring any supported Omnisharp log level

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,10 +356,14 @@
         },
         "omnisharp.loggingLevel": {
           "type": "string",
-          "default": "default",
+          "default": "information",
           "enum": [
-            "default",
-            "verbose"
+            "trace",
+            "debug",
+            "information",
+            "warning",
+            "error",
+            "critical"
           ],
           "description": "Specifies the level of logging output from the OmniSharp server."
         },

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -33,7 +33,12 @@ export class Options {
             ? csharpConfig.get<boolean>('omnisharpUsesMono')
             : omnisharpConfig.get<boolean>('useMono');
 
-        const loggingLevel = omnisharpConfig.get<string>('loggingLevel');
+        // support the legacy "verbose" level as "debug"
+        let loggingLevel = omnisharpConfig.get<string>('loggingLevel');
+        if (loggingLevel.toLowerCase() === 'verbose') {
+            loggingLevel = 'debug';
+        }
+
         const autoStart = omnisharpConfig.get<boolean>('autoStart', true);
 
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -235,19 +235,16 @@ export class OmniSharpServer {
 
         const solutionPath = launchTarget.target;
         const cwd = path.dirname(solutionPath);
+        this._options = Options.Read();
+        
         let args = [
             '-s', solutionPath,
             '--hostPID', process.pid.toString(),
             '--stdio',
             'DotNet:enablePackageRestore=false',
-            '--encoding', 'utf-8'
+            '--encoding', 'utf-8',
+            '-loglevel', this._options.loggingLevel
         ];
-
-        this._options = Options.Read();
-
-        if (this._options.loggingLevel === 'verbose') {
-            args.push('-v');
-        }
 
         this._logger.appendLine(`Starting OmniSharp server at ${new Date().toLocaleString()}`);
         this._logger.increaseIndent();

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -243,7 +243,7 @@ export class OmniSharpServer {
             '--stdio',
             'DotNet:enablePackageRestore=false',
             '--encoding', 'utf-8',
-            '-loglevel', this._options.loggingLevel
+            '--loglevel', this._options.loggingLevel
         ];
 
         this._logger.appendLine(`Starting OmniSharp server at ${new Date().toLocaleString()}`);


### PR DESCRIPTION
Fixes #993 

This PR allows the user to set any log level that Omnisharp supports in the user settings.

The default is `information`.

Note 1: that this is technically a breaking change, since I removed the old `verbose` log level as it doesn't exist in Omnisharp and replaced the allowed values with the ones Omnisharp can understand (if it's critical, we can bring back that `verbose` level and map to `debug` but I think this is a fringe feature and there is no need for such "phase out"). 

Note 2: this only works with latest Omnisharp builds, but that has already been included into the latest C# extension.