### PR TITLE
Fix RemoteProcessPicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,13 +502,11 @@
             "razor"
           ]
         },
-        "runtime": "node",
         "runtimeArgs": [],
         "variables": {
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess"
         },
-        "program": "./out/src/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {
@@ -1317,7 +1315,16 @@
             "request": "attach",
             "processId": "${command:pickProcess}"
           }
-        ]
+        ],
+        "windows": {
+          "program": "./.debugger/vsdbg-ui.exe"
+        },
+        "osx": {
+          "program": "./.debugger/vsdbg-ui"
+        },
+        "linux": {
+          "program": "./.debugger/vsdbg-ui"
+        }
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1172,102 +1172,102 @@
           }
         },
         "configurationSnippets": [
-            {
-                "label": ".NET: Launch .NET Core Console App",
-                "description": "Launch a .NET Core Console App with a debugger.",
-                "body": {
-                    "name": ".NET Core Launch (console)",
-                    "type": "coreclr",
-                    "request": "launch",
-                    "preLaunchTask": "build",
-                    "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
-                    "args": [],
-                    "cwd": "^\"\\${workspaceRoot}\"",
-                    "stopAtEntry": false,
-                    "console": "internalConsole"
-                }
-            },
-            {
-                "label": ".NET: Attach to local .NET Core Console App",
-                "description": "Attach a debugger to a .NET Core Console App.",
-                "body": {
-                    "name": ".NET Core Attach",
-                    "type": "coreclr",
-                    "request": "attach",
-                    "processId": "^\"\\${command:pickProcess}\""
-                }
-            },
-            {
-                "label": ".NET: Launch a local .NET Core Web App",
-                "description": "Launch a .NET Core Web App with both a browser and a debugger.",
-                "body": {
-                    "name": ".NET Core Launch (web)",
-                    "type": "coreclr",
-                    "request": "launch",
-                    "preLaunchTask": "build",
-                    "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
-                    "args": [],
-                    "cwd": "^\"\\${workspaceRoot}\"",
-                    "stopAtEntry": false,
-                    "launchBrowser": {
-                        "enabled": true,
-                        "args": "^\"\\${auto-detect-url}\"",
-                        "windows": {
-                            "command": "cmd.exe",
-                            "args": "^\"/C start \\${auto-detect-url}\""
-                        },
-                        "osx": {
-                            "command": "open"
-                        },
-                        "linux": {
-                            "command": "xdg-open"
-                        }
-                    },
-                    "env": {
-                        "ASPNETCORE_ENVIRONMENT": "Development"
-                    },
-                    "sourceFileMap": {
-                        "/Views": "^\"\\${workspaceRoot}/Views\""
-                    }
-                }
-            },
-            {
-                "label": ".NET: Launch a remote .NET Core Console App",
-                "description": "Launch a .NET Core Console App on a remote machine.",
-                "body": {
-                    "name": ".NET Core Launch (console)",
-                    "type": "coreclr",
-                    "request": "launch",
-                    "preLaunchTask": "build",
-                    "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
-                    "args": [],
-                    "cwd": "^\"\\${workspaceRoot}\"",
-                    "stopAtEntry": false,
-                    "console": "internalConsole",
-                    "pipeTransport": {
-                        "pipeCwd": "^\"\\${workspaceRoot}\"",
-                        "pipeProgram": "^\"${3:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
-                        "pipeArgs": [],
-                        "debuggerPath": "^\"${4:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
-                    }
-                }
-            },
-            {
-                "label": ".NET: Attach to remote .NET Core Console App",
-                "description": "Attach a debugger to a .NET Core Console App on a remote machine.",
-                "body": {
-                    "name": ".NET Core Attach",
-                    "type": "coreclr",
-                    "request": "attach",
-                    "processId": "^\"\\${command:pickRemoteProcess}\"",
-                    "pipeTransport": {
-                        "pipeCwd": "^\"\\${workspaceRoot}\"",
-                        "pipeProgram": "^\"${1:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
-                        "pipeArgs": [],
-                        "debuggerPath": "^\"${2:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
-                    }
-                }
+          {
+            "label": ".NET: Launch .NET Core Console App",
+            "description": "Launch a .NET Core Console App with a debugger.",
+            "body": {
+              "name": ".NET Core Launch (console)",
+              "type": "coreclr",
+              "request": "launch",
+              "preLaunchTask": "build",
+              "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
+              "args": [],
+              "cwd": "^\"\\${workspaceRoot}\"",
+              "stopAtEntry": false,
+              "console": "internalConsole"
             }
+          },
+          {
+            "label": ".NET: Attach to local .NET Core Console App",
+            "description": "Attach a debugger to a .NET Core Console App.",
+            "body": {
+              "name": ".NET Core Attach",
+              "type": "coreclr",
+              "request": "attach",
+              "processId": "^\"\\${command:pickProcess}\""
+            }
+          },
+          {
+            "label": ".NET: Launch a local .NET Core Web App",
+            "description": "Launch a .NET Core Web App with both a browser and a debugger.",
+            "body": {
+              "name": ".NET Core Launch (web)",
+              "type": "coreclr",
+              "request": "launch",
+              "preLaunchTask": "build",
+              "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
+              "args": [],
+              "cwd": "^\"\\${workspaceRoot}\"",
+              "stopAtEntry": false,
+              "launchBrowser": {
+                "enabled": true,
+                "args": "^\"\\${auto-detect-url}\"",
+                "windows": {
+                  "command": "cmd.exe",
+                  "args": "^\"/C start \\${auto-detect-url}\""
+                },
+                "osx": {
+                  "command": "open"
+                },
+                "linux": {
+                  "command": "xdg-open"
+                }
+              },
+              "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              },
+              "sourceFileMap": {
+                "/Views": "^\"\\${workspaceRoot}/Views\""
+              }
+            }
+          },
+          {
+            "label": ".NET: Launch a remote .NET Core Console App",
+            "description": "Launch a .NET Core Console App on a remote machine.",
+            "body": {
+              "name": ".NET Core Launch (console)",
+              "type": "coreclr",
+              "request": "launch",
+              "preLaunchTask": "build",
+              "program": "^\"\\${workspaceRoot}/bin/Debug/${1:<target-framework>}/${2:<project-name.dll>}\"",
+              "args": [],
+              "cwd": "^\"\\${workspaceRoot}\"",
+              "stopAtEntry": false,
+              "console": "internalConsole",
+              "pipeTransport": {
+                "pipeCwd": "^\"\\${workspaceRoot}\"",
+                "pipeProgram": "^\"${3:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
+                "pipeArgs": [],
+                "debuggerPath": "^\"${4:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
+              }
+            }
+          },
+          {
+            "label": ".NET: Attach to remote .NET Core Console App",
+            "description": "Attach a debugger to a .NET Core Console App on a remote machine.",
+            "body": {
+              "name": ".NET Core Attach",
+              "type": "coreclr",
+              "request": "attach",
+              "processId": "^\"\\${command:pickRemoteProcess}\"",
+              "pipeTransport": {
+                "pipeCwd": "^\"\\${workspaceRoot}\"",
+                "pipeProgram": "^\"${1:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
+                "pipeArgs": [],
+                "debuggerPath": "^\"${2:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
+              }
+            }
+          }
         ],
         "initialConfigurations": [
           {

--- a/package.json
+++ b/package.json
@@ -502,11 +502,13 @@
             "razor"
           ]
         },
+        "runtime": "node",
         "runtimeArgs": [],
         "variables": {
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess"
         },
+        "program": "./out/src/coreclr-debug/proxy.js",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {
@@ -1315,16 +1317,7 @@
             "request": "attach",
             "processId": "${command:pickProcess}"
           }
-        ],
-        "windows": {
-          "program": "./.debugger/vsdbg-ui.exe"
-        },
-        "osx": {
-          "program": "./.debugger/vsdbg-ui"
-        },
-        "linux": {
-          "program": "./.debugger/vsdbg-ui"
-        }
+        ]
       }
     ]
   }

