### PR TITLE
Clarify and shorten watch NPM task description [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To **run and develop** do the following:
 * Run `npm i`
 * Run `npm run compile`
 * Open in Visual Studio Code (`code .`)
-* *Optional:* run `tsc -w`, make code changes (on Windows, try `start node ".\node_modules\typescript\bin\tsc -w"`)
+* *Optional:* run `npm run watch`, make code changes
 * Press <kbd>F5</kbd> to debug
 
 To **test** do the following: `npm run test` or <kbd>F5</kbd> in VS Code with the "Launch Tests" debug configuration.


### PR DESCRIPTION
The `tsc` can be run from already defined NPM script and by this:

- no local installation is needed for compiler
- the long path for Windows OS command is no longer required

Usage:
npm run watch

> csharp@1.8.0 watch /Users/piotrblazejewicz/git/omnisharp-vscode
> tsc -watch -p ./

3:19:52 PM - Compilation complete. Watching for file changes.
...

Thanks!