### PR TITLE
Update Mono to latest alpha build to fix .NET Core 2.0-preview2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.11.0-beta2",
+  "version": "1.11.0-beta3",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "runtimeDependencies": [
     {
       "description": "Mono Runtime (Linux / x86)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-4.8.0.478.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-5.2.0.104.zip",
       "installPath": "./bin",
       "platforms": [
         "linux"
@@ -84,7 +84,7 @@
     },
     {
       "description": "Mono Runtime (Linux / x64)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-4.8.0.478.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-5.2.0.104.zip",
       "installPath": "./bin",
       "platforms": [
         "linux"
@@ -100,7 +100,7 @@
     },
     {
       "description": "Mono Runtime (macOS)",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-4.8.0.478.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-5.2.0.104.zip",
       "installPath": "./bin",
       "platforms": [
         "darwin"
@@ -113,7 +113,7 @@
     },
     {
       "description": "Mono Framework Assemblies",
-      "url": "https://omnisharpdownload.blob.core.windows.net/ext/framework-4.8.0.478.zip",
+      "url": "https://omnisharpdownload.blob.core.windows.net/ext/framework-5.2.0.104.zip",
       "installPath": "./bin/framework",
       "platforms": [
         "darwin",


### PR DESCRIPTION
Fixes #1495