### PR TITLE
Add 'console' to launch.json schema

### DIFF
--- a/debugger.md
+++ b/debugger.md
@@ -118,13 +118,13 @@ Environment variables may be passed to your program using this schema:
     }
 
 #####Console (terminal) window
-By default, processes are launched with their console output (stdout/stderr) going to the VS Code Debugger Console. This is useful for executables that take their input file files, the network, etc. But this does NOT work for applications that want to read from the console (ex: `Console.ReadLine`). For these applications, use a setting such as the following:
+By default, processes are launched with their console output (stdout/stderr) going to the VS Code Debugger Console. This is useful for executables that take their input from the network, files, etc. But this does NOT work for applications that want to read from the console (ex: `Console.ReadLine`). For these applications, use a setting such as the following:
 
     "console": "integratedTerminal"
 
-When this is set to `integratedTerminal` the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneith the editor to interact with your application.
+When this is set to `integratedTerminal` the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneath the editor to interact with your application.
 
-When this is set to `externalTerminal` the target process will run in a seperate terminal.
+When this is set to `externalTerminal` the target process will run in a separate terminal.
 
 ##### Stepping into properties and operators
 The debugger steps over properties and operators in managed code by default. In most cases, this provides a better debugging experience. To change this and enable stepping into properties or operators add:

--- a/debugger.md
+++ b/debugger.md
@@ -117,10 +117,14 @@ Environment variables may be passed to your program using this schema:
         "myVariableName":"theValueGoesHere"
     }
 
-#####External console (terminal) window
-The target process can optionally launch into a separate console window. You will want this if your console app takes console input (ex: Console.ReadLine). This can be enabled with:
+#####Console (terminal) window
+By default, processes are launched with their console output (stdout/stderr) going to the VS Code Debugger Console. This is useful for executables that take their input file files, the network, etc. But this does NOT work for applications that want to read from the console (ex: `Console.ReadLine`). For these applications, use a setting such as the following:
 
-    "externalConsole": true
+    "console": "integratedTerminal"
+
+When this is set to `integratedTerminal` the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneith the editor to interact with your application.
+
+When this is set to `externalTerminal` the target process will run in a seperate terminal.
 
 ##### Stepping into properties and operators
 The debugger steps over properties and operators in managed code by default. In most cases, this provides a better debugging experience. To change this and enable stepping into properties or operators add:

--- a/package.json
+++ b/package.json
@@ -618,9 +618,24 @@
                 "description": "Environment variables passed to the program.",
                 "default": {}
               },
+              "console": {
+                "type": "string",
+                "enum": [
+                  "internalConsole",
+                  "integratedTerminal",
+                  "externalTerminal"
+                ],
+                "enumDescriptions": [
+                  "Output to the VS Code Debug Console. This doesn't support reading console input (ex:Console.ReadLine)",
+                  "VS Code's integrated terminal",
+                  "External terminal that can be configured via user settings"
+                ],
+                "description": "Where to launch the debug target.",
+                "default": "internalConsole"
+              },
               "externalConsole": {
                 "type": "boolean",
-                "description": "If 'true' the debugger should launch the target application into a new external console.",
+                "description": "Attribute 'externalConsole' is deprecated, use 'console' instead.",
                 "default": false
               },
               "sourceFileMap": {
@@ -1111,7 +1126,7 @@
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
-            "externalConsole": false
+            "console": "internalConsole"
           },
           {
             "name": ".NET Core Launch (web)",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -27,7 +27,7 @@ interface ConsoleLaunchConfiguration extends DebugConfiguration {
     cwd: string;
     stopAtEntry: boolean;
     env?: any;
-    externalConsole?: boolean;
+    console?: string;
 }
 
 interface CommandLine {
@@ -188,7 +188,7 @@ export class AssetGenerator {
             program: this.computeProgramPath(),
             args: [],
             cwd: '${workspaceRoot}',
-            externalConsole: false,
+            console: "internalConsole",
             stopAtEntry: false,
             internalConsoleOptions: "openOnSessionStart"
         };

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -273,9 +273,20 @@
                     "description": "Environment variables passed to the program.",
                     "default": {}
                 },
+                "console": {
+                    "type": "string",
+                    "enum": [ "internalConsole", "integratedTerminal", "externalTerminal" ],
+                    "enumDescriptions": [
+                        "Output to the VS Code Debug Console. This doesn't support reading console input (ex:Console.ReadLine)",
+                        "VS Code's integrated terminal",
+                        "External terminal that can be configured via user settings"
+                    ],
+                    "description": "Where to launch the debug target.",
+                    "default": "internalConsole"
+                },
                 "externalConsole": {
                     "type": "boolean",
-                    "description": "If 'true' the debugger should launch the target application into a new external console.",
+                    "description": "Attribute 'externalConsole' is deprecated, use 'console' instead.",
                     "default": false
                 },
                 "sourceFileMap": {


### PR DESCRIPTION
This checkin completes the external (and integrated) console work by updating the launch.json schema to add the new attributes. I also updated the documentation and templates.