### PR TITLE
Switch to download.visualstudio.microsoft.com part 1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ const platform = require('./out/src/platform');
 const util = require('./out/src/common');
 const child_process = require('child_process');
 const optionsSchemaGenerator = require('./out/src/tools/GenerateOptionsSchema');
+const packageDependencyUpdater = require('./out/src/tools/UpdatePackageDependencies');
 
 const Logger = logger.Logger;
 const PackageManager = packages.PackageManager;
@@ -42,6 +43,10 @@ gulp.task('clean', () => {
 
 gulp.task('generateOptionsSchema', () => {
     optionsSchemaGenerator.GenerateOptionsSchema();
+});
+
+gulp.task('updatePackageDependencies', () => {
+    packageDependencyUpdater.updatePackageDependencies();
 });
 
 // Install Tasks

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "runtimeDependencies": [
     {
       "description": "Mono Runtime (Linux / x86)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86-5.2.0-omnisharp1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/mono.linux-x86-5.2.0-omnisharp1.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
@@ -85,7 +85,7 @@
     },
     {
       "description": "Mono Runtime (Linux / x64)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.linux-x86_64-5.2.0-omnisharp1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/mono.linux-x86_64-5.2.0-omnisharp1.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.linux-x86_64-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
@@ -102,7 +102,7 @@
     },
     {
       "description": "Mono Runtime (macOS)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/mono.osx-5.2.0-omnisharp1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/mono.osx-5.2.0-omnisharp1.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/mono.osx-5.2.0-omnisharp1.zip",
       "installPath": "./bin",
       "platforms": [
@@ -116,7 +116,7 @@
     },
     {
       "description": "Mono Framework Assemblies",
-      "url": "https://omnisharpdownload.azureedge.net/ext/framework-5.2.0-omnisharp1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/framework-5.2.0-omnisharp1.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/framework-5.2.0-omnisharp1.zip",
       "installPath": "./bin/framework",
       "platforms": [
@@ -127,7 +127,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x86)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/omnisharp-win-x86-1.22.0.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/omnisharp-win-x86-1.22.0.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.22.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
@@ -140,7 +140,7 @@
     },
     {
       "description": "OmniSharp (.NET 4.6 / x64)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/omnisharp-win-x64-1.22.0.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/omnisharp-win-x64-1.22.0.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.22.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [
@@ -153,7 +153,7 @@
     },
     {
       "description": "OmniSharp (Mono 4.6)",
-      "url": "https://omnisharpdownload.azureedge.net/ext/omnisharp-mono-1.22.0.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/10942097/51c64a0c8945d53601bbf75af88d88f3/omnisharp-mono-1.22.0.zip",
       "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-mono-1.22.0.zip",
       "installPath": "./bin/omnisharp",
       "platforms": [

--- a/src/tools/GenerateOptionsSchema.ts
+++ b/src/tools/GenerateOptionsSchema.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 
 function AppendFieldsToObject(reference: any, obj: any) {
 
@@ -94,5 +95,9 @@ export function GenerateOptionsSchema() {
     packageJSON.contributes.debuggers[1].configurationAttributes.launch = schemaJSON.definitions.LaunchOptions;
     packageJSON.contributes.debuggers[1].configurationAttributes.attach = schemaJSON.definitions.AttachOptions;
 
-    fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2));
+    let content = JSON.stringify(packageJSON, null, 2);
+    if (os.platform() === 'win32') {
+        content = content.replace(/\n/gm, "\r\n");
+    }
+    fs.writeFileSync('package.json', content);
 }

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import { Package } from '../packages';
+
+interface PackageJSONFile
+{
+    runtimeDependencies : Package[];
+}
+
+export function updatePackageDependencies() {
+
+    const urlsIndex = process.argv.indexOf("--urls");
+    const newPrimaryUrls = urlsIndex >= 0 ? process.argv[urlsIndex+1] : undefined;
+    
+    const fallbackUrlsIndex = process.argv.indexOf("--fallbackUrls");
+    const newFallbackUrls = fallbackUrlsIndex >= 0 ? process.argv[fallbackUrlsIndex+1] : undefined;
+    
+    if (newPrimaryUrls === undefined || newPrimaryUrls === "-?" || newPrimaryUrls === "-h") {
+        console.log("This command will update the URLs for package dependencies in package.json");
+        console.log();
+        console.log("Syntax: updatePackageDependencies --urls \"<url1>,<url2>,...\" [--fallbackUrls \"<fallback-url-1>,<fallback-url-2>...\"]");
+        console.log();
+        return;
+    }
+
+    if (newPrimaryUrls.length === 0) {
+        throw new Error("Invalid first argument to updatePackageDependencies. URL string argument expected.");
+    }
+
+    let packageJSON: PackageJSONFile = JSON.parse(fs.readFileSync('package.json').toString());
+    
+    // map from lowercase filename to Package
+    const mapFileNameToDependency = {};
+
+    // First build the map
+    packageJSON.runtimeDependencies.forEach(dependency => {
+        let fileName = getLowercaseFileNameFromUrl(dependency.url);
+        let existingDependency = mapFileNameToDependency[fileName];
+        if (existingDependency !== undefined) {
+            throw new Error(`Multiple dependencies found with filename '${fileName}': '${existingDependency.url}' and '${dependency.url}'.`);
+        }
+        mapFileNameToDependency[fileName] = dependency;
+    });
+    
+    let findDependencyToUpdate = (url : string): Package => {
+        let fileName = getLowercaseFileNameFromUrl(url);
+        let dependency = mapFileNameToDependency[fileName];
+        if (dependency === undefined) {
+            throw new Error(`Unable to update item for url '${url}'. No 'runtimeDependency' found with filename '${fileName}'.`);
+        }
+
+        console.log(`Updating ${url}`);
+        return dependency;
+    };
+
+    newPrimaryUrls.split(',').forEach(urlToUpdate =>{
+        let depedency = findDependencyToUpdate(urlToUpdate);
+        depedency.url = urlToUpdate;
+    });
+
+    if (newFallbackUrls !== undefined) {
+        newFallbackUrls.split(',').forEach(urlToUpdate =>{
+            let depedency = findDependencyToUpdate(urlToUpdate);
+            depedency.fallbackUrl = urlToUpdate;
+        }); 
+    }
+
+    let content = JSON.stringify(packageJSON, null, 2);
+    if (os.platform() === 'win32') {
+        content = content.replace(/\n/gm, "\r\n");
+    }
+    fs.writeFileSync('package.json', content);
+}
+
+function getLowercaseFileNameFromUrl(url : string) : string {
+
+    if (!url.startsWith("https://")) {
+        throw new Error(`Unexpected URL '${url}'. URL expected to start with 'https://'.`);
+    }
+
+    if (!url.endsWith(".zip")) {
+        throw new Error(`Unexpected URL '${url}'. URL expected to end with '.zip'.`);
+    }
+
+    let index = url.lastIndexOf("/");
+    return url.substr(index + 1).toLowerCase();    
+}


### PR DESCRIPTION
This checkin in the first part of the work to switch to using download.visualstudio.microsoft.com.

This checkin does two things:
1. It replaces the OmniSharp links with CDN links
2. It adds a new gulp task to update links in package.json. This will allow us to script the insertion process.