### PR TITLE
Send events from the debugger to unit test code

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -541,27 +541,10 @@ function doesAnyAssetExist(generator: AssetGenerator) {
     });
 }
 
-function deleteAsset(path: string) {
-    return new Promise<void>((resolve, reject) => {
-        fs.exists(path, exists => {
-            if (exists) {
-                // TODO: Should we check after unlinking to see if the file still exists?
-                fs.unlink(path, err => {
-                    if (err) {
-                        return reject(err);
-                    }
-
-                    resolve();
-                });
-            }
-        });
-    });
-}
-
 function deleteAssets(generator: AssetGenerator) {
     return Promise.all([
-        deleteAsset(generator.launchJsonPath),
-        deleteAsset(generator.tasksJsonPath)
+        util.deleteIfExists(generator.launchJsonPath),
+        util.deleteIfExists(generator.tasksJsonPath)
     ]);
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -73,6 +73,25 @@ export function fileExists(filePath: string): Promise<boolean> {
     });
 }
 
+export function deleteIfExists(filePath: string): Promise<void> {
+    return fileExists(filePath)
+    .then((exists: boolean) => {
+        return new Promise<void>((resolve, reject) => {
+            if (!exists) {
+                resolve();
+            }
+
+            fs.unlink(filePath, err => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve();
+            });
+        });
+    });
+}
+
 export enum InstallFileType {
     Begin,
     Lock

--- a/src/coreclr-debug/debuggerEventsProtocol.ts
+++ b/src/coreclr-debug/debuggerEventsProtocol.ts
@@ -10,18 +10,19 @@
 // 
 // All messages are sent as UTF-8 JSON text with a tailing '\n'
 export namespace DebuggerEventsProtocol {
-    export enum EventType {
+    export module EventType {
         // Indicates that the vsdbg-ui has received the attach or launch request and is starting up
-        starting,
+        export const Starting = "starting";
         // Indicates that vsdbg-ui has successfully launched the specified process.
         // The ProcessLaunchedEvent interface details the event payload.
-        processLaunched,
+        export const ProcessLaunched = "processLaunched";
         // Debug session is ending
-        debuggingStopped
-    }
+        export const DebuggingStopped = "debuggingStopped";
+    };
 
     export interface DebuggerEvent {
-        eventType: EventType;
+        // Contains one of the 'DebuggerEventsProtocol.EventType' values
+        eventType: string;
     }
 
     export interface ProcessLaunchedEvent extends DebuggerEvent {

--- a/src/coreclr-debug/debuggerEventsProtocol.ts
+++ b/src/coreclr-debug/debuggerEventsProtocol.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+// This contains the definition of messages that VsDbg-UI can send back to a listener which registers itself via the 'debuggerEventsPipeName'
+// property on a launch or attach request.
+// 
+// All messages are sent as UTF-8 JSON text with a tailing '\n'
+export namespace DebuggerEventsProtocol {
+    export enum EventType {
+        // Indicates that the vsdbg-ui has received the attach or launch request and is starting up
+        starting,
+        // Indicates that vsdbg-ui has successfully launched the specified process.
+        // The ProcessLaunchedEvent interface details the event payload.
+        processLaunched,
+        // Debug session is ending
+        debuggingStopped
+    }
+
+    export interface DebuggerEvent {
+        eventType: EventType;
+    }
+
+    export interface ProcessLaunchedEvent extends DebuggerEvent {
+        // Process id of the newly-launched target process
+        targetProcessId: number;
+    }
+
+    // Decodes a packet received from the debugger into an event
+    export function decodePacket(packet: Buffer) : DebuggerEvent {
+        // Verify the message ends in a newline
+        if (packet[packet.length-1] != 10 /*\n*/) {
+            throw new Error("Unexpected message received from debugger.");
+        }
+
+        const message = packet.toString('utf-8', 0, packet.length-1);
+        return JSON.parse(message);
+    }
+}


### PR DESCRIPTION
This checkin completes the next chunk of work for unit test debugging in VS Code. The changes here are to create an event channel to receive events from the debugger.

Remaining work:
- Fire new events into OmniSharp
- Somehow build the project if it is out of date before running the test
