### PR TITLE
Fix running and debugging NUnit tests

### DIFF
--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -104,7 +104,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         if (testFeature) {
             // this test method has a test feature
             let testFrameworkName = 'xunit';
-            if (testFeature.Name == 'NunitTestMethod') {
+            if (testFeature.Name == 'NUnitTestMethod') {
                 testFrameworkName = 'nunit';
             }
             else if (testFeature.Name == 'MSTestMethod') {


### PR DESCRIPTION
I found that when I click the "run test" item on my NUnit test class, it wouldn't do anything. Turning up the log level showed me the call to the server:

```
[dbug]: OmniSharp.Middleware.LoggingMiddleware
        ************ Request ************
POST - /v2/runtest
************ Headers ************
Content-Type - application/json
************  Body ************
{
  "FileName": "/Users/gileadis/Projects/Armor of God/Unity/Armor of God/Assets/Scripts/Editor/TypewriterTextTests.cs",
  "MethodName": "TypewriterTextTests.TestComplete",
  "TestFrameworkName": "xunit"
}
```

Notice the TestFrameworkName of `xunit`, even though I'm running an NUnit test. Digging through the code pointed me to this typo. I'm not certain it's the culprit, but it seems worth fixing in any case.