### PR TITLE
Debugger: Make changes to detect and require macOS Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See our [change log](https://github.com/OmniSharp/omnisharp-vscode/blob/v1.10.0/
 * Currently, the C# debugger officially supports the following operating systems:
 
   * Windows (64-bit only)
-  * macOS
+  * macOS 10.12 (Sierra) and newer
   * Ubuntu 14.04+ (and distros based on it)
   * Debian 8.7+
   * Red Hat Enterprise Linux (RHEL) / CentOS / Oracle Linux 7.3+

--- a/debugger.md
+++ b/debugger.md
@@ -4,14 +4,6 @@ This page gives you detailed instructions on how to debug code running under .NE
 #### Your Feedback​
 File bugs and feature requests [here](https://github.com/OmniSharp/omnisharp-vscode/issues) and [join our insiders group](http://landinghub.visualstudio.com/dotnetcoreinsiders) to help us build great tooling for .NET Core.
 
-#### Requirements
-* Requires .NET Core 1.0 (rc2 and earlier releases are not supported)
-* X64 only
-* Supported operating systems: 
-    * macOS: 10.11+ (El Capitan+)
-    * Linux: Red Hat Enterprise Linux 7.2+, Ubuntu 14.04 LTS, Ubuntu 16.04 LTS, Debian 8.2+, Linux Mint 17+, CentOS 7.1+, Oracle Linux 7.1+, Fedora 23, openSUSE 13.2
-    * Windows: 7+
-
 ### First Time setup
 ##### 1: Get Visual Studio Code
 Install Visual Studio Code (VSC). Pick the latest VSC version from here: https://code.visualstudio.com Make sure it is at least 1.5. 

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as os from 'os';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { CoreClrDebugUtil, DotnetInfo, } from './util';
 import * as debugInstall from './install';
@@ -45,6 +46,14 @@ export function activate(thisExtension : vscode.Extension<any>, context: vscode.
 function completeDebuggerInstall(logger: Logger, channel: vscode.OutputChannel) : void {
     _debugUtil.checkDotNetCli()
         .then((dotnetInfo: DotnetInfo) => {
+
+            if (os.platform() === "darwin" && !CoreClrDebugUtil.isMacOSSupported()) {
+                logger.appendLine("[ERROR] The debugger cannot be installed. The debugger requires macOS 10.12 (Sierra) or newer.");
+                channel.show();
+                vscode.window.showErrorMessage("The .NET Core debugger cannot be installed. The debugger requires macOS 10.12 (Sierra) or newer.");
+                return;
+            }
+
             let installer = new debugInstall.DebugInstaller(_debugUtil);
             installer.finishInstall()
                 .then(() => {

--- a/src/coreclr-debug/proxy.ts
+++ b/src/coreclr-debug/proxy.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as path from 'path';
+import * as os from 'os';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import * as child_process from 'child_process';
 import { CoreClrDebugUtil } from './util';
@@ -70,6 +71,11 @@ function proxy() {
         //first check if dotnet is on the path and new enough
         util.checkDotNetCli()
             .then((dotnetInfo) => {
+                if (os.platform() === "darwin" && !CoreClrDebugUtil.isMacOSSupported()) {
+                    sendErrorMessage("The .NET Core debugger cannot be started. The debugger requires macOS 10.12 (Sierra) or newer.");
+                    return;
+                }
+
                 // next check if we have begun installing packages
                 common.installFileExists(common.InstallFileType.Begin)
                     .then((beginExists: boolean) => {

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -7,6 +7,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as semver from 'semver';
+import * as os from 'os';
 import { execChildProcess } from './../common';
 import { Logger } from './../logger';
 
@@ -114,6 +115,12 @@ export class CoreClrDebugUtil
 
             return dotnetInfo;
         });
+    }
+
+    public static isMacOSSupported() : boolean {
+        // .NET Core 2.0 requires macOS 10.12 (Sierra), which is Darwin 16.0+
+        // Darwin version chart: https://en.wikipedia.org/wiki/Darwin_(operating_system)
+        return semver.gte(os.release(), "16.0.0");
     }
 
     public static existsSync(path: string) : boolean {


### PR DESCRIPTION
.NET Core 2.0 only supports Sierra, and it will fall over on older versions of macOS. This adds detection code to let users know what is going on.