### PR TITLE
Adding generateAssets to activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,6 +329,7 @@
     "onCommand:o.pickProjectAndStart",
     "onCommand:o.showOutput",
     "onCommand:dotnet.restore",
+    "onCommand:dotnet.generateAssets",
     "onCommand:csharp.downloadDebugger",
     "onCommand:csharp.listProcess",
     "onCommand:csharp.listRemoteProcess",


### PR DESCRIPTION
Fixing _.NET: Generate Assets for Build and Debug_ command not found error.