### PR TITLE
Add 'omnisharp.waitForDebugger' option to pass the --debug flag with launching OmniSharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,6 +342,11 @@
           "default": false,
           "description": "Launch OmniSharp with Mono."
         },
+        "omnisharp.waitForDebugger": {
+          "type": "boolean",
+          "default": false,
+          "description": "Pass the --debug flag when launching the OmniSharp server to allow a debugger to be attached."
+        },
         "omnisharp.loggingLevel": {
           "type": "string",
           "default": "information",

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -9,6 +9,7 @@ export class Options {
     constructor(
         public path?: string,
         public useMono?: boolean,
+        public waitForDebugger?: boolean,
         public loggingLevel?: string,
         public autoStart?: boolean,
         public projectLoadTimeout?: number,
@@ -33,6 +34,8 @@ export class Options {
             ? csharpConfig.get<boolean>('omnisharpUsesMono')
             : omnisharpConfig.get<boolean>('useMono');
 
+        const waitForDebugger = omnisharpConfig.get<boolean>('waitForDebugger', false);
+
         // support the legacy "verbose" level as "debug"
         let loggingLevel = omnisharpConfig.get<string>('loggingLevel');
         if (loggingLevel.toLowerCase() === 'verbose') {
@@ -45,6 +48,6 @@ export class Options {
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
 
-        return new Options(path, useMono, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings);
+        return new Options(path, useMono, waitForDebugger, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings);
     }
 }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -246,6 +246,10 @@ export class OmniSharpServer {
             '--loglevel', this._options.loggingLevel
         ];
 
+        if (this._options.waitForDebugger === true) {
+            args.push('--debug');
+        }
+
         this._logger.appendLine(`Starting OmniSharp server at ${new Date().toLocaleString()}`);
         this._logger.increaseIndent();
         this._logger.appendLine(`Target: ${solutionPath}`);


### PR DESCRIPTION
Useful for debugging