### PR TITLE
Add support for passing debug options when unit test debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Tests that define display names are now run properly. ([#1426](https://github.com/OmniSharp/omnisharp-vscode/issues/1426), PR: [omnisharp-roslyn#833](https://github.com/OmniSharp/omnisharp-roslyn/pull/833))
 * Tests with similar names are no longer incorrectly run together when one of them is clicked. ([#1432](https://github.com/OmniSharp/omnisharp-vscode/issues/1432), PR: [omnisharp-roslyn#833](https://github.com/OmniSharp/omnisharp-roslyn/pull/833))
 * Improve response from running/debugging tests to include output from build and test summary. ([#419](https://github.com/OmniSharp/omnisharp-vscode/issues/419), [#455](https://github.com/OmniSharp/omnisharp-vscode/issues/455), PR: [#1436](https://github.com/OmniSharp/omnisharp-vscode/pull/1436))
+* Added `csharp.unitTestDebugingOptions` setting to pass launch.json-style debug options (example: `justMyCode`) when unit test debugging.
 
 #### Project System
 

--- a/package.json
+++ b/package.json
@@ -359,6 +359,84 @@
           ],
           "description": "If the current Linux distribution is not recognized, this option can be used to tell the debugger what version can be used. After changing this option, close VS Code, remove the debugger folder (~/.vscode/extensions/ms-vscode.csharp-<ver>/.debugger) if it has already downloaded, and restart VS Code."
         },
+        "csharp.unitTestDebugingOptions": {
+          "type": "object",
+          "description": "Options to use with the debugger when launching for unit test debugging. Any launch.json option is valid here.",
+          "default": {},
+          "properties": {
+            "sourceFileMap": {
+              "type": "object",
+              "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {
+                "<source-path>": "<target-path>"
+              }
+            },
+            "justMyCode": {
+              "type": "boolean",
+              "description": "Optional flag to only show user code.",
+              "default": true
+            },
+            "symbolPath": {
+              "type": "array",
+              "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "requireExactSource": {
+              "type": "boolean",
+              "description": "Optional flag to require current source code to match the pdb.",
+              "default": true
+            },
+            "enableStepFiltering": {
+              "type": "boolean",
+              "description": "Optional flag to enable stepping over Properties and Operators.",
+              "default": true
+            },
+            "debugServer": {
+              "type": "number",
+              "description": "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
+              "default": 4711 
+            },
+            "logging": {
+              "description": "Optional flags to determine what types of messages should be logged to the output window.",
+              "type": "object",
+              "required": [],
+              "default": {},
+              "properties": {
+                "exceptions": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+                  "default": true
+                },
+                "moduleLoad": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                  "default": true
+                },
+                "programOutput": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+                  "default": true
+                },
+                "engineLogging": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+                  "default": false
+                },
+                "browserStdOut": {
+                  "type": "boolean",
+                  "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
+                  "default": true
+                }
+              }
+            }
+          }
+        },
         "csharp.suppressDotnetRestoreNotification": {
           "type": "boolean",
           "default": false,

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -85,18 +85,28 @@ export function runDotnetTest(testMethod: string, fileName: string, testFramewor
 }
 
 function createLaunchConfiguration(program: string, args: string, cwd: string, debuggerEventsPipeName: string) {
-    return {
-        // NOTE: uncomment this for vsdbg developement
-        // debugServer: 4711,
-        name: ".NET Test Launch",
-        type: "coreclr",
-        request: "launch",
-        debuggerEventsPipeName: debuggerEventsPipeName,
-        program,
-        args,
-        cwd,
-        stopAtEntry: true
-    };
+    let debugOptions = vscode.workspace.getConfiguration('csharp').get('unitTestDebugingOptions');
+
+    // Get the initial set of options from the workspace setting
+    let result:any;
+    if (typeof debugOptions === "object") {
+        // clone the options object to avoid changing it
+        result = JSON.parse(JSON.stringify(debugOptions));
+    } else {
+        result = {};
+    }
+
+    // Now fill in the rest of the options
+    result.name = ".NET Test Launch";
+    result.type = "coreclr";
+    result.request = "launch";
+    result.debuggerEventsPipeName = debuggerEventsPipeName;
+    result.program = program;
+    result.args = args;
+    result.cwd = cwd;
+    result.stopAtEntry = true;
+
+    return result;
 }
 
 function getLaunchConfigurationForVSTest(server: OmniSharpServer, fileName: string, testMethod: string, testFrameworkName: string, debugEventListener: DebugEventListener): Promise<any> {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -104,7 +104,6 @@ function createLaunchConfiguration(program: string, args: string, cwd: string, d
     result.program = program;
     result.args = args;
     result.cwd = cwd;
-    result.stopAtEntry = true;
 
     return result;
 }

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -5,8 +5,12 @@ OptionsSchema.json defines the type for Launch/Attach options.
 If there are any modifications to the OptionsSchema.json file. Please run `gulp generateOptionsSchema` at the repo root.
 This will call GenerateOptionsSchema and update the package.json file. 
 
-**NOTE:** *Any manual changes to package.json's object.contributes.debuggers[0].configurationAttributes will be 
-replaced by this generator*
+### Important notes:
+
+1. Any manual changes to package.json's object.contributes.debuggers[0].configurationAttributes will be 
+replaced by this generator.
+2. This does **NOT** update the schema for csharp.unitTestDebugingOptions. So if the schema change is something valuable in unit test debugging, consider updating that section of package.json (look for `"csharp.unitTestDebugingOptions"`). The schema will work even if this step is omitted, but users will not get IntelliSense help when editing the new option if this step is skipped.
+
 
 If there is any other type of options added in the future, you will need to modify the GenerateOptionsSchema function 
 to have it appear in package.json. It only adds launch and attach.


### PR DESCRIPTION
Recently there have been a few cases where I wanted to have folks enable debugging options when debugging unit tests, but we didn't have any way of providing them. This checkin fixes that.

This will address https://github.com/OmniSharp/omnisharp-vscode/issues/940