### PR TITLE
Add '"' and ':' as trigger characters for project.json completion

### DIFF
--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -45,7 +45,8 @@ export function addJSONProviders(): Disposable {
     let contributions = [new ProjectJSONContribution(xhr)];
     contributions.forEach(contribution => {
         let selector = contribution.getDocumentSelector();
-        subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution), '"', ':'));
+        let triggerCharacters = ['"', ':', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+        subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution), ...triggerCharacters));
         subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
     });
 

--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -45,7 +45,7 @@ export function addJSONProviders(): Disposable {
     let contributions = [new ProjectJSONContribution(xhr)];
     contributions.forEach(contribution => {
         let selector = contribution.getDocumentSelector();
-        subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution)));
+        subscriptions.push(languages.registerCompletionItemProvider(selector, new JSONCompletionItemProvider(contribution), '"', ':'));
         subscriptions.push(languages.registerHoverProvider(selector, new JSONHoverProvider(contribution)));
     });
 

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -105,6 +105,7 @@ export class ProjectJSONContribution implements IJSONContribution {
                             let proposal = new CompletionItem(name);
                             proposal.kind = CompletionItemKind.Property;
                             proposal.insertText = insertText;
+                            proposal.filterText = JSON.stringify(name);
                             result.add(proposal);
                         }
                         if (results.length === LIMIT) {


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1277

This defines additional characters that should trigger completion in project.json files.

![image](https://cloud.githubusercontent.com/assets/116161/24159875/8eea5e78-0e1d-11e7-873a-a11affe96658.png)

![image](https://cloud.githubusercontent.com/assets/116161/24159864/896bd60c-0e1d-11e7-8994-ac8e7231749b.png)
