### PR TITLE
Update the debugger to 1.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,8 +157,8 @@
     },
     {
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-win7-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-win7-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "win7-x64"
@@ -167,8 +167,8 @@
     },
     {
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-osx.10.11-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-osx.10.11-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-osx.10.11-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-osx.10.11-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "osx.10.11-x64"
@@ -181,8 +181,8 @@
     },
     {
       "description": ".NET Core Debugger (CentOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-centos.7-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-centos.7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-centos.7-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-centos.7-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "centos.7-x64"
@@ -195,8 +195,8 @@
     },
     {
       "description": ".NET Core Debugger (Debian / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-debian.8-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-debian.8-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-debian.8-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-debian.8-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "debian.8-x64"
@@ -209,8 +209,8 @@
     },
     {
       "description": ".NET Core Debugger (Fedora 23 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-fedora.23-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-fedora.23-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-fedora.23-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-fedora.23-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "fedora.23-x64"
@@ -223,8 +223,8 @@
     },
     {
       "description": ".NET Core Debugger (Fedora 24 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-fedora.24-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-fedora.24-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-fedora.24-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-fedora.24-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "fedora.24-x64"
@@ -237,8 +237,8 @@
     },
     {
       "description": ".NET Core Debugger (OpenSUSE 13 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-opensuse.13.2-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-opensuse.13.2-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-opensuse.13.2-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-opensuse.13.2-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "opensuse.13.2-x64"
@@ -251,8 +251,8 @@
     },
     {
       "description": ".NET Core Debugger (OpenSUSE 42 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-opensuse.42.1-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-opensuse.42.1-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-opensuse.42.1-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-opensuse.42.1-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "opensuse.42.1-x64"
@@ -265,8 +265,8 @@
     },
     {
       "description": ".NET Core Debugger (RHEL / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-rhel.7.2-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-rhel.7.2-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-rhel.7.2-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-rhel.7.2-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "rhel.7-x64"
@@ -279,8 +279,8 @@
     },
     {
       "description": ".NET Core Debugger (Ubuntu 14.04 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.14.04-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.14.04-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.14.04-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.14.04-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "ubuntu.14.04-x64"
@@ -293,8 +293,8 @@
     },
     {
       "description": ".NET Core Debugger (Ubuntu 16.04 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.16.04-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.16.04-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.16.04-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.16.04-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "ubuntu.16.04-x64"
@@ -307,8 +307,8 @@
     },
     {
       "description": ".NET Core Debugger (Ubuntu 16.10 / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.16.10-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-1/coreclr-debug-ubuntu.16.10-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.16.10-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-9-2/coreclr-debug-ubuntu.16.10-x64.zip",
       "installPath": ".debugger",
       "runtimeIds": [
         "ubuntu.16.10-x64"


### PR DESCRIPTION
This updates the debugger to the 1.9.2 version. This includes the support needed for unit test support and limited desktop CLR debugging.