### PR TITLE
Remove "or use Command Prompt"

### DIFF
--- a/debugger.md
+++ b/debugger.md
@@ -39,7 +39,7 @@ The first time that C# code is opened in VS Code, the extension will download th
 The following steps have to executed for every project. 
 
 ##### 1: Get a project
-You can start from scratch by creating an empty project with `dotnet new`. Begin by opening the terminal in Visual Studio Code (`View->Integrated Terminal`) or use Command Prompt and type these commands:
+You can start from scratch by creating an empty project with `dotnet new`. Begin by opening the terminal in Visual Studio Code (`View->Integrated Terminal`) and type these commands:
 
     cd ~
     mkdir MyApplication


### PR DESCRIPTION
As noted by @rajkumar42 there is a command that won't work in Command Prompt (`cd ~`). Removing the option to use command prompt to avoid confusing other readers.