### PR TITLE
Fix dotnet restore for project.json

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -85,7 +85,7 @@ interface Command {
 
 function projectsToCommands(projects: protocol.ProjectDescriptor[]): Promise<Command>[] {
     return projects.map(project => {
-        let projectDirectory = project.Path;
+        let projectDirectory = project.Directory;
 
         return new Promise<Command>((resolve, reject) => {
             fs.lstat(projectDirectory, (err, stats) => {
@@ -98,7 +98,7 @@ function projectsToCommands(projects: protocol.ProjectDescriptor[]): Promise<Com
                 }
 
                 resolve({
-                    label: `dotnet restore - (${project.Name || path.basename(project.Path)})`,
+                    label: `dotnet restore - (${project.Name || path.basename(project.Directory)})`,
                     description: projectDirectory,
                     execute() {
                         return dotnetRestore(projectDirectory);
@@ -117,13 +117,13 @@ export function dotnetRestoreAllProjects(server: OmniSharpServer) {
 
     return serverUtils.requestWorkspaceInformation(server).then(info => {
 
-        let projectDescriptors = protocol.getDotNetCoreProjectDescriptors(info);
+        let descriptors = protocol.getDotNetCoreProjectDescriptors(info);
 
-        if (projectDescriptors.length === 0) {
+        if (descriptors.length === 0) {
             return Promise.reject("No .NET Core projects found");
         }
 
-        let commandPromises = projectsToCommands(projectDescriptors);
+        let commandPromises = projectsToCommands(descriptors);
 
         return Promise.all(commandPromises).then(commands => {
             return vscode.window.showQuickPick(commands);
@@ -135,7 +135,7 @@ export function dotnetRestoreAllProjects(server: OmniSharpServer) {
     });
 }
 
-export function dotnetRestoreForProject(server: OmniSharpServer, fileName: string) {
+export function dotnetRestoreForProject(server: OmniSharpServer, filePath: string) {
 
     if (!server.isRunning()) {
         return Promise.reject('OmniSharp server is not running.');
@@ -143,23 +143,21 @@ export function dotnetRestoreForProject(server: OmniSharpServer, fileName: strin
 
     return serverUtils.requestWorkspaceInformation(server).then(info => {
 
-        let projectDescriptors = protocol.getDotNetCoreProjectDescriptors(info);
+        let descriptors = protocol.getDotNetCoreProjectDescriptors(info);
 
-        if (projectDescriptors.length === 0) {
+        if (descriptors.length === 0) {
             return Promise.reject("No .NET Core projects found");
         }
 
-        let directory = path.dirname(fileName);
-
-        for (let projectDescriptor of projectDescriptors) {
-            if (projectDescriptor.Path === fileName) {
-                return dotnetRestore(directory, fileName);
+        for (let descriptor of descriptors) {
+            if (descriptor.FilePath === filePath) {
+                return dotnetRestore(descriptor.Directory, filePath);
             }
         }
     });
 }
 
-function dotnetRestore(cwd: string, fileName?: string) {
+function dotnetRestore(cwd: string, filePath?: string) {
     return new Promise<void>((resolve, reject) => {
         channel.clear();
         channel.show();
@@ -167,8 +165,8 @@ function dotnetRestore(cwd: string, fileName?: string) {
         let cmd = 'dotnet';
         let args = ['restore'];
 
-        if (fileName) {
-            args.push(fileName);
+        if (filePath) {
+            args.push(filePath);
         }
 
         let dotnet = cp.spawn(cmd, args, { cwd: cwd, env: process.env });

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -523,7 +523,8 @@ export function findNetStandardTargetFramework(project: MSBuildProject): TargetF
 
 export interface ProjectDescriptor {
     Name: string;
-    Path: string;
+    Directory: string;
+    FilePath: string;
 }
 
 export function getDotNetCoreProjectDescriptors(info: WorkspaceInformationResponse): ProjectDescriptor[] {
@@ -531,7 +532,11 @@ export function getDotNetCoreProjectDescriptors(info: WorkspaceInformationRespon
 
     if (info.DotNet && info.DotNet.Projects.length > 0) {
         for (let project of info.DotNet.Projects) {
-            result.push({ Name: project.Name, Path: project.Path });
+            result.push({
+                Name: project.Name,
+                Directory: project.Path,
+                FilePath: path.join(project.Path, 'project.json')
+            });
         }
     }
 
@@ -539,7 +544,11 @@ export function getDotNetCoreProjectDescriptors(info: WorkspaceInformationRespon
         for (let project of info.MsBuild.Projects) {
             if (findNetCoreAppTargetFramework(project) !== undefined ||
                 findNetStandardTargetFramework(project) !== undefined) {
-                result.push({ Name: path.basename(project.Path), Path: project.Path });
+                result.push({
+                    Name: path.basename(project.Path),
+                    Directory: path.dirname(project.Path),
+                    FilePath: project.Path
+                });
             }
         }
     }


### PR DESCRIPTION
In fixing dotnet restore for .csproj, I unintentionally broke it for project.json. The problem here is that OmniSharp returns different information for `Path` with regard to project.json or .csproj. For project.json, it's the directory that the project.json lives in, and for .csproj, it's the actually file path. This change addresses that by adding a `FilePath` property to our `ProjectDescriptor` which represents the real file path and renamed `Path` to `Directory` to be a bit clearer.

cc @jchannon