### PR TITLE
Add more files to .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,9 @@ src/**
 .gitignore
 .travis.yml
 tsconfig.json
+ISSUE_TEMPLATE
+tslint.json
+gulpfile.js
 
 **/.nyc_output/**
 **/coverage/**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.10.0-beta4",
+  "version": "1.10.0-beta5",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",


### PR DESCRIPTION
This adds more files to the .vscodeignore file. Most importantly this excludes gulpfile.js as Windows Defender doesn't like it.