### PR TITLE
Only send telemetry for Linux distros that appears on an approved list

### DIFF
--- a/src/CSharpExtDownloader.ts
+++ b/src/CSharpExtDownloader.ts
@@ -115,7 +115,7 @@ export class CSharpExtDownloader
                 telemetryProps['platform.architecture'] = platformInfo.architecture;
                 telemetryProps['platform.platform'] = platformInfo.platform;
                 if (platformInfo.distribution) {
-                    telemetryProps['platform.distribution'] = platformInfo.distribution.toString();
+                    telemetryProps['platform.distribution'] = platformInfo.distribution.toTelemetryString();
                 }
 
                 if (this.reporter) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as util from './common';
@@ -35,21 +36,29 @@ export class LinuxDistribution {
 
     /**
      * Returns a string representation of LinuxDistribution that only returns the
-     * distro name if it appears on an approved list of known distros. Otherwise,
+     * distro name if it appears on an allowed list of known distros. Otherwise,
      * it returns 'other'.
      */
     public toTelemetryString(): string {
-        const approvedList = [
+        const allowedList = [
             'antergos', 'arch', 'centos', 'debian', 'deepin', 'elementary', 'fedora',
             'galliumos', 'gentoo', 'kali', 'linuxmint', 'manjoro', 'neon', 'opensuse',
             'parrot', 'rhel', 'ubuntu', 'zorin'
         ];
 
-        if (this.name === unknown || approvedList.indexOf(this.name) >= 0) {
+        if (this.name === unknown || allowedList.indexOf(this.name) >= 0) {
             return this.toString();
         }
         else {
-            return 'other';
+            // Having a hash of the name will be helpful to identify spikes in the 'other'
+            // bucket when a new distro becomes popular and needs to be added to the
+            // allowed list above.
+            const hash = crypto.createHash('sha256');
+            hash.update(this.name);
+
+            const hashedName = hash.digest('hex');
+
+            return `other (${hashedName})`;
         }
     }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -33,6 +33,26 @@ export class LinuxDistribution {
         return `name=${this.name}, version=${this.version}`;
     }
 
+    /**
+     * Returns a string representation of LinuxDistribution that only returns the
+     * distro name if it appears on an approved list of known distros. Otherwise,
+     * it returns 'other'.
+     */
+    public toTelemetryString(): string {
+        const approvedList = [
+            'antergos', 'arch', 'centos', 'debian', 'deepin', 'elementary', 'fedora',
+            'galliumos', 'gentoo', 'kali', 'linuxmint', 'manjoro', 'neon', 'opensuse',
+            'parrot', 'rhel', 'ubuntu', 'zorin'
+        ];
+
+        if (this.name === unknown || approvedList.indexOf(this.name) >= 0) {
+            return this.toString();
+        }
+        else {
+            return 'other';
+        }
+    }
+
     private static FromFilePath(filePath: string): Promise<LinuxDistribution> {
         return new Promise<LinuxDistribution>((resolve, reject) => {
             fs.readFile(filePath, 'utf8', (error, data) => {


### PR DESCRIPTION
This change ensures that we only send the name of a Linux distro to the telemetry report if it appears in an approved list of known distros. The idea here is to avoid sending distro names that we don't recognize in case the user might have built the distro themselves and included personally-identifiable information in the distro name.