### PR TITLE
Adding support for Zorin 12.1 OS

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -266,6 +266,7 @@ export class PlatformInformation {
 
         switch (distributionName) {
             case 'Zorin OS':
+            case 'zorin': // ID changed in 12.1
                 if (distributionVersion === "12") {
                     return ubuntu_16_04;
                 }


### PR DESCRIPTION
ID is now set as zorin in 12.1 instead of Zorin OS