### PR TITLE
Always use posix paths in asset generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### Other Updates and Fixes
 
 * Improvements made to project.json package completion experience. ([#1338](https://github.com/OmniSharp/omnisharp-vscode/pull/1338))
+* Assets for building and debugging are now always generated with POSIX style paths. ([#1354](https://github.com/OmniSharp/omnisharp-vscode/pull/1354))
 
 ## 1.8.0 (March 10, 2017)
 

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -194,15 +194,20 @@ export class AssetGenerator {
         return result;
     }
 
+    private convertNativePathToPosix(pathString: string) : string {
+        let parts = pathString.split(path.sep);
+        return parts.join(path.posix.sep);
+    }
+
     private createLaunchConfiguration(): ConsoleLaunchConfiguration {
         return {
             name: '.NET Core Launch (console)',
             type: 'coreclr',
             request: 'launch',
             preLaunchTask: 'build',
-            program: this.computeProgramPath(),
+            program: this.convertNativePathToPosix(this.computeProgramPath()),
             args: [],
-            cwd: this.computeWorkingDirectory(),
+            cwd: this.convertNativePathToPosix(this.computeWorkingDirectory()),
             console: "internalConsole",
             stopAtEntry: false,
             internalConsoleOptions: "openOnSessionStart"
@@ -215,9 +220,9 @@ export class AssetGenerator {
             type: 'coreclr',
             request: 'launch',
             preLaunchTask: 'build',
-            program: this.computeProgramPath(),
+            program: this.convertNativePathToPosix(this.computeProgramPath()),
             args: [],
-            cwd: this.computeWorkingDirectory(),
+            cwd: this.convertNativePathToPosix(this.computeWorkingDirectory()),
             stopAtEntry: false,
             internalConsoleOptions: "openOnSessionStart",
             launchBrowser: {
@@ -282,7 +287,7 @@ export class AssetGenerator {
 
         return {
             taskName: 'build',
-            args: [buildPath],
+            args: [this.convertNativePathToPosix(buildPath)],
             isBuildCommand: true,
             problemMatcher: '$msCompile'
         };

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -19,7 +19,7 @@ suite("Asset generation: project.json", () => {
         let buildPath = tasksJson.tasks[0].args[0];
 
         // ${workspaceRoot}/project.json
-        let segments = buildPath.split(path.sep);
+        let segments = buildPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'project.json']);
     });
 
@@ -31,7 +31,7 @@ suite("Asset generation: project.json", () => {
         let buildPath = tasksJson.tasks[0].args[0];
 
         // ${workspaceRoot}/nested/project.json
-        let segments = buildPath.split(path.sep);
+        let segments = buildPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'project.json']);
     });
 
@@ -43,7 +43,7 @@ suite("Asset generation: project.json", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -55,7 +55,7 @@ suite("Asset generation: project.json", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -67,7 +67,7 @@ suite("Asset generation: project.json", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -79,7 +79,7 @@ suite("Asset generation: project.json", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 });
@@ -127,7 +127,7 @@ suite("Asset generation: csproj", () => {
         let buildPath = tasksJson.tasks[0].args[0];
 
         // ${workspaceRoot}/project.json
-        let segments = buildPath.split(path.sep);
+        let segments = buildPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'testApp.csproj']);
     });
 
@@ -139,7 +139,7 @@ suite("Asset generation: csproj", () => {
         let buildPath = tasksJson.tasks[0].args[0];
 
         // ${workspaceRoot}/nested/project.json
-        let segments = buildPath.split(path.sep);
+        let segments = buildPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'testApp.csproj']);
     });
 
@@ -151,7 +151,7 @@ suite("Asset generation: csproj", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -163,7 +163,7 @@ suite("Asset generation: csproj", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -175,7 +175,7 @@ suite("Asset generation: csproj", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
@@ -187,7 +187,7 @@ suite("Asset generation: csproj", () => {
         let programPath = launchJson.configurations[0].program;
 
         // ${workspaceRoot}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.sep);
+        let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceRoot}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 });


### PR DESCRIPTION
We were using native 'path.join' when creating paths for VS Code assets
(tasks.json, launch.json). On windows this would produce windows style
paths. If the assets are checked into source control and used on posix
systems, they will break. Posix paths will run perfectly fine on
windows, so always use posix paths.