### PR TITLE
Be sure to exit from resolved promise deleteIfExists(...) helper

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -78,7 +78,7 @@ export function deleteIfExists(filePath: string): Promise<void> {
     .then((exists: boolean) => {
         return new Promise<void>((resolve, reject) => {
             if (!exists) {
-                resolve();
+                return resolve();
             }
 
             fs.unlink(filePath, err => {


### PR DESCRIPTION
Failing to exit when the specified file path doens't exist means that we try to delete that file even though it doesn't exist. This results in a timing issue because the deletion is asynchronous. Essentially, it might unintentionally delete the file springs into being before the promise is resolved.

The issue I'm fixing is where a Unix pipe file path might get deleted while we're trying to connect to it.