### PR TITLE
read [csharp] configuration section for startup formatting settings

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -185,10 +185,12 @@ function launch(cwd: string, args: string[]): Promise<LaunchResult> {
 
         if (options.useEditorFormattingSettings) 
         {
-            let editorConfig = vscode.workspace.getConfiguration('editor');
-            args.push(`formattingOptions:useTabs=${!editorConfig.get('insertSpaces', true)}`);
-            args.push(`formattingOptions:tabSize=${editorConfig.get('tabSize', 4)}`);
-            args.push(`formattingOptions:indentationSize=${editorConfig.get('tabSize',4)}`);
+            let globalConfig = vscode.workspace.getConfiguration();
+            let csharpConfig = vscode.workspace.getConfiguration('[csharp]');
+
+            args.push(`formattingOptions:useTabs=${!getConfigurationValue(globalConfig, csharpConfig, 'editor.insertSpaces', true)}`);
+            args.push(`formattingOptions:tabSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
+            args.push(`formattingOptions:indentationSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
         }
 
         if (options.path && options.useMono) {
@@ -204,6 +206,16 @@ function launch(cwd: string, args: string[]): Promise<LaunchResult> {
             return launchNix(launchPath, cwd, args);
         }
     });
+}
+
+function getConfigurationValue(globalConfig: vscode.WorkspaceConfiguration, csharpConfig: vscode.WorkspaceConfiguration,
+    configurationPath: string, defaultValue: any): any {
+    
+    if (csharpConfig[configurationPath] != undefined) {
+        return csharpConfig[configurationPath];
+    }
+    
+    return globalConfig.get(configurationPath, defaultValue);
 }
 
 function getLaunchPath(platformInfo: PlatformInformation): string {


### PR DESCRIPTION
This change ensures we first check `[csharp]` section before looking at the global configuration section when determining OmniSharp startup formatting settings.

Note that the VS Code API [doesn't support](https://github.com/Microsoft/vscode/issues/20190) reading language specific settings at the moment so the look up is done using regular JSON property access.

Fixes #1632 
Fixes #1574 (duplicate bugs)