### PR TITLE
Launch json program doc fix

### DIFF
--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -18,12 +18,16 @@ The `preLaunchTask` field runs the associated taskName in tasks.json before debu
 This will create a task that runs `dotnet build`. You can read more about tasks at [https://code.visualstudio.com/docs/editor/tasks](https://code.visualstudio.com/docs/editor/tasks).
 
 ## Program
-The program field is set to the path to the application dll or .NET Core host executable to launch. 
+The program field is set to the path of the application dll or .NET Core host executable to launch.
 
-Example: "${workspaceRoot}/bin/Debug/\<target-framework\>/\<project-name.dll\>" where:
+This property normally takes the form: "${workspaceRoot}/bin/Debug/\<target-framework\>/\<project-name.dll\>".
 
-* \<target-framework\>: (example: 'netstandard1.5') This is the framework that the app is being built for. It is set in the project.json file.
-* \<project-name\>: (example: 'MyApp') The name of the project being debugged.",
+Example: "${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll"
+
+Where:
+
+* \<target-framework\> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.
+* \<project-name.dll\> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.
 
 ## Cwd
 The working directory of the target process.

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -22,7 +22,7 @@ The program field is set to the path of the application dll or .NET Core host ex
 
 This property normally takes the form: "${workspaceRoot}/bin/Debug/\<target-framework\>/\<project-name.dll\>".
 
-Example: "${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll"
+Example: `"${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll"`
 
 Where:
 

--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/(target-framework)/(project-name.dll)'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n(target-framework) is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n(project-name.dll) is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
                 "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
               },
               "cwd": {
@@ -1404,7 +1404,7 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/(target-framework)/(project-name.dll)'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n(target-framework) is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n(project-name.dll) is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
                 "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
               },
               "cwd": {

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
                 "type": "string"
               },
               "default": {
-                "<source-path>": "<target-path>"
+                "<insert-source-path-here>": "<insert-target-path-here>"
               }
             },
             "justMyCode": {
@@ -477,8 +477,8 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Path to the application dll or .NET Core host executable to launch. Example: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>' where:\n<target-framework>: (example: 'netstandard1.5') This is the name of the framework that the app is being built for. It is set in the project.json file.\n<project-name>: (example: 'MyApp') The name of the project being debugged.",
-                "default": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>"
+                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
               },
               "cwd": {
                 "type": "string",
@@ -643,7 +643,7 @@
                   "type": "string"
                 },
                 "default": {
-                  "<source-path>": "<target-path>"
+                  "<insert-source-path-here>": "<insert-target-path-here>"
                 }
               },
               "justMyCode": {
@@ -951,7 +951,7 @@
                   "type": "string"
                 },
                 "default": {
-                  "<source-path>": "<target-path>"
+                  "<insert-source-path-here>": "<insert-target-path-here>"
                 }
               },
               "justMyCode": {
@@ -1334,7 +1334,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
+            "program": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
@@ -1345,7 +1345,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
+            "program": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
@@ -1404,8 +1404,8 @@
             "properties": {
               "program": {
                 "type": "string",
-                "description": "Path to the application dll or .NET Core host executable to launch. Example: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>' where:\n<target-framework>: (example: 'netstandard1.5') This is the name of the framework that the app is being built for. It is set in the project.json file.\n<project-name>: (example: 'MyApp') The name of the project being debugged.",
-                "default": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>"
+                "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
               },
               "cwd": {
                 "type": "string",
@@ -1570,7 +1570,7 @@
                   "type": "string"
                 },
                 "default": {
-                  "<source-path>": "<target-path>"
+                  "<insert-source-path-here>": "<insert-target-path-here>"
                 }
               },
               "justMyCode": {
@@ -1878,7 +1878,7 @@
                   "type": "string"
                 },
                 "default": {
-                  "<source-path>": "<target-path>"
+                  "<insert-source-path-here>": "<insert-target-path-here>"
                 }
               },
               "justMyCode": {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -126,7 +126,7 @@ export class AssetGenerator {
     private computeProgramPath() {
         if (!this.hasProject) {
             // If there's no target project data, use a placeholder for the path.
-            return '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>';
+            return '${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll';
         }
 
         let result = '${workspaceRoot}';

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -261,8 +261,8 @@
             "properties": {
                 "program": {
                     "type": "string",
-                    "description": "Path to the application dll or .NET Core host executable to launch. Example: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>' where:\n<target-framework>: (example: 'netstandard1.5') This is the name of the framework that the app is being built for. It is set in the project.json file.\n<project-name>: (example: 'MyApp') The name of the project being debugged.",
-                    "default": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>"
+                    "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                    "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
                 },
                 "cwd": {
                     "type": "string",
@@ -340,7 +340,7 @@
                         "type": "string"
                     },
                     "default": {
-                        "<source-path>": "<target-path>"
+                        "<insert-source-path-here>": "<insert-target-path-here>"
                     }
                 },
                 "justMyCode": {
@@ -406,7 +406,7 @@
                         "type": "string"
                     },
                     "default": {
-                        "<source-path>": "<target-path>"
+                        "<insert-source-path-here>": "<insert-target-path-here>"
                     }
                 },
                 "justMyCode": {

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -261,7 +261,7 @@
             "properties": {
                 "program": {
                     "type": "string",
-                    "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n<target-framework> is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n<project-name.dll> is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+                    "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceRoot}/bin/Debug/(target-framework)/(project-name.dll)'\nExample: '${workspaceRoot}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n(target-framework) is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n(project-name.dll) is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
                     "default": "${workspaceRoot}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
                 },
                 "cwd": {


### PR DESCRIPTION
This checkin makes tweaks to the docs/default value/template value for 'program' to hopefully make it really clear what one should use, and that you can't just leave it at some weird thing with '<' characters in it.

This resolves #1668.