### PR TITLE
discover CSX files as launch targets

### DIFF
--- a/src/features/status.ts
+++ b/src/features/status.ts
@@ -26,7 +26,8 @@ let defaultSelector: vscode.DocumentSelector = [
     'csharp', // c#-files OR
     { pattern: '**/project.json' }, // project.json-files OR
     { pattern: '**/*.sln' }, // any solution file OR
-    { pattern: '**/*.csproj' } // an csproj file
+    { pattern: '**/*.csproj' }, // an csproj file
+    { pattern: '**/*.csx' } // C# script
 ];
 
 class Status {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -73,7 +73,8 @@ function select(resources: vscode.Uri[], rootPath: string): LaunchTarget[] {
         hasCsProjFiles = false,
         hasSlnFile = false,
         hasProjectJson = false,
-        hasProjectJsonAtRoot = false;
+        hasProjectJsonAtRoot = false,
+        hasCSX = false;
 
     hasCsProjFiles = resources.some(isCSharpProject);
 
@@ -106,17 +107,9 @@ function select(resources: vscode.Uri[], rootPath: string): LaunchTarget[] {
             });
         }
 
-        // Add CSX files
+        // Discover CSX files
         if (isCsx(resource)) {
-            const dirname = path.dirname(resource.fsPath);
-
-            targets.push({
-                label: path.basename(resource.fsPath),
-                description: vscode.workspace.asRelativePath(path.dirname(resource.fsPath)),
-                target: dirname,
-                directory: dirname,
-                kind: LaunchTargetKind.Csx
-            });
+            hasCSX = true;
         }
     });
 
@@ -130,6 +123,17 @@ function select(resources: vscode.Uri[], rootPath: string): LaunchTarget[] {
             target: rootPath,
             directory: rootPath,
             kind: LaunchTargetKind.Folder
+        });
+    }
+
+    // if we noticed any CSX file(s), add a single CSX-specific target pointing at the root folder
+    if (hasCSX) {
+        targets.push({
+            label: "CSX",
+            description: path.basename(rootPath),
+            target: rootPath,
+            directory: rootPath,
+            kind: LaunchTargetKind.Csx
         });
     }
 

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -16,7 +16,8 @@ import { Options } from './options';
 export enum LaunchTargetKind {
     Solution,
     ProjectJson,
-    Folder
+    Folder,
+    Csx
 }
 
 /**
@@ -44,7 +45,7 @@ export function findLaunchTargets(): Thenable<LaunchTarget[]> {
     const options = Options.Read();
 
     return vscode.workspace.findFiles(
-        /*include*/ '{**/*.sln,**/*.csproj,**/project.json}', 
+        /*include*/ '{**/*.sln,**/*.csproj,**/project.json,**/*.csx}', 
         /*exclude*/ '{**/node_modules/**,**/.git/**,**/bower_components/**}',
         /*maxResults*/ options.maxProjectResults)
     .then(resources => {
@@ -104,6 +105,19 @@ function select(resources: vscode.Uri[], rootPath: string): LaunchTarget[] {
                 kind: LaunchTargetKind.ProjectJson
             });
         }
+
+        // Add CSX files
+        if (isCsx(resource)) {
+            const dirname = path.dirname(resource.fsPath);
+
+            targets.push({
+                label: path.basename(resource.fsPath),
+                description: vscode.workspace.asRelativePath(path.dirname(resource.fsPath)),
+                target: dirname,
+                directory: dirname,
+                kind: LaunchTargetKind.Csx
+            });
+        }
     });
 
     // Add the root folder under the following circumstances:
@@ -132,6 +146,10 @@ function isSolution(resource: vscode.Uri): boolean {
 
 function isProjectJson(resource: vscode.Uri): boolean {
     return /\project.json$/i.test(resource.fsPath);
+}
+
+function isCsx(resource: vscode.Uri): boolean {
+    return /\.csx$/i.test(resource.fsPath);
 }
 
 export interface LaunchResult {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -107,8 +107,8 @@ function select(resources: vscode.Uri[], rootPath: string): LaunchTarget[] {
             });
         }
 
-        // Discover CSX files
-        if (isCsx(resource)) {
+        // Discover if there is any CSX file
+        if (!hasCSX && isCsx(resource)) {
             hasCSX = true;
         }
     });

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -350,11 +350,11 @@ export class OmniSharpServer {
     public autoStart(preferredPath: string): Thenable<void> {
         return findLaunchTargets().then(launchTargets => {
             // If there aren't any potential launch targets, we create file watcher and try to
-            // start the server again once a *.sln, *.csproj or project.json file is created.
+            // start the server again once a *.sln, *.csproj, project.json or CSX file is created.
             if (launchTargets.length === 0) {
                 return new Promise<void>((resolve, reject) => {
                     // 1st watch for files
-                    let watcher = vscode.workspace.createFileSystemWatcher('{**/*.sln,**/*.csproj,**/project.json}',
+                    let watcher = vscode.workspace.createFileSystemWatcher('{**/*.sln,**/*.csproj,**/project.json,**/*.csx}',
                         /*ignoreCreateEvents*/ false,
                         /*ignoreChangeEvents*/ true,
                         /*ignoreDeleteEvents*/ true);


### PR DESCRIPTION
This PR enables CSX to be discovered as valid OmniSharp launch points. 
Allows CSX intellisense / language services to be used without a "fake" `project.json` that's currently needed (for OmniSharp to light up).

<img width="605" alt="screenshot 2017-02-15 23 46 16" src="https://cloud.githubusercontent.com/assets/1710369/23043329/2bf2d812-f49c-11e6-89e2-c319f0465846.png">
  