### PR TITLE
Clean up and adding required fields.

### DIFF
--- a/package.json
+++ b/package.json
@@ -703,7 +703,6 @@
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
                 "type": "object",
                 "required": [
-                  "pipeProgram",
                   "debuggerPath"
                 ],
                 "default": {
@@ -947,7 +946,6 @@
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
                 "type": "object",
                 "required": [
-                  "pipeProgram",
                   "debuggerPath"
                 ],
                 "default": {

--- a/package.json
+++ b/package.json
@@ -696,22 +696,16 @@
                     "type": "boolean",
                     "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
                     "default": false
-                  },
-                  "trace": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the output window.",
-                    "default": false
-                  },
-                  "traceResponse": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
-                    "default": false
                   }
                 }
               },
               "pipeTransport": {
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
                 "type": "object",
+                "required": [
+                  "pipeProgram",
+                  "debuggerPath"
+                ],
                 "default": {
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
@@ -946,22 +940,16 @@
                     "type": "boolean",
                     "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
                     "default": false
-                  },
-                  "trace": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the output window.",
-                    "default": false
-                  },
-                  "traceResponse": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
-                    "default": false
                   }
                 }
               },
               "pipeTransport": {
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
                 "type": "object",
+                "required": [
+                  "pipeProgram",
+                  "debuggerPath"
+                ],
                 "default": {
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -44,6 +44,7 @@
         },
         "PipeTransport": {
             "type": "object",
+            "required": ["pipeProgram", "debuggerPath"],
             "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
             "default": {
                 "pipeCwd": "${workspaceRoot}",
@@ -136,16 +137,6 @@
                 "engineLogging": {
                     "type": "boolean",
                     "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
-                    "default": false
-                },
-                "trace": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the output window.",
-                    "default": false
-                },
-                "traceResponse": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the output window.",
                     "default": false
                 }
             }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -44,7 +44,7 @@
         },
         "PipeTransport": {
             "type": "object",
-            "required": ["pipeProgram", "debuggerPath"],
+            "required": ["debuggerPath"],
             "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
             "default": {
                 "pipeCwd": "${workspaceRoot}",


### PR DESCRIPTION
Requiring pipeProgram and debuggerPath to PipeTransport.
Removing trace and trace response as they have been merged into engine
logging.

This replaces: #1171 #1207 

@gregg-miskelly 