### PR TITLE
Allow 'type' to be customized for unit test debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,15 @@
                   "default": true
                 }
               }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "coreclr",
+                "clr"
+              ],
+              "description": "Type type of code to debug. Can be either 'coreclr' for .NET Core debugging, or 'clr' for Desktop .NET Framework. 'clr' only works on Windows as the Desktop framework is Windows-only.",
+              "default": "coreclr"
             }
           }
         },

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -111,9 +111,12 @@ function createLaunchConfiguration(program: string, args: string, cwd: string, d
         result = {};
     }
 
+    if (!result.type) {
+        result.type = "coreclr";
+    }
+
     // Now fill in the rest of the options
     result.name = ".NET Test Launch";
-    result.type = "coreclr";
     result.request = "launch";
     result.debuggerEventsPipeName = debuggerEventsPipeName;
     result.program = program;


### PR DESCRIPTION
This checkin allows the unit test debugging options to set 'type'. This resolves #1586.