### PR TITLE
Update mono runtime and framework assemblies with custom build for OSX/Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "runtimeDependencies": [
     {
       "description": "Mono Runtime (Linux / x86)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86-5.2.0.104.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-5.2.0.104.zip",
+      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86-5.2.0-omnisharp1.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
         "linux"
@@ -85,8 +85,8 @@
     },
     {
       "description": "Mono Runtime (Linux / x64)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86_64-5.2.0.104.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-5.2.0.104.zip",
+      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86_64-5.2.0-omnisharp1.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
         "linux"
@@ -102,8 +102,8 @@
     },
     {
       "description": "Mono Runtime (macOS)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.osx-5.2.0.104.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-5.2.0.104.zip",
+      "url": "https://omnisharpdownload.azureedge.net/ext/mono.osx-5.2.0-omnisharp1.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
         "darwin"
@@ -116,8 +116,8 @@
     },
     {
       "description": "Mono Framework Assemblies",
-      "url": "https://omnisharpdownload.azureedge.net/ext/framework-5.2.0.104.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/framework-5.2.0.104.zip",
+      "url": "https://omnisharpdownload.azureedge.net/ext/framework-5.2.0-omnisharp1.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/framework-5.2.0-omnisharp1.zip",
       "installPath": "./bin/framework",
       "platforms": [
         "darwin",


### PR DESCRIPTION
This adds a custom build of the Mono runtime that cherry picks https://github.com/mono/mono/pull/5020 to address https://github.com/OmniSharp/omnisharp-vscode/issues/1566.