### PR TITLE
Switch from deprecated outDir to outFiles in tasks config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/src"
+            "outFiles": [
+                "${workspaceRoot}/out/src/**/*.js"
+            ]
         },
         {
             "name": "Launch Tests",
@@ -21,7 +23,9 @@
             "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out/test"
+            "outFiles": [
+                "${workspaceRoot}/out/test/**/*.js"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This commit updates tasks configuration to use current
configuration keys and to limit number of warnings displayed in
VSCode itself (at least in my installation of insider build).


Similar one:
Microsoft/vscode-generator-code#59

Thanks!