### PR TITLE
WIP: Support '/open', '/close', and new '/completion' and '/completionItem/resolve' OmniSharp end points

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -5,57 +5,102 @@
 
 'use strict';
 
-import {Disposable, Uri, workspace} from 'vscode';
-import {OmniSharpServer} from '../omnisharp/server';
+import { OmniSharpServer } from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
+import * as utils from '../common';
+import * as vscode from 'vscode';
 
-function forwardDocumentChanges(server: OmniSharpServer): Disposable {
+function isValidDocument(document: vscode.TextDocument) {
+    return !document.isUntitled
+        && document.languageId === 'csharp';
+}
 
-    return workspace.onDidChangeTextDocument(event => {
-
-        let {document} = event;
-        if (document.isUntitled || document.languageId !== 'csharp') {
+export function registerOpenDocuments(server: OmniSharpServer) {
+    utils.buildPromiseChain(vscode.workspace.textDocuments, document => {
+        if (!isValidDocument(document)) {
             return;
         }
 
-        if (!server.isRunning()) {
+        return serverUtils.fileOpen(server, { FileName: document.fileName });
+    });
+}
+
+function forwardDocumentOpenCloseEvents(server: OmniSharpServer): vscode.Disposable {
+    let d1 = vscode.workspace.onDidOpenTextDocument(document => {
+        if (!isValidDocument(document) ||
+            !server.isRunning()) {
             return;
         }
 
-        serverUtils.updateBuffer(server, {Buffer: document.getText(), FileName: document.fileName}).catch(err => {
+        serverUtils.fileOpen(server, { FileName: document.fileName })
+            .catch(err => {
+                console.error(err);
+                return err;
+            });
+    });
+
+    let d2 = vscode.workspace.onDidCloseTextDocument(document => {
+        if (!isValidDocument(document) ||
+            !server.isRunning()) {
+            return;
+        }
+
+        serverUtils.fileClose(server, { FileName: document.fileName })
+            .catch(err => {
+                console.error(err);
+                return err;
+            });
+    });
+
+    return vscode.Disposable.from(d1, d2);
+}
+
+function forwardDocumentChanges(server: OmniSharpServer): vscode.Disposable {
+
+    return vscode.workspace.onDidChangeTextDocument(event => {
+
+        let { document } = event;
+        
+        if (!isValidDocument(document) ||
+            !server.isRunning()) {
+            return;
+        }
+
+        serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName }).catch(err => {
             console.error(err);
             return err;
         });
     });
 }
 
-function forwardFileChanges(server: OmniSharpServer): Disposable {
+function forwardFileChanges(server: OmniSharpServer): vscode.Disposable {
 
-    function onFileSystemEvent(uri: Uri): void {
+    function onFileSystemEvent(uri: vscode.Uri): void {
         if (!server.isRunning()) {
             return;
         }
-        
+
         let req = { FileName: uri.fsPath };
-        
+
         serverUtils.filesChanged(server, [req]).catch(err => {
             console.warn(`[o] failed to forward file change event for ${uri.fsPath}`, err);
             return err;
         });
     }
 
-    const watcher = workspace.createFileSystemWatcher('**/*.*');
+    const watcher = vscode.workspace.createFileSystemWatcher('**/*.*');
     let d1 = watcher.onDidCreate(onFileSystemEvent);
     let d2 = watcher.onDidChange(onFileSystemEvent);
     let d3 = watcher.onDidDelete(onFileSystemEvent);
 
-    return Disposable.from(watcher, d1, d2, d3);
+    return vscode.Disposable.from(watcher, d1, d2, d3);
 }
 
-export default function forwardChanges(server: OmniSharpServer): Disposable {
+export default function forwardChanges(server: OmniSharpServer): vscode.Disposable {
 
     // combine file watching and text document watching
-    return Disposable.from(
+    return vscode.Disposable.from(
+        forwardDocumentOpenCloseEvents(server),
         forwardDocumentChanges(server),
         forwardFileChanges(server));
 }

--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -5,14 +5,24 @@
 
 'use strict';
 
-import {extractSummaryText} from './documentation';
 import AbstractSupport from './abstractProvider';
-import * as protocol from '../omnisharp/protocol';
+import { V2 as protocol } from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
-import {createRequest} from '../omnisharp/typeConvertion';
-import {CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Range, Position} from 'vscode';
+import * as vscode from 'vscode';
 
-export default class OmniSharpCompletionItemProvider extends AbstractSupport implements CompletionItemProvider {
+class OmniSharpCompletionItem extends vscode.CompletionItem {
+
+    readonly fileName: string;
+    readonly itemIndex: number;
+
+    constructor(label: string, kind: vscode.CompletionItemKind, fileName: string, itemIndex: number) {
+        super(label, kind);
+        this.fileName = fileName;
+        this.itemIndex = itemIndex;
+    }
+}
+
+export default class OmniSharpCompletionItemProvider extends AbstractSupport implements vscode.CompletionItemProvider {
 
     // copied from Roslyn here: https://github.com/dotnet/roslyn/blob/6e8f6d600b6c4bc0b92bc3d782a9e0b07e1c9f8e/src/Features/Core/Portable/Completion/CompletionRules.cs#L166-L169
     private static DefaultCommitCharacters = [
@@ -20,99 +30,98 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
         '~', '=', '<', '>', '?', '@', '#', '\'', '\"', '\\'];
 
-    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
+    public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.CompletionList> {
+        let request: protocol.CompletionRequest = {
+            FileName: document.fileName,
+            Position: document.offsetAt(position),
+            Trigger: this._createTrigger(document, position)
+        };
 
-        let wordToComplete = '';
-        let range = document.getWordRangeAtPosition(position);
-        if (range) {
-            wordToComplete = document.getText(new Range(range.start, position));
+        return serverUtils.completion(this._server, request)
+            .then(response => {
+                let items: vscode.CompletionItem[] = [];
+
+                for (let index = 0; index < response.Items.length; index++) {
+                    let item = response.Items[index];
+                    let kind = _kinds[item.Kind] || vscode.CompletionItemKind.Property;
+
+                    let newItem = new OmniSharpCompletionItem(item.DisplayText, kind, document.fileName, index);
+                    newItem.filterText = item.FilterText;
+                    newItem.sortText = item.SortText;
+
+                    items.push(newItem);
+                }
+
+                return new vscode.CompletionList(items, /*isIncomplete*/ false);
+            });
+    }
+
+    public resolveCompletionItem(item: vscode.CompletionItem, token: vscode.CancellationToken): Promise<vscode.CompletionItem> {
+        if (item instanceof OmniSharpCompletionItem) {
+            let request: protocol.CompletionItemResolveRequest = {
+                FileName: item.fileName,
+                ItemIndex: item.itemIndex,
+                DisplayText: item.label
+            };
+
+            return serverUtils.completionItemResolve(this._server, request)
+                .then(response => {
+                    item.documentation = response.Item.Description;
+                    item.insertText = response.Item.TextEdit.NewText;
+                    item.range = protocol.toRange(response.Item.TextEdit.Range);
+
+                    return item;
+                });
+        }
+    }
+
+    private _createTrigger(document: vscode.TextDocument, position: vscode.Position): protocol.CompletionTrigger {
+        // Currently, there's no good way to determine *how* completion was trigger (e.g. by typing, by specifically invoking, etc.)
+        //
+        //   * If the position is at the start of a line, we assume that completion was triggered by specifically
+        //     invoking it (e.g. Ctrl+Space), and specify a 'default' trigger.
+        //   * If the position is after the start of a line, we assume that completion was triggered by typing and
+        //     specify an 'insertion' trigger with the character to the left of the position.
+
+        if (position.character === 0) {
+            return {
+                Kind: protocol.CompletionTriggerKind.Invoke
+            };
         }
 
-        let req = createRequest<protocol.AutoCompleteRequest>(document, position);
-        req.WordToComplete = wordToComplete;
-        req.WantDocumentationForEveryCompletionResult = true;
-        req.WantKind = true;
-        req.WantReturnType = true;
+        let characterToLeft = new vscode.Range(new vscode.Position(position.line, position.character - 1), position);
 
-        return serverUtils.autoComplete(this._server, req).then(responses => {
-
-            if (!responses) {
-                return;
-            }
-
-            let result: CompletionItem[] = [];
-            let completions: { [c: string]: CompletionItem[] } = Object.create(null);
-
-            // transform AutoCompleteResponse to CompletionItem and
-            // group by code snippet
-            for (let response of responses) {
-                let completion = new CompletionItem(response.CompletionText);
-
-                completion.detail = response.ReturnType
-                    ? `${response.ReturnType} ${response.DisplayText}`
-                    : response.DisplayText;
-
-                completion.documentation = extractSummaryText(response.Description);
-                completion.kind = _kinds[response.Kind] || CompletionItemKind.Property;
-                completion.insertText = response.CompletionText.replace(/<>/g, '');
-                completion.commitCharacters = OmniSharpCompletionItemProvider.DefaultCommitCharacters;
-
-                let array = completions[completion.label];
-                if (!array) {
-                    completions[completion.label] = [completion];
-                }
-                else {
-                    array.push(completion);
-                }
-            }
-
-            // per suggestion group, select on and indicate overloads
-            for (let key in completions) {
-
-                let suggestion = completions[key][0],
-                    overloadCount = completions[key].length - 1;
-
-                if (overloadCount === 0) {
-                    // remove non overloaded items
-                    delete completions[key];
-
-                }
-                else {
-                    // indicate that there is more
-                    suggestion.detail = `${suggestion.detail} (+ ${overloadCount} overload(s))`;
-                }
-                
-                result.push(suggestion);
-            }
-
-            return result;
-        });
+        return {
+            Kind: protocol.CompletionTriggerKind.Insertion,
+            Character: document.getText(characterToLeft)
+        };
     }
 }
 
-const _kinds: { [kind: string]: CompletionItemKind; } = Object.create(null);
+const _kinds: { [kind: string]: vscode.CompletionItemKind; } = Object.create(null);
 
-// types
-_kinds['Class'] = CompletionItemKind.Class;
-_kinds['Delegate'] = CompletionItemKind.Class; // need a better option for this.
-_kinds['Enum'] = CompletionItemKind.Enum;
-_kinds['Interface'] = CompletionItemKind.Interface;
-_kinds['Struct'] = CompletionItemKind.Struct;
+// There are two potential kinds that are not covered below: 'Intrinsic' and 'Reference'.
+// However, it's not clear that this every show up in practice.
 
-// variables
-_kinds['Local'] = CompletionItemKind.Variable;
-_kinds['Parameter'] = CompletionItemKind.Variable;
-_kinds['RangeVariable'] = CompletionItemKind.Variable;
+_kinds['Class'] = vscode.CompletionItemKind.Class;
+_kinds['Constant'] = vscode.CompletionItemKind.Constant;
+_kinds['Delegate'] = vscode.CompletionItemKind.Class; // need a better option for this.
+_kinds['Enum'] = vscode.CompletionItemKind.Enum;
+_kinds['EnumMember'] = vscode.CompletionItemKind.EnumMember;
+_kinds['Event'] = vscode.CompletionItemKind.Event;
+_kinds['ExtensionMethod'] = vscode.CompletionItemKind.Method;
+_kinds['Field'] = vscode.CompletionItemKind.Field;
+_kinds['Interface'] = vscode.CompletionItemKind.Interface;
+_kinds['Keyword'] = vscode.CompletionItemKind.Keyword;
+_kinds['Label'] = vscode.CompletionItemKind.Unit; // need a better option for this.
+_kinds['Local'] = vscode.CompletionItemKind.Variable;
+_kinds['Method'] = vscode.CompletionItemKind.Method;
+_kinds['Module'] = vscode.CompletionItemKind.Module;
+_kinds['Namespace'] = vscode.CompletionItemKind.Module;
+_kinds['Operator'] = vscode.CompletionItemKind.Operator;
+_kinds['Parameter'] = vscode.CompletionItemKind.Variable;
+_kinds['Property'] = vscode.CompletionItemKind.Property;
+_kinds['RangeVariable'] = vscode.CompletionItemKind.Variable;
+_kinds['Structure'] = vscode.CompletionItemKind.Struct;
+_kinds['TypeParameter'] = vscode.CompletionItemKind.TypeParameter;
 
-// members
-_kinds['Const'] = CompletionItemKind.Constant;
-_kinds['EnumMember'] = CompletionItemKind.EnumMember;
-_kinds['Event'] = CompletionItemKind.Event;
-_kinds['Field'] = CompletionItemKind.Field;
-_kinds['Method'] = CompletionItemKind.Method;
-_kinds['Property'] = CompletionItemKind.Property;
-
-// other stuff
-_kinds['Label'] = CompletionItemKind.Unit; // need a better option for this.
-_kinds['Keyword'] = CompletionItemKind.Keyword;
-_kinds['Namespace'] = CompletionItemKind.Module;

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -433,9 +433,9 @@ export namespace V2 {
     }
 
     export module CompletionTriggerKind {
-        export const Invoke = 'Invoke';
-        export const Insertion = 'Insertion';
-        export const Deletion = 'Deletion';
+        export const Invoke = 'invoke';
+        export const Insertion = 'insertion';
+        export const Deletion = 'deletion';
     }
 
     export interface CompletionTrigger {
@@ -448,17 +448,33 @@ export namespace V2 {
         Trigger: CompletionTrigger;
     }
 
+    export module CharacterSetModificationRuleKind {
+        export const Add = 'add';
+        export const Remove = 'remove';
+        export const Replace = 'replace';
+    }
+
+    export interface CharacterSetModificationRule {
+        Kind: string;
+        Characters: string[];
+    }
+
     export interface CompletionItem {
         DisplayText: string;
         Kind: string;
         FilterText: string;
         SortText: string;
+        CommitCharacterRules: CharacterSetModificationRule[];
+
+        // These properties must be resolved via the '/v2/completionItem/resolve' end point
+        // before they are available.
         Description?: string;
         TextEdit?: TextEdit;
         AdditionalTextEdits: TextEdit[];
     }
 
     export interface CompletionResponse {
+        DefaultCommitCharacters: string[];
         IsSuggestionMode: boolean;
         Items: CompletionItem[];
     }

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -17,8 +17,24 @@ export function codeCheck(server: OmniSharpServer, request: protocol.Request, to
     return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.CodeCheck, request, token);
 }
 
+export function completion(server: OmniSharpServer, request: protocol.V2.CompletionRequest) {
+    return server.makeRequest<protocol.V2.CompletionResponse>(protocol.V2.Requests.Completion, request);
+}
+
+export function completionItemResolve(server: OmniSharpServer, request: protocol.V2.CompletionItemResolveRequest) {
+    return server.makeRequest<protocol.V2.CompletionItemResolveResponse>(protocol.V2.Requests.CompletionItemResolve, request);
+}
+
 export function currentFileMembersAsTree(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.CurrentFileMembersAsTreeResponse>(protocol.Requests.CurrentFileMembersAsTree, request, token);
+}
+
+export function fileClose(server: OmniSharpServer, request: protocol.FileBasedRequest) {
+    return server.makeRequest<void>(protocol.Requests.FileClose, request);
+}
+
+export function fileOpen(server: OmniSharpServer, request: protocol.FileBasedRequest) {
+    return server.makeRequest<void>(protocol.Requests.FileOpen, request);
 }
 
 export function filesChanged(server: OmniSharpServer, requests: protocol.Request[]) {


### PR DESCRIPTION
This is a work in progress. It's related to https://github.com/OmniSharp/omnisharp-roslyn/pull/884

TODO:
- [x] Handle commit characters properly
- [ ] Handle multi-line text edits