### PR TITLE
Fix IntelliSense

### DIFF
--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -5,12 +5,13 @@
 
 'use strict';
 
-import {extractSummaryText} from './documentation';
+import { extractSummaryText } from './documentation';
 import AbstractSupport from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
-import {createRequest} from '../omnisharp/typeConvertion';
-import {CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Range, Position} from 'vscode';
+import { createRequest } from '../omnisharp/typeConvertion';
+import { CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Range, Position, SnippetString } from 'vscode';
+import { Delimiter } from "./utils";
 
 export default class OmniSharpCompletionItemProvider extends AbstractSupport implements CompletionItemProvider {
 
@@ -19,7 +20,7 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         ' ', '{', '}', '[', ']', '(', ')', '.', ',', ':',
         ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
         '~', '=', '<', '>', '?', '@', '#', '\'', '\"', '\\'];
-    
+
     private static CommitCharactersWithoutSpace = [
         '{', '}', '[', ']', '(', ')', '.', ',', ':',
         ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
@@ -38,6 +39,7 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         req.WantDocumentationForEveryCompletionResult = true;
         req.WantKind = true;
         req.WantReturnType = true;
+        req.WantSnippet = true;
 
         return serverUtils.autoComplete(this._server, req).then(responses => {
 
@@ -46,57 +48,200 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
             }
 
             let result: CompletionItem[] = [];
-            let completions: { [c: string]: CompletionItem[] } = Object.create(null);
+            let completionGroups: { [label: string]: CompletionGroup } = Object.create(null);
 
-            // transform AutoCompleteResponse to CompletionItem and
-            // group by code snippet
             for (let response of responses) {
-                let completion = new CompletionItem(response.CompletionText);
+                let completionText = OmniSharpCompletionItemProvider.getCompletionText(response);
+                let group = completionGroups[completionText.label];
+                if (!group) {
+                    let completion = new CompletionItem(completionText.label);
 
-                completion.detail = response.ReturnType
-                    ? `${response.ReturnType} ${response.DisplayText}`
-                    : response.DisplayText;
+                    completion.detail = response.ReturnType
+                        ? `${response.ReturnType} ${response.DisplayText}`
+                        : response.DisplayText;
 
-                completion.documentation = extractSummaryText(response.Description);
-                completion.kind = _kinds[response.Kind] || CompletionItemKind.Property;
-                completion.insertText = response.CompletionText.replace(/<>/g, '');
+                    completion.documentation = extractSummaryText(response.Description);
+                    completion.kind = _kinds[response.Kind] || CompletionItemKind.Property;
+                    completion.insertText = completionText.insertText;
 
-                completion.commitCharacters = response.IsSuggestionMode
-                    ? OmniSharpCompletionItemProvider.CommitCharactersWithoutSpace
-                    : OmniSharpCompletionItemProvider.AllCommitCharacters;
+                    completion.commitCharacters = response.IsSuggestionMode
+                        ? OmniSharpCompletionItemProvider.CommitCharactersWithoutSpace
+                        : OmniSharpCompletionItemProvider.AllCommitCharacters;
 
-                let array = completions[completion.label];
-                if (!array) {
-                    completions[completion.label] = [completion];
-                }
-                else {
-                    array.push(completion);
+                    group = { represent: completion, overloadCount: 0, maxTabStopCount: completionText.tabStopCount };
+                    completionGroups[completionText.label] = group;
+                } else {
+                    group.overloadCount++;
+
+                    // Provide any valid documentation, if present.                    
+                    if (group.represent.documentation == null || group.represent.documentation.length == 0) {
+                        let documentation = extractSummaryText(response.Description);
+                        if (documentation != null && documentation.length > 0) {
+                            group.represent.documentation = documentation;
+                        }
+                    }
+
+                    if (group.maxTabStopCount < completionText.tabStopCount) {
+                        group.maxTabStopCount = completionText.tabStopCount;
+                        group.represent.insertText = completionText.insertText;
+                    }
                 }
             }
 
-            // per suggestion group, select on and indicate overloads
-            for (let key in completions) {
-
-                let suggestion = completions[key][0],
-                    overloadCount = completions[key].length - 1;
-
-                if (overloadCount === 0) {
-                    // remove non overloaded items
-                    delete completions[key];
-
-                }
-                else {
-                    // indicate that there is more
+            for (let key in completionGroups) {
+                let suggestion = completionGroups[key].represent;
+                let overloadCount = completionGroups[key].overloadCount;
+                if (overloadCount > 0) {
                     suggestion.detail = `${suggestion.detail} (+ ${overloadCount} overload(s))`;
                 }
-                
                 result.push(suggestion);
             }
 
             return result;
         });
     }
+
+    private static getCompletionText(response: protocol.AutoCompleteResponse): CompletionText {
+        if (response.Kind == 'Keyword') {
+            return OmniSharpCompletionItemProvider.getKeywordCompletionText(response.CompletionText);
+        }
+
+        // CompletionText contains parameters only when         
+        if (response.CompletionText.indexOf(_paramsDelimiter.start) >= 0) {
+            console.log(response.CompletionText);
+            return OmniSharpCompletionItemProvider.getOverridingMethodCompletionText(response.CompletionText, response.ReturnType);
+        }
+
+        let completionText = <CompletionText>{ tabStopCount: 0 };
+        let hasParams = false;
+        let hasTypeParams = false;
+
+        let label = response.DisplayText;
+        label = _paramsDelimiter.replace(label, found => {
+            if (found.length > 0) {
+                hasParams = true;
+            }
+            return '';
+        });
+
+        label = _typeParamsDelimiter.replace(label, found => {
+            hasTypeParams = true;
+            return '';
+        });
+
+        completionText.label = label;
+
+        let text = response.DisplayText;
+        let getTabStop = () => { return '$' + ++completionText.tabStopCount; };
+        if (hasTypeParams) {
+            text = _typeParamsDelimiter.replace(text, found => { return getTabStop(); });
+        }
+        if (hasParams) {
+            text = _paramsDelimiter.replace(text, found => { return getTabStop(); });
+        }
+
+        if (response.Kind == 'Method' && response.ReturnType == 'void') {
+            text += ';';
+        }
+        text += '$0';
+        completionText.insertText = new SnippetString(text);
+        return completionText;
+    }
+
+    private static getKeywordCompletionText(keyword: string): CompletionText {
+        let completionText = <CompletionText>{ label: keyword };
+
+        if (keyword in _trailingSpaceKeywords) {
+            completionText.insertText = keyword + ' ';
+            completionText.tabStopCount = 0;
+        } else if (keyword in _paramKeywords) {
+            completionText.insertText = new SnippetString(keyword + '($1)$0');
+            completionText.tabStopCount = 1;
+        } else {
+            completionText.insertText = keyword;
+            completionText.tabStopCount = 0;
+        }
+
+        return completionText;
+    }
+
+    private static getOverridingMethodCompletionText(text: string, returnType: string): CompletionText {
+        let baseCode = 'base.' + text + ';$0';
+        baseCode = _paramsDelimiter.replace(baseCode, found => {
+            let params = found.split(',');
+            for (let i = 0; i < params.length; i++) {
+                let paramBlock = params[i];
+                let paramSplit = paramBlock.split(/\s+/);
+                let paramName = paramSplit[paramSplit.length - 1];
+                params[i] = paramName;
+            }
+
+            return params.join(', ');
+        });
+
+        if (returnType != 'void') {
+            baseCode = 'return ' + baseCode;
+        }
+
+        return {
+            label: text,
+            insertText: new SnippetString(returnType + ' ' + text + '\n{\n\t' + baseCode + '\n}'),
+            tabStopCount: 0
+        };
+    }
 }
+
+interface CompletionText {
+    label: string;
+    insertText: string | SnippetString;
+    tabStopCount: number;
+}
+
+interface CompletionGroup {
+    represent: CompletionItem;
+    overloadCount: number;
+    maxTabStopCount: number;
+}
+
+const _typeParamsDelimiter = new Delimiter('<', '>');
+const _paramsDelimiter = new Delimiter('(', ')');
+
+const _trailingSpaceKeywords: { [keyword: string]: boolean } = Object.create(null);
+_trailingSpaceKeywords['abstract'] = true;
+_trailingSpaceKeywords['as'] = true;
+_trailingSpaceKeywords['async'] = true;
+_trailingSpaceKeywords['await'] = true;
+_trailingSpaceKeywords['const'] = true;
+_trailingSpaceKeywords['dynamic'] = true;
+_trailingSpaceKeywords['explicit'] = true;
+_trailingSpaceKeywords['extern'] = true;
+_trailingSpaceKeywords['goto'] = true;
+_trailingSpaceKeywords['implicit'] = true;
+_trailingSpaceKeywords['in'] = true;
+_trailingSpaceKeywords['internal'] = true;
+_trailingSpaceKeywords['is'] = true;
+_trailingSpaceKeywords['out'] = true;
+_trailingSpaceKeywords['override'] = true;
+_trailingSpaceKeywords['params'] = true;
+_trailingSpaceKeywords['private'] = true;
+_trailingSpaceKeywords['protected'] = true;
+_trailingSpaceKeywords['public'] = true;
+_trailingSpaceKeywords['readonly'] = true;
+_trailingSpaceKeywords['ref'] = true;
+_trailingSpaceKeywords['sealed'] = true;
+_trailingSpaceKeywords['stackalloc'] = true;
+_trailingSpaceKeywords['static'] = true;
+_trailingSpaceKeywords['unsafe'] = true;
+_trailingSpaceKeywords['using'] = true;
+_trailingSpaceKeywords['var'] = true;
+_trailingSpaceKeywords['virtual'] = true;
+_trailingSpaceKeywords['volatile'] = true;
+_trailingSpaceKeywords['yield'] = true;
+
+const _paramKeywords: { [keyword: string]: boolean } = Object.create(null);
+_paramKeywords['nameof'] = true;
+_paramKeywords['typeof'] = true;
+_paramKeywords['sizeof'] = true;
 
 const _kinds: { [kind: string]: CompletionItemKind; } = Object.create(null);
 

--- a/src/features/utils.ts
+++ b/src/features/utils.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+export class Delimiter {
+
+    private _start: string;
+    private _end: string;
+
+    public get start(): string {
+        return this._start;
+    }
+
+    public get end(): string {
+        return this._end;
+    }
+
+    constructor(start: string, end: string) {
+        this._start = start;
+        this._end = end;
+    }
+
+    public wrap(value: any): string {
+        return this.start + value + this.end;
+    }
+
+    public replace(text: string, replace: string | ((found: string) => string)): string {
+        let range = this._findRange(text);
+        if (!range) {
+            return text;
+        }
+
+        let before = text.substr(0, range.start);
+        let after = text.substring(range.end, text.length);
+        let replaceString: string = undefined;
+
+        if (typeof replace === 'string') {
+            replaceString = replace;
+        } else {
+            replaceString = replace(text.substring(range.start, range.end));
+        }
+
+        return before + replaceString + after;
+    }
+
+    private _findRange(text: string): TextRange {
+        let startIndex = text.indexOf(this.start);
+        if (startIndex >= 0) {
+            startIndex += this.start.length;
+            let endIndex = text.indexOf(this.end, startIndex);
+            if (endIndex >= 0) {
+                return { start: startIndex, end: endIndex };
+            }
+        }
+        return undefined;
+    }
+}
+
+interface TextRange {
+    start: number;
+    end: number;
+}


### PR DESCRIPTION
This is a fix I made to make the code completion faster.
I know that this might be against the whole `Omnisharp` architecture where the client should simply adopt the work done by the server to the specific client. But at least I give it a try :)

* Keywords that are unlikely to be a prefix for a user snippet come
  with a trailing white space.

* Keywords that require a parameter comes with a snippet where the
  single tabstop is for the parameter.

* For each CompletionItem, the label is a simplified signature.
  A simplified signature is a signature where the actual type
  parameters and parameters are stripped away so that only the
  <> and () are remaining. For example, the simplified signature
  of Something<T>(float f, int n) is Something<>().

* If an item contains type parameters or parameters, the item
  ships with a snippet where tabstops are the places for
  type parameters and parameters. Note that each parameter does
  not have its own tabstop. Instead, a tabstop is placed for
  the whole type parameters or parameters.

* Items are considered overloaded if they have the same label.
  If overloaded, the representing item has a snippet with the
  highest tabstop count, and the documentation can be any
  arbitrary one.

* For overriding methods, the completion text auto completes
  the whole method simply by calling the base method.

### Preview
Completing methods for two different types.
![method_completion](https://user-images.githubusercontent.com/20881989/27897388-fe3afd50-625a-11e7-85b7-09c61b044f78.gif)


Completing an overriding method.
![overriding_method](https://user-images.githubusercontent.com/20881989/27897389-022f5d48-625b-11e7-97b8-2f74ed104026.gif)