--- a/scripts/remoteProcessPickerScript
+++ b/scripts/remoteProcessPickerScript
@@ -1,0 +1,1 @@
+uname && if [ "$(uname)" = "Linux" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= ; elif [ "$(uname)" = "Darwin" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= -c; fi

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -82,17 +82,15 @@ export class RemoteAttachPicker {
             let scriptShellCmd: string = "sh -s";
             pipeCmdList.push(pipeProgram);
 
-            if (pipeArgs.filter(arg => arg === "${debuggerCommand}").length > 0) {
-                for (let arg of pipeArgs)
-                {
-                    if (arg === "${debuggerCommand}")
-                    {
-                        pipeCmdList.push(scriptShellCmd);
+            const debuggerCommandString: string = "${debuggerCommand}";
+
+            if (pipeArgs.indexOf(debuggerCommandString) > 0) {
+                for (let arg of pipeArgs) {
+                    while (arg.indexOf("${debuggerCommand}") >= 0) {
+                        arg = arg.replace("${debuggerCommand}", scriptShellCmd);
                     }
-                    else
-                    {
-                        pipeCmdList.push(arg);
-                    }
+                    
+                    pipeCmdList.push(arg);
                 }
             }
             else {

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -129,7 +129,7 @@ export class RemoteAttachPicker {
     }
 
     public static getRemoteOSAndProcesses(pipeCmd: string): Promise<AttachItem[]> {
-        
+
         // Commands to get OS and processes
         const command = `uname && if [ "$(uname)" == "Linux" ] ; then ${RemoteAttachPicker.linuxPsCommand} ; elif [ "$(uname)" == "Darwin" ] ; ` +
             `then ${RemoteAttachPicker.osxPsCommand}; fi`;
@@ -413,26 +413,26 @@ function execChildProcess(process: string, workingDirectory: string): Promise<st
 // VSCode cannot find the path "c:\windows\system32\bash.exe" as bash.exe is only available on 64bit OS. 
 // It can be invoked from "c:\windows\sysnative\bash.exe", so adding "c:\windows\sysnative" to path if we identify
 // VSCode is running in windows and doesn't have it in the path.
-function GetSysNativePathIfNeeded() : Promise<any> {
-    return PlatformInformation.GetCurrent().then(platformInfo => { 
+function GetSysNativePathIfNeeded(): Promise<any> {
+    return PlatformInformation.GetCurrent().then(platformInfo => {
         let env = process.env;
         if (platformInfo.isWindows && platformInfo.architecture === "x86_64") {
-            let sysnative : String = process.env.WINDIR + "\\sysnative";
-            env.Path = process.env.PATH + ";" + sysnative;                   
+            let sysnative: String = process.env.WINDIR + "\\sysnative";
+            env.Path = process.env.PATH + ";" + sysnative;
         }
-        
+
         return env;
     });
 }
 
 function execChildProcessAndOutputErrorToChannel(process: string, workingDirectory: string, channel: vscode.OutputChannel): Promise<string> {
-    channel.appendLine(`Executing: ${process}`);    
+    channel.appendLine(`Executing: ${process}`);
 
     return new Promise<string>((resolve, reject) => {
         return GetSysNativePathIfNeeded().then(newEnv => {
             child_process.exec(process, { cwd: workingDirectory, env: newEnv, maxBuffer: 500 * 1024 }, (error: Error, stdout: string, stderr: string) => {
                 let channelOutput = "";
-                
+
                 if (stdout && stdout.length > 0) {
                     channelOutput.concat(stdout);
                 }

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -82,7 +82,7 @@ export class RemoteAttachPicker {
             pipeCmdList.push(pipeProgram);
             pipeCmdList = pipeCmdList.concat(pipeArgs);
 
-            const scriptShellCmdList: string[] = ["bash", "-s"];
+            const scriptShellCmdList: string[] = ["sh", "-s"];
 
             pipeCmdList = pipeCmdList.concat(scriptShellCmdList);
 
@@ -131,7 +131,7 @@ export class RemoteAttachPicker {
     public static getRemoteOSAndProcesses(pipeCmd: string): Promise<AttachItem[]> {
 
         // Commands to get OS and processes
-        const command = `uname && if [ "$(uname)" == "Linux" ] ; then ${RemoteAttachPicker.linuxPsCommand} ; elif [ "$(uname)" == "Darwin" ] ; ` +
+        const command = `uname && if [ "$(uname)" = "Linux" ] ; then ${RemoteAttachPicker.linuxPsCommand} ; elif [ "$(uname)" = "Darwin" ] ; ` +
             `then ${RemoteAttachPicker.osxPsCommand}; fi`;
 
         // Create a temp file to redirect commands to the pipeProgram to solve quoting issues.

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -84,7 +84,7 @@ export class RemoteAttachPicker {
 
             const debuggerCommandString: string = "${debuggerCommand}";
 
-            if (pipeArgs.indexOf(debuggerCommandString) > 0) {
+            if (pipeArgs.filter(arg => arg.indexOf(debuggerCommandString) >= 0).length > 0) {
                 for (let arg of pipeArgs) {
                     while (arg.indexOf("${debuggerCommand}") >= 0) {
                         arg = arg.replace("${debuggerCommand}", scriptShellCmd);

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -79,14 +79,26 @@ export class RemoteAttachPicker {
             }
 
             let pipeCmdList: string[] = [];
+            let scriptShellCmd: string = "sh -s";
             pipeCmdList.push(pipeProgram);
 
-            // Remove debuggerCommand for remoteProcessPicker
-            pipeCmdList = pipeCmdList.concat(pipeArgs.filter(arg => arg !== "${debuggerCommand}"));
-
-            let scriptShellCmd: string = "sh -s";
-
-            pipeCmdList.push(scriptShellCmd);
+            if (pipeArgs.filter(arg => arg === "${debuggerCommand}").length > 0) {
+                for (let arg of pipeArgs)
+                {
+                    if (arg === "${debuggerCommand}")
+                    {
+                        pipeCmdList.push(scriptShellCmd);
+                    }
+                    else
+                    {
+                        pipeCmdList.push(arg);
+                    }
+                }
+            }
+            else {
+                pipeCmdList = pipeCmdList.concat(pipeArgs);
+                pipeCmdList.push(scriptShellCmd);
+            }
 
             let pipeCmd: string = quoteArgs ? this.createArgumentList(pipeCmdList) : pipeCmdList.join(' ');
 
@@ -107,10 +119,18 @@ export class RemoteAttachPicker {
         let ret = "";
 
         for (let arg of args) {
-            if (ret) {
+            if (ret)
+            {
                 ret += " ";
             }
-            ret += `"${arg}"`;
+            
+            if (arg.includes(' ')) {
+                ret += `"${arg}"`;
+            }
+            else
+            {
+                ret += `${arg}`;
+            }
         }
 
         return ret;


### PR DESCRIPTION
Allowing quoteArgs to handle the pipeProgram and pipeArgs quotes. 

Moving the uname and ps command into a temp file so it can be redirected into the pipeProgram so the current shell does not mangle the command string.

Tested:
Windows -> Linux
Windows -> Docker Linux
Windows -> Mac
Mac -> Linux

+ Fixing configuration snippet formatting