### PR TITLE
Support to run MSTest based tests

### DIFF
--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -187,14 +187,14 @@ export function updateCodeLensForTest(bucket: vscode.CodeLens[], fileName: strin
     let testFeature = node.Features.find(value => (value.Name == 'XunitTestMethod' || value.Name == 'NUnitTestMethod' || value.Name == 'MSTestMethod'));
     if (testFeature) {
         // this test method has a test feature
-        let testFrameworkName = 'xunit'
+        let testFrameworkName = 'xunit';
         if(testFeature.Name == 'NunitTestMethod')
         {
             testFrameworkName = 'nunit';
         }
         else if(testFeature.Name == 'MSTestMethod')
         {
-            testFrameworkName = 'mstest'
+            testFrameworkName = 'mstest';
         }
         
         bucket.push(new vscode.CodeLens(

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -184,10 +184,19 @@ export function updateCodeLensForTest(bucket: vscode.CodeLens[], fileName: strin
         return;
     }
 
-    let testFeature = node.Features.find(value => (value.Name == 'XunitTestMethod' || value.Name == 'NUnitTestMethod'));
+    let testFeature = node.Features.find(value => (value.Name == 'XunitTestMethod' || value.Name == 'NUnitTestMethod' || value.Name == 'MSTestMethod'));
     if (testFeature) {
         // this test method has a test feature
-        let testFrameworkName = testFeature.Name == 'XunitTestMethod' ? 'xunit' : 'nunit';
+        let testFrameworkName = 'xunit'
+        if(testFeature.Name == 'NunitTestMethod')
+        {
+            testFrameworkName = 'nunit';
+        }
+        else if(testFeature.Name == 'MSTestMethod')
+        {
+            testFrameworkName = 'mstest'
+        }
+        
         bucket.push(new vscode.CodeLens(
             toRange(node.Location),
             { title: "run test", command: 'dotnet.test.run', arguments: [testFeature.Data, fileName, testFrameworkName] }));


### PR DESCRIPTION
Fixes #1482

Added in support to run MSTest based tests.
Accompanying PR: https://github.com/OmniSharp/omnisharp-roslyn/pull/856 