### PR TITLE
Update build task to launch "npm run compile"

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,8 +1,14 @@
 {
 	"version": "0.1.0",
-	"command": "gulp",
-	"isShellCommand": true,
 	"tasks": [
+		{
+			"taskName": "build",
+			"command": "npm",
+			"isShellCommand": true,
+			"args": ["run", "compile"],
+			"showOutput": "always",
+			"isBuildCommand": true
+		},
 		{
 			"taskName": "test",
 			"showOutput": "always",
@@ -10,7 +16,9 @@
 		},
 		{
 			"taskName": "tslint",
-			"args": [],
+			"command": "gulp",
+			"isShellCommand": true,
+			"args": ["tslint"],
 			"problemMatcher": {
 				"owner": "tslint",
 				"fileLocation": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,10 @@
 		},
 		{
 			"taskName": "test",
+			"command": "echo",
 			"showOutput": "always",
+			"isShellCommand": true,
+			"args": ["Run tests in VS Code by launching the debugg with the 'Launch Tests' configuration."],
 			"isTestCommand": true
 		},
 		{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,18 +145,6 @@ gulp.task('package:offline', ['clean'], () => {
     return promise;
 });
 
-/// Test Task
-gulp.task('test', () => {
-    gulp.src('out/test/**/*.tests.js')
-        .pipe(mocha({ ui: "tdd" }))
-        .once('error', () => {
-            process.exit(1);
-        })
-        .once('end', () => {
-            process.exit();
-        });
-});
-
 /// Misc Tasks
 const allTypeScript = [
     'src/**/*.ts',


### PR DESCRIPTION
This uses the new tasks.json support in VS Code 1.9 to allow tasks to run different commands. So, now you should be able to build with <kbd>Cmd+Shift+B</kbd> in VS Code.