### PR TITLE
Don't create hidden diagnostics

### DIFF
--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -33,7 +33,6 @@ export default class OmnisharpCodeActionProvider extends AbstractProvider implem
     }
 
     public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Promise<Command[]> {
-
         if (this._disabled) {
             return;
         }

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -100,12 +100,10 @@ export class Advisor {
         for (let key in this._projectSourceFileCounts) {
             sourceFileCount += this._projectSourceFileCounts[key];
             if (sourceFileCount > 1000) {
-                console.log(`_isHugeProject = true (${sourceFileCount})`);
                 return true;
             }
         }
 
-        console.log(`_isHugeProject = false (${sourceFileCount})`);
         return false;
     }
 }
@@ -195,8 +193,10 @@ class DiagnosticsProvider extends AbstractSupport {
         let handle = setTimeout(() => {
             serverUtils.codeCheck(this._server, { FileName: document.fileName }, source.token).then(value => {
 
+                let quickFixes = value.QuickFixes.filter(DiagnosticsProvider._shouldInclude);
+
                 // Easy case: If there are no diagnostics in the file, we can clear it quickly. 
-                if (value.QuickFixes.length === 0) {
+                if (quickFixes.length === 0) {
                     if (this._diagnostics.has(document.uri)) {
                         this._diagnostics.delete(document.uri);
                     }
@@ -205,7 +205,7 @@ class DiagnosticsProvider extends AbstractSupport {
                 }
 
                 // (re)set new diagnostics for this document
-                let diagnostics = value.QuickFixes.map(DiagnosticsProvider._asDiagnostic);
+                let diagnostics = quickFixes.map(DiagnosticsProvider._asDiagnostic);
 
                 this._diagnostics.set(document.uri, diagnostics);
             });
@@ -230,7 +230,10 @@ class DiagnosticsProvider extends AbstractSupport {
 
             serverUtils.codeCheck(this._server, { FileName: null }, this._projectValidation.token).then(value => {
 
-                let quickFixes = value.QuickFixes.sort((a, b) => a.FileName.localeCompare(b.FileName));
+                let quickFixes = value.QuickFixes
+                    .filter(DiagnosticsProvider._shouldInclude)
+                    .sort((a, b) => a.FileName.localeCompare(b.FileName));
+
                 let entries: [vscode.Uri, vscode.Diagnostic[]][] = [];
                 let lastEntry: [vscode.Uri, vscode.Diagnostic[]];
 
@@ -269,6 +272,10 @@ class DiagnosticsProvider extends AbstractSupport {
         });
     }
 
+    private static _shouldInclude(quickFix: protocol.QuickFix): boolean {
+        return quickFix.LogLevel.toLowerCase() !== 'hidden';
+    }
+
     // --- data converter
 
     private static _asDiagnostic(quickFix: protocol.QuickFix): vscode.Diagnostic {
@@ -279,13 +286,13 @@ class DiagnosticsProvider extends AbstractSupport {
 
     private static _asDiagnosticSeverity(logLevel: string): vscode.DiagnosticSeverity {
         switch (logLevel.toLowerCase()) {
-            case 'warning':
-            case 'warn':
-                return vscode.DiagnosticSeverity.Warning;
-            case 'hidden':
-                return vscode.DiagnosticSeverity.Information;
-            default:
+            case 'error':
                 return vscode.DiagnosticSeverity.Error;
+            case 'warning':
+                return vscode.DiagnosticSeverity.Warning;
+            // info and hidden
+            default:
+                return vscode.DiagnosticSeverity.Information;
         }
     }
 


### PR DESCRIPTION
Fixes #1231

This stops reporting "Remove unnecessary using directives" (and other Roslyn hidden diagnostics) as "info" diagnostics in the problems window. This has an impact of no longer showing a squiggle for unnecessary usings in the editor, but we will hopefully be able to address that by fading the usings in the editor (https://github.com/Microsoft/vscode/issues/20219).
