### PR TITLE
Don't show message about projects having trouble loading when there are only warnings

### DIFF
--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -241,7 +241,10 @@ export function reportServerStatus(server: OmniSharpServer): vscode.Disposable{
             message.Errors.forEach(error => asErrorMessage);
             message.Warnings.forEach(warning => asWarningMessage);
             appendLine();
-            showMessageSoon();
+
+            if (message.Errors.length > 0) {
+                showMessageSoon();
+            }
         }
     });
 


### PR DESCRIPTION
Fixes #707

C# for VS Code is a little over-excited about showing the message that there were problems loading projects. Essentially, it will show it if there were warnings or errors. This changes that behavior to only show it if there are errors because it's perfectly reasonable for a project to contain warnings and not complain to the user every time they open it.