### PR TITLE
Support for optional formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
         "omnisharp.format.enable": {
           "type": "boolean",
           "default": true,
-          "description": "Specifes whether OmniSharp should be used for C# code formatting."
+          "description": "Enable/disable default C# formatter (requires restart)."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -366,6 +366,11 @@
           "type": "boolean",
           "default": true,
           "description": "Specifes whether OmniSharp should use VS Code editor settings for C# code formatting (use of tabs, indentation size)."
+        },
+        "omnisharp.format.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifes whether OmniSharp should be used for C# code formatting."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -214,6 +214,11 @@
     "configuration": {
       "title": "C# configuration",
       "properties": {
+        "csharp.format.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable default C# formatter (requires restart)."
+        },
         "csharp.suppressDotnetInstallWarning": {
           "type": "boolean",
           "default": false,
@@ -366,11 +371,6 @@
           "type": "boolean",
           "default": true,
           "description": "Specifes whether OmniSharp should use VS Code editor settings for C# code formatting (use of tabs, indentation size)."
-        },
-        "omnisharp.format.enable": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable/disable default C# formatter (requires restart)."
         }
       }
     },

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -14,7 +14,8 @@ export class Options {
         public autoStart?: boolean,
         public projectLoadTimeout?: number,
         public maxProjectResults?: number,
-        public useEditorFormattingSettings?: boolean) { }
+        public useEditorFormattingSettings?: boolean,
+        public useFormatting?: boolean) { }
 
     public static Read(): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -47,7 +48,8 @@ export class Options {
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
+        const useFormatting = omnisharpConfig.get<boolean>('format.enable', true);
 
-        return new Options(path, useMono, waitForDebugger, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings);
+        return new Options(path, useMono, waitForDebugger, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings, useFormatting);
     }
 }

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -48,7 +48,8 @@ export class Options {
         const projectLoadTimeout = omnisharpConfig.get<number>('projectLoadTimeout', 60);
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
-        const useFormatting = omnisharpConfig.get<boolean>('format.enable', true);
+
+        const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
         return new Options(path, useMono, waitForDebugger, loggingLevel, autoStart, projectLoadTimeout, maxProjectResults, useEditorFormattingSettings, useFormatting);
     }


### PR DESCRIPTION
* New option: "omnisharp.format.enable".
* Omnisharp respects "omnisharp.format.enable" option for self-registering as code formatter.