### PR TITLE
Rename 'clrdbg' to 'vsdbg' in the schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -705,7 +705,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -714,7 +714,7 @@
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -738,7 +738,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
+                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
                   },
                   "pipeEnv": {
                     "type": "object",
@@ -953,7 +953,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -962,7 +962,7 @@
                   "pipeCwd": "${workspaceRoot}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -986,7 +986,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
+                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
                   },
                   "pipeEnv": {
                     "type": "object",

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -45,12 +45,12 @@
         "PipeTransport": {
             "type": "object",
             "required": ["debuggerPath"],
-            "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg).",
+            "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
             "default": {
                 "pipeCwd": "${workspaceRoot}",
                 "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                 "pipeArgs": [],
-                "debuggerPath" : "enter the path for the debugger on the target machine, for example ~/clrdbg/clrdbg"
+                "debuggerPath" : "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
             },
             "properties": {
                 "pipeCwd": {
@@ -74,7 +74,7 @@
                 "debuggerPath" : {
                     "type" : "string",
                     "description" : "The full path to the debugger on the target machine.",
-                    "default" : "~/clrdbg/clrdbg"
+                    "default" : "~/vsdbg/vsdbg"
                 },
                 "pipeEnv": {
                     "type": "object",
@@ -324,7 +324,7 @@
                 },
                 "pipeTransport": {
                     "$ref": "#/definitions/PipeTransport",
-                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg)."
+                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
                 }
             }
         },
@@ -390,7 +390,7 @@
                 },
                 "pipeTransport": {
                     "$ref": "#/definitions/PipeTransport",
-                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (clrdbg)."
+                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
                 }
             }
         }


### PR DESCRIPTION
The schema still referred to clrdbg. This fixes it.