### PR TITLE
Add summary line after test run

### DIFF
--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -55,12 +55,26 @@ export function runDotnetTest(testMethod: string, fileName: string, testFramewor
 
     serverUtils.runTest(server, request)
         .then(response => {
-            if (response.Pass) {
-                output.appendLine('Test passed \n');
+            const totalTests = response.Results.length;
+
+            let totalPassed = 0, totalFailed = 0, totalSkipped = 0;
+            for (let result of response.Results) {
+                switch (result.Outcome) {
+                    case protocol.V2.TestOutcomes.Failed:
+                        totalFailed += 1;
+                        break;
+                    case protocol.V2.TestOutcomes.Passed:
+                        totalPassed += 1;
+                        break;
+                    case protocol.V2.TestOutcomes.Skipped:
+                        totalSkipped += 1;
+                        break;
+                }
             }
-            else {
-                output.appendLine('Test failed \n');
-            }
+
+            output.appendLine('');
+            output.appendLine(`Total tests: ${totalTests}. Passed: ${totalPassed}. Failed: ${totalFailed}. Skipped: ${totalSkipped}`);
+            output.appendLine('');
 
             disposable.dispose();
         },

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -538,7 +538,15 @@ export namespace V2 {
         TestFrameworkName: string;
     }
 
-    export interface DotNetResult {
+    export module TestOutcomes {
+        export const None = 'none';
+        export const Passed = 'passed';
+        export const Failed = 'failed';
+        export const Skipped = 'skipped';
+        export const NotFound = 'notfound';
+    }
+
+    export interface DotNetTestResult {
         MethodName: string;
         Outcome: string;
         ErrorMessage: string;
@@ -548,6 +556,7 @@ export namespace V2 {
     export interface RunTestResponse {
         Failure: string;
         Pass: boolean;
+        Results: DotNetTestResult[];
     }
 
     export interface TestMessageEvent {


### PR DESCRIPTION
Fixes #419
Fixes #455

This adds a simple summary line after a test run that indicates how many tests passed, how many failed, and how many skipped.

![image](https://cloud.githubusercontent.com/assets/116161/25502878/2e3cd7ca-2b4d-11e7-9aaf-37a70dd7b617.png)
