### PR TITLE
Update OmniSharp and add support for running/debugging tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.14.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.14.0.1.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
@@ -130,7 +130,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.14.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.14.0.1.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
@@ -141,7 +141,7 @@
     },
     {
       "description": "OmniSharp (Mono 4.6)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.14.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.14.0.1.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.9.0-beta2",
+  "version": "1.9.0-beta3",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.11.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.14.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
@@ -130,7 +130,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.11.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.14.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "win32"
@@ -141,7 +141,7 @@
     },
     {
       "description": "OmniSharp (Mono 4.6)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.11.0.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.14.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
         "darwin",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -11,6 +11,7 @@ import { OmniSharpServer } from './omnisharp/server';
 import * as serverUtils from './omnisharp/utils';
 import * as protocol from './omnisharp/protocol';
 import { tolerantParse } from './json';
+import * as util from './common';
 
 export class AssetGenerator {
     public rootPath: string;
@@ -154,11 +155,6 @@ export class AssetGenerator {
         return result;
     }
 
-    private convertNativePathToPosix(pathString: string) : string {
-        let parts = pathString.split(path.sep);
-        return parts.join(path.posix.sep);
-    }
-
     private createLaunchConfiguration(): string{
         return `
 {
@@ -167,9 +163,9 @@ export class AssetGenerator {
     "request": "launch",
     "preLaunchTask": "build",
     // If you have changed target frameworks, make sure to update the program path.
-    "program": "${this.convertNativePathToPosix(this.computeProgramPath())}",
+    "program": "${util.convertNativePathToPosix(this.computeProgramPath())}",
     "args": [],
-    "cwd": "${this.convertNativePathToPosix(this.computeWorkingDirectory())}",
+    "cwd": "${util.convertNativePathToPosix(this.computeWorkingDirectory())}",
     // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
     "console": "internalConsole",
     "stopAtEntry": false,
@@ -185,9 +181,9 @@ export class AssetGenerator {
     "request": "launch",
     "preLaunchTask": "build",
     // If you have changed target frameworks, make sure to update the program path.
-    "program": "${this.convertNativePathToPosix(this.computeProgramPath())}",
+    "program": "${util.convertNativePathToPosix(this.computeProgramPath())}",
     "args": [],
-    "cwd": "${this.convertNativePathToPosix(this.computeWorkingDirectory())}",
+    "cwd": "${util.convertNativePathToPosix(this.computeWorkingDirectory())}",
     "stopAtEntry": false,
     "internalConsoleOptions": "openOnSessionStart",
     "launchBrowser": {
@@ -253,7 +249,7 @@ export class AssetGenerator {
 
         return {
             taskName: 'build',
-            args: [this.convertNativePathToPosix(buildPath)],
+            args: [util.convertNativePathToPosix(buildPath)],
             isBuildCommand: true,
             problemMatcher: '$msCompile'
         };

--- a/src/common.ts
+++ b/src/common.ts
@@ -112,3 +112,8 @@ export function deleteInstallFile(type: InstallFileType): Promise<void> {
         });
     });
 }
+
+export function convertNativePathToPosix(pathString: string): string {
+    let parts = pathString.split(path.sep);
+    return parts.join(path.posix.sep);
+}

--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -22,7 +22,7 @@ function forwardDocumentChanges(server: OmniSharpServer): Disposable {
             return;
         }
 
-        serverUtils.updateBuffer(server, {Buffer: document.getText(), Filename: document.fileName}).catch(err => {
+        serverUtils.updateBuffer(server, {Buffer: document.getText(), FileName: document.fileName}).catch(err => {
             console.error(err);
             return err;
         });
@@ -36,7 +36,7 @@ function forwardFileChanges(server: OmniSharpServer): Disposable {
             return;
         }
         
-        let req = { Filename: uri.fsPath };
+        let req = { FileName: uri.fsPath };
         
         serverUtils.filesChanged(server, [req]).catch(err => {
             console.warn(`[o] failed to forward file change event for ${uri.fsPath}`, err);

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -39,7 +39,7 @@ export default class OmnisharpCodeActionProvider extends AbstractProvider implem
         }
 
         let req: protocol.V2.GetCodeActionsRequest = {
-            Filename: document.fileName,
+            FileName: document.fileName,
             Selection: OmnisharpCodeActionProvider._asRange(range)
         };
 
@@ -49,7 +49,7 @@ export default class OmnisharpCodeActionProvider extends AbstractProvider implem
                     title: codeAction.Name,
                     command: this._commandId,
                     arguments: [<protocol.V2.RunCodeActionRequest>{
-                        Filename: document.fileName,
+                        FileName: document.fileName,
                         Selection: OmnisharpCodeActionProvider._asRange(range),
                         Identifier: codeAction.Identifier,
                         WantsTextChanges: true

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -32,7 +32,7 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
     };
 
     provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-        return serverUtils.currentFileMembersAsTree(this._server, { Filename: document.fileName }, token).then(tree => {
+        return serverUtils.currentFileMembersAsTree(this._server, { FileName: document.fileName }, token).then(tree => {
             let ret: CodeLens[] = [];
             tree.TopLevelTypeDefinitions.forEach(node => this._convertQuickFix(ret, document.fileName, node));
             return ret;
@@ -59,7 +59,7 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
         if (codeLens instanceof OmniSharpCodeLens) {
 
             let req = <protocol.FindUsagesRequest>{
-                Filename: codeLens.fileName,
+                FileName: codeLens.fileName,
                 Line: codeLens.range.start.line + 1,
                 Column: codeLens.range.start.character + 1,
                 OnlyThisFile: false,
@@ -75,7 +75,7 @@ export default class OmniSharpCodeLensProvider extends AbstractSupport implement
                 codeLens.command = {
                     title: len === 1 ? '1 reference' : `${len} references`,
                     command: 'editor.action.showReferences',
-                    arguments: [Uri.file(req.Filename), codeLens.range.start, res.QuickFixes.map(toLocation)]
+                    arguments: [Uri.file(req.FileName), codeLens.range.start, res.QuickFixes.map(toLocation)]
                 };
 
                 return codeLens;

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -193,7 +193,7 @@ class DiagnosticsProvider extends AbstractSupport {
 
         let source = new vscode.CancellationTokenSource();
         let handle = setTimeout(() => {
-            serverUtils.codeCheck(this._server, { Filename: document.fileName }, source.token).then(value => {
+            serverUtils.codeCheck(this._server, { FileName: document.fileName }, source.token).then(value => {
 
                 // Easy case: If there are no diagnostics in the file, we can clear it quickly. 
                 if (value.QuickFixes.length === 0) {
@@ -228,7 +228,7 @@ class DiagnosticsProvider extends AbstractSupport {
         this._projectValidation = new vscode.CancellationTokenSource();
         let handle = setTimeout(() => {
 
-            serverUtils.codeCheck(this._server, { Filename: null }, this._projectValidation.token).then(value => {
+            serverUtils.codeCheck(this._server, { FileName: null }, this._projectValidation.token).then(value => {
 
                 let quickFixes = value.QuickFixes.sort((a, b) => a.FileName.localeCompare(b.FileName));
                 let entries: [vscode.Uri, vscode.Diagnostic[]][] = [];

--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -14,7 +14,7 @@ export default class OmnisharpDocumentSymbolProvider extends AbstractSupport imp
 
     public provideDocumentSymbols(document: TextDocument, token: CancellationToken): Promise<SymbolInformation[]> {
 
-        return serverUtils.currentFileMembersAsTree(this._server, { Filename: document.fileName }, token).then(tree => {
+        return serverUtils.currentFileMembersAsTree(this._server, { FileName: document.fileName }, token).then(tree => {
             let ret: SymbolInformation[] = [];
             for (let node of tree.TopLevelTypeDefinitions) {
                 toDocumentSymbol(ret, node);

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -139,7 +139,7 @@ export function debugDotnetTest(testMethod: string, fileName: string, testFramew
 
     return serverUtils.debugTestCheck(server, request)
         .then(response => {
-            debugType = response.PreferredDebugType;
+            debugType = response.DebugType;
             return getLaunchConfiguration(server, debugType, fileName, testMethod, testFrameworkName);
         })
         .then(config => {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -36,7 +36,13 @@ export function registerDotNetTestDebugCommand(server: OmniSharpServer): vscode.
 // Run test through dotnet-test command. This function can be moved to a separate structure
 export function runDotnetTest(testMethod: string, fileName: string, testFrameworkName: string, server: OmniSharpServer) {
     getTestOutputChannel().show();
-    getTestOutputChannel().appendLine('Running test ' + testMethod + '...');
+    getTestOutputChannel().appendLine(`Running test ${testMethod}...`);
+
+    let disposable = server.onTestMessage(e =>
+    {
+        getTestOutputChannel().appendLine(e.Message);
+    });
+
     serverUtils
         .runDotNetTest(server, { FileName: fileName, MethodName: testMethod, TestFrameworkName: testFrameworkName })
         .then(
@@ -47,9 +53,12 @@ export function runDotnetTest(testMethod: string, fileName: string, testFramewor
             else {
                 getTestOutputChannel().appendLine('Test failed \n');
             }
+
+            disposable.dispose();
         },
         reason => {
             vscode.window.showErrorMessage(`Failed to run test because ${reason}.`);
+            disposable.dispose();
         });
 }
 

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -146,6 +146,7 @@ export function debugDotnetTest(testMethod: string, fileName: string, testFramew
             return vscode.commands.executeCommand('vscode.startDebug', config);
         })
         .then(() => {
+            // TODO: Need to find out when the attach is really complete from the debugger. This is currently a race.
             if (debugType === "attach") {
                 serverUtils.debugTestReady(server, { Filename: fileName });
             }

--- a/src/features/formattingEditProvider.ts
+++ b/src/features/formattingEditProvider.ts
@@ -15,7 +15,7 @@ export default class FormattingSupport extends AbstractSupport implements Docume
     public provideDocumentRangeFormattingEdits(document: TextDocument, range: Range, options: FormattingOptions, token: CancellationToken): Promise<TextEdit[]> {
 
         let request = <protocol.FormatRangeRequest>{
-            Filename: document.fileName,
+            FileName: document.fileName,
             Line: range.start.line + 1,
             Column: range.start.character + 1,
             EndLine: range.end.line + 1,
@@ -32,7 +32,7 @@ export default class FormattingSupport extends AbstractSupport implements Docume
     public provideOnTypeFormattingEdits(document: TextDocument, position: Position, ch: string, options: FormattingOptions, token: CancellationToken): Promise<TextEdit[]> {
 
         let request = <protocol.FormatAfterKeystrokeRequest> {
-            Filename: document.fileName,
+            FileName: document.fileName,
             Line: position.line + 1,
             Column: position.character + 1,
             Character: ch

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -16,7 +16,7 @@ export default class OmnisharpWorkspaceSymbolProvider extends AbstractSupport im
 
     public provideWorkspaceSymbols(search: string, token: CancellationToken): Promise<SymbolInformation[]> {
 
-        return serverUtils.findSymbols(this._server, { Filter: search, Filename: '' }, token).then(res => {
+        return serverUtils.findSymbols(this._server, { Filter: search, FileName: '' }, token).then(res => {
             if (res && Array.isArray(res.QuickFixes)) {
                 return res.QuickFixes.map(OmnisharpWorkspaceSymbolProvider._asSymbolInformation);
             }

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -22,6 +22,7 @@ export module Requests {
     export const GetCodeActions = '/getcodeactions';
     export const GoToDefinition = '/gotoDefinition';
     export const FindImplementations = '/findimplementations';
+    export const Project = '/project';
     export const Projects = '/projects';
     export const RemoveFromProject = '/removefromproject';
     export const Rename = '/rename';
@@ -59,7 +60,7 @@ export namespace WireProtocol {
 }
 
 export interface Request {
-    Filename: string;
+    FileName: string;
     Line?: number;
     Column?: number;
     Buffer?: string;
@@ -420,9 +421,8 @@ export namespace V2 {
         export const RunCodeAction = '/v2/runcodeaction';
         export const GetTestStartInfo = '/v2/getteststartinfo';
         export const RunTest = '/v2/runtest';
-        export const DebugTestCheck = '/v2/debugtest/check';
-        export const DebugTestStart = '/v2/debugtest/start';
-        export const DebugTestReady = '/v2/debugtest/ready';
+        export const DebugTestGetStartInfo = '/v2/debugtest/getstartinfo';
+        export const DebugTestRun = '/v2/debugtest/run';
     }
 
     export interface Point {
@@ -498,28 +498,22 @@ export namespace V2 {
     }
 
     // dotnet-test endpoints
-    export interface DebugTestCheckRequest extends Request {
-    }
-
-    export interface DebugTestCheckResponse {
-        DebugType: string;
-    }
-
-    export interface DebugTestStartRequest extends Request {
+    export interface DebugTestGetStartInfoRequest extends Request {
         MethodName: string;
         TestFrameworkName: string;
     }
 
-    export interface DebugTestStartResponse {
-        ProcessId: number;
-        HostProcessId: number;
+    export interface DebugTestGetStartInfoResponse {
+        FileName: string;
+        Arguments: string;
+        WorkingDirectory: string;
+        EnvironmentVariables: Map<string, string>;
     }
 
-    export interface DebugTestReadyRequest extends Request {
+    export interface DebugTestRunRequest extends Request {
     }
 
-    export interface DebugTestReadyResponse {
-        IsReady: boolean;
+    export interface DebugTestRunResponse {
     }
 
     export interface GetTestStartInfoRequest extends Request {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -419,7 +419,10 @@ export namespace V2 {
         export const GetCodeActions = '/v2/getcodeactions';
         export const RunCodeAction = '/v2/runcodeaction';
         export const GetTestStartInfo = '/v2/getteststartinfo';
-        export const RunDotNetTest = '/v2/runtest';
+        export const RunTest = '/v2/runtest';
+        export const DebugTestCheck = '/v2/debugtest/check';
+        export const DebugTestStart = '/v2/debugtest/start';
+        export const DebugTestReady = '/v2/debugtest/ready';
     }
 
     export interface Point {
@@ -495,8 +498,31 @@ export namespace V2 {
     }
 
     // dotnet-test endpoints
-    export interface GetTestStartInfoRequest {
-        FileName: string;
+    export interface DebugTestCheckRequest extends Request {
+    }
+
+    export interface DebugTestCheckResponse {
+        PreferredDebugType: string;
+    }
+
+    export interface DebugTestStartRequest extends Request {
+        MethodName: string;
+        TestFrameworkName: string;
+    }
+
+    export interface DebugTestStartResponse {
+        ProcessId: number;
+        HostProcessId: number;
+    }
+
+    export interface DebugTestReadyRequest extends Request {
+    }
+
+    export interface DebugTestReadyResponse {
+        IsReady: boolean;
+    }
+
+    export interface GetTestStartInfoRequest extends Request {
         MethodName: string;
         TestFrameworkName: string;
     }
@@ -507,8 +533,7 @@ export namespace V2 {
         WorkingDirectory: string;
     }
 
-    export interface RunDotNetTestRequest {
-        FileName: string;
+    export interface RunTestRequest extends Request {
         MethodName: string;
         TestFrameworkName: string;
     }
@@ -520,7 +545,7 @@ export namespace V2 {
         ErrorStackTrace: string;
     }
 
-    export interface RunDotNetTestResponse {
+    export interface RunTestResponse {
         Failure: string;
         Pass: boolean;
     }

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -504,6 +504,7 @@ export namespace V2 {
     export interface GetTestStartInfoResponse {
         Executable: string;
         Argument: string;
+        WorkingDirectory: string;
     }
 
     export interface RunDotNetTestRequest {
@@ -512,9 +513,21 @@ export namespace V2 {
         TestFrameworkName: string;
     }
 
+    export interface DotNetResult {
+        MethodName: string;
+        Outcome: string;
+        ErrorMessage: string;
+        ErrorStackTrace: string;
+    }
+
     export interface RunDotNetTestResponse {
         Failure: string;
         Pass: boolean;
+    }
+
+    export interface TestMessageEvent {
+        MessageLevel: string;
+        Message: string;
     }
 }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -502,7 +502,7 @@ export namespace V2 {
     }
 
     export interface DebugTestCheckResponse {
-        PreferredDebugType: string;
+        DebugType: string;
     }
 
     export interface DebugTestStartRequest extends Request {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -43,6 +43,8 @@ module Events {
 
     export const MsBuildProjectDiagnostics = 'MsBuildProjectDiagnostics';
 
+    export const TestMessage = 'TestMessage';
+
     export const BeforeServerInstall = 'BeforeServerInstall';
     export const BeforeServerStart = 'BeforeServerStart';
     export const ServerStart = 'ServerStart';
@@ -191,6 +193,10 @@ export class OmniSharpServer {
 
     public onMsBuildProjectDiagnostics(listener: (e: protocol.MSBuildProjectDiagnostics) => any, thisArg?: any) {
         return this._addListener(Events.MsBuildProjectDiagnostics, listener, thisArg);
+    }
+
+    public onTestMessage(listener: (e: protocol.V2.TestMessageEvent) => any, thisArg?: any) {
+        return this._addListener(Events.TestMessage, listener, thisArg);
     }
 
     public onBeforeServerInstall(listener: () => any) {

--- a/src/omnisharp/typeConvertion.ts
+++ b/src/omnisharp/typeConvertion.ts
@@ -45,7 +45,7 @@ export function createRequest<T extends protocol.Request>(document: vscode.TextD
     }
 
     let request: protocol.Request = {
-        Filename: document.fileName,
+        FileName: document.fileName,
         Buffer: includeBuffer ? document.getText() : undefined,
         Line,
         Column

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -85,8 +85,20 @@ export function getTestStartInfo(server: OmniSharpServer, request: protocol.V2.G
     return server.makeRequest<protocol.V2.GetTestStartInfoResponse>(protocol.V2.Requests.GetTestStartInfo, request);
 }
 
-export function runDotNetTest(server: OmniSharpServer, request: protocol.V2.RunDotNetTestRequest) {
-    return server.makeRequest<protocol.V2.RunDotNetTestResponse>(protocol.V2.Requests.RunDotNetTest, request);
+export function runTest(server: OmniSharpServer, request: protocol.V2.RunTestRequest) {
+    return server.makeRequest<protocol.V2.RunTestResponse>(protocol.V2.Requests.RunTest, request);
+}
+
+export function debugTestCheck(server: OmniSharpServer, request: protocol.V2.DebugTestCheckRequest) {
+    return server.makeRequest<protocol.V2.DebugTestCheckResponse>(protocol.V2.Requests.DebugTestCheck, request);
+}
+
+export function debugTestStart(server: OmniSharpServer, request: protocol.V2.DebugTestStartRequest) {
+    return server.makeRequest<protocol.V2.DebugTestStartResponse>(protocol.V2.Requests.DebugTestStart, request);
+}
+
+export function debugTestReady(server: OmniSharpServer, request: protocol.V2.DebugTestReadyRequest) {
+    return server.makeRequest<protocol.V2.DebugTestReadyResponse>(protocol.V2.Requests.DebugTestReady, request);
 }
 
 export function isNetCoreProject(project: protocol.MSBuildProject) {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -57,6 +57,10 @@ export function rename(server: OmniSharpServer, request: protocol.RenameRequest,
     return server.makeRequest<protocol.RenameResponse>(protocol.Requests.Rename, request, token);
 }
 
+export function requestProjectInformation(server: OmniSharpServer, request: protocol.Request) {
+    return server.makeRequest<protocol.ProjectInformationResponse>(protocol.Requests.Project, request);
+}
+
 export function requestWorkspaceInformation(server: OmniSharpServer) {
     return server.makeRequest<protocol.WorkspaceInformationResponse>(protocol.Requests.Projects);
 }
@@ -89,16 +93,12 @@ export function runTest(server: OmniSharpServer, request: protocol.V2.RunTestReq
     return server.makeRequest<protocol.V2.RunTestResponse>(protocol.V2.Requests.RunTest, request);
 }
 
-export function debugTestCheck(server: OmniSharpServer, request: protocol.V2.DebugTestCheckRequest) {
-    return server.makeRequest<protocol.V2.DebugTestCheckResponse>(protocol.V2.Requests.DebugTestCheck, request);
+export function debugTestGetStartInfo(server: OmniSharpServer, request: protocol.V2.DebugTestGetStartInfoRequest) {
+    return server.makeRequest<protocol.V2.DebugTestGetStartInfoResponse>(protocol.V2.Requests.DebugTestGetStartInfo, request);
 }
 
-export function debugTestStart(server: OmniSharpServer, request: protocol.V2.DebugTestStartRequest) {
-    return server.makeRequest<protocol.V2.DebugTestStartResponse>(protocol.V2.Requests.DebugTestStart, request);
-}
-
-export function debugTestReady(server: OmniSharpServer, request: protocol.V2.DebugTestReadyRequest) {
-    return server.makeRequest<protocol.V2.DebugTestReadyResponse>(protocol.V2.Requests.DebugTestReady, request);
+export function debugTestRun(server: OmniSharpServer, request: protocol.V2.DebugTestRunRequest) {
+    return server.makeRequest<protocol.V2.DebugTestRunResponse>(protocol.V2.Requests.DebugTestRun, request);
 }
 
 export function isNetCoreProject(project: protocol.MSBuildProject) {


### PR DESCRIPTION
There's a bit of a dance here with debugging of 'dotnet test':

* On a legacy .NET CLI (e.g. "preview2" or earlier -- project.json stuff), we request the command-line to launch test test runner and simply launch the debugger with that command-line. This is largely unchanged from what we had before.
* On a newer .NET CLI (e.g. "preview3" or newer -- .csproj stuff), we ask OmniSharp to launch the test runner process and it returns the process id to us. Then, we attach the debugger to the process id and signal OmniSharp that we're ready to start debugging. OmniSharp then signals 'dotnet test' to start running tests.

@gregg-miskelly: I've run into a few issues here that I'd like to get some help with if possible:

1. I initially tried launching the debugger for .csproj projects like we do for project.json projects, but I ran into a snag. Once the debugger launches the testhost process, it immediately runs to completion instead of waiting to be signaled. However, if I launch the process myself (via `Process.Start(...)` in OmniSharp or `child_process.span(...)` in VS Code, the process waits until I signal 'dotnet test'.
2. I was able to see debugging working on Windows, but got an error message ("Couldn't attach to process") on my Mac. Are there issues with local attach I should be aware of? How can I debug an issue like that?