### PR TITLE
Hide status bar message

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -68,7 +68,7 @@ function completeDebuggerInstall(logger: Logger, channel: vscode.OutputChannel) 
                     let installer = new debugInstall.DebugInstaller(_debugUtil);
                     installer.finishInstall()
                         .then(() => {
-                            vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.');
+                            vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.', 5000);
                         })
                         .catch((err) => {
                             logger.appendLine("[ERROR]: An error occured while installing the .NET Core Debugger:");


### PR DESCRIPTION
Today, when installing the .NET Core Debugger a success message is shown in the status bar. That message never hides itself and this PR adds a 5sec timeout.