### PR TITLE
Fix "go to definition" from metadata within the same metadata file

### DIFF
--- a/src/features/definitionMetadataDocumentProvider.ts
+++ b/src/features/definitionMetadataDocumentProvider.ts
@@ -30,8 +30,7 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
     }
 
     public getExistingMetadataResponseUri(sourceName:string) : Uri {
-        const uri = this.createUri(sourceName);
-        return uri;
+        return this.createUri(sourceName);
     }
 
     public register() : void {
@@ -44,7 +43,6 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
 
     private createUri(sourceName:string) : Uri {
         return Uri.parse(this.scheme + "://" +
-                         sourceName.replace(/\\/g, "/")
-                                                    .replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
+            sourceName.replace(/\\/g, "/").replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
     }
 }

--- a/src/features/definitionMetadataDocumentProvider.ts
+++ b/src/features/definitionMetadataDocumentProvider.ts
@@ -29,7 +29,7 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
         return uri;
     }
 
-    public getExistingMetadataResponseUri(sourceName:string) : Uri {
+    public getExistingMetadataResponseUri(sourceName: string) : Uri {
         return this.createUri(sourceName);
     }
 
@@ -37,11 +37,11 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
         this._registration = workspace.registerTextDocumentContentProvider(this.scheme, this);
     }
 
-    public provideTextDocumentContent(uri : Uri) : string {
+    public provideTextDocumentContent(uri: Uri) : string {
         return this._documents.get(uri.toString()).Source;
     }
 
-    private createUri(sourceName:string) : Uri {
+    private createUri(sourceName: string) : Uri {
         return Uri.parse(this.scheme + "://" +
             sourceName.replace(/\\/g, "/").replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
     }

--- a/src/features/definitionMetadataDocumentProvider.ts
+++ b/src/features/definitionMetadataDocumentProvider.ts
@@ -23,10 +23,14 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
     }
 
     public addMetadataResponse(metadataResponse: MetadataResponse) : Uri {
-        const uri = this.createUri(metadataResponse);
-
+        const uri = this.createUri(metadataResponse.SourceName);
         this._documents.set(uri.toString(), metadataResponse);
 
+        return uri;
+    }
+
+    public getExistingMetadataResponseUri(sourceName:string) : Uri {
+        const uri = this.createUri(sourceName);
         return uri;
     }
 
@@ -38,9 +42,9 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
         return this._documents.get(uri.toString()).Source;
     }
 
-    private createUri(metadataResponse: MetadataResponse) : Uri {
+    private createUri(sourceName:string) : Uri {
         return Uri.parse(this.scheme + "://" +
-                         metadataResponse.SourceName.replace(/\\/g, "/")
+                         sourceName.replace(/\\/g, "/")
                                                     .replace(/(.*)\/(.*)/g, "$1/[metadata] $2"));
     }
 }

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -34,7 +34,7 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
 
                 // if it is part of an already used metadata file, retrieve its uri instead of going to the physical file
                 if (gotoDefinitionResponse.FileName.startsWith("$metadata$")) {
-                    let uri = this._definitionMetadataDocumentProvider.getExistingMetadataResponseUri(gotoDefinitionResponse.FileName);
+                    const uri = this._definitionMetadataDocumentProvider.getExistingMetadataResponseUri(gotoDefinitionResponse.FileName);
                     return toLocationFromUri(uri, gotoDefinitionResponse);
                 }
 

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -8,7 +8,7 @@
 import AbstractSupport from './abstractProvider';
 import {MetadataRequest, GoToDefinitionRequest, MetadataSource} from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
-import {createRequest, toLocation} from '../omnisharp/typeConvertion';
+import {createRequest, toLocation, toUriLocation} from '../omnisharp/typeConvertion';
 import {Uri, TextDocument, Position, Location, CancellationToken, DefinitionProvider} from 'vscode';
 import DefinitionMetadataDocumentProvider from './definitionMetadataDocumentProvider';
 import TelemetryReporter from 'vscode-extension-telemetry';
@@ -30,6 +30,11 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
         return serverUtils.goToDefinition(this._server, req, token).then(gotoDefinitionResponse => {
 
             if (gotoDefinitionResponse && gotoDefinitionResponse.FileName) {
+                if (gotoDefinitionResponse.FileName.startsWith("$metadata$")) {
+                    let uri = this._definitionMetadataDocumentProvider.getExistingMetadataResponseUri(gotoDefinitionResponse.FileName);
+                    return toUriLocation(uri, gotoDefinitionResponse);
+                }
+
                 return toLocation(gotoDefinitionResponse);
             } else if (gotoDefinitionResponse.MetadataSource) {
                 const metadataSource: MetadataSource = gotoDefinitionResponse.MetadataSource;

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -8,7 +8,7 @@
 import AbstractSupport from './abstractProvider';
 import {MetadataRequest, GoToDefinitionRequest, MetadataSource} from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
-import {createRequest, toLocation, toUriLocation} from '../omnisharp/typeConvertion';
+import {createRequest, toLocation, toLocationFromUri} from '../omnisharp/typeConvertion';
 import {Uri, TextDocument, Position, Location, CancellationToken, DefinitionProvider} from 'vscode';
 import DefinitionMetadataDocumentProvider from './definitionMetadataDocumentProvider';
 import TelemetryReporter from 'vscode-extension-telemetry';
@@ -29,16 +29,23 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
 
         return serverUtils.goToDefinition(this._server, req, token).then(gotoDefinitionResponse => {
 
+            // the defintion is in source
             if (gotoDefinitionResponse && gotoDefinitionResponse.FileName) {
+
+                // if it is part of an already used metadata file, retrieve its uri instead of going to the physical file
                 if (gotoDefinitionResponse.FileName.startsWith("$metadata$")) {
                     let uri = this._definitionMetadataDocumentProvider.getExistingMetadataResponseUri(gotoDefinitionResponse.FileName);
-                    return toUriLocation(uri, gotoDefinitionResponse);
+                    return toLocationFromUri(uri, gotoDefinitionResponse);
                 }
 
+                // if it is a normal source definition, convert the response to a location
                 return toLocation(gotoDefinitionResponse);
+               
+            // the definition is in metadata
             } else if (gotoDefinitionResponse.MetadataSource) {
                 const metadataSource: MetadataSource = gotoDefinitionResponse.MetadataSource;
 
+                // go to metadata endpoint for more information
                 return serverUtils.getMetadata(this._server, <MetadataRequest> {
                     Timeout: 5000,
                     AssemblyName: metadataSource.AssemblyName,

--- a/src/omnisharp/typeConvertion.ts
+++ b/src/omnisharp/typeConvertion.ts
@@ -22,6 +22,20 @@ export function toLocation(location: protocol.ResourceLocation | protocol.QuickF
     return new vscode.Location(fileName, position);
 }
 
+export function toUriLocation(uri:vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
+    const position = new vscode.Position(location.Line - 1, location.Column - 1);
+
+    const endLine = (<protocol.QuickFix>location).EndLine;
+    const endColumn = (<protocol.QuickFix>location).EndColumn;
+
+    if (endLine !== undefined && endColumn !== undefined) {
+        const endPosition = new vscode.Position(endLine - 1, endColumn - 1);
+        return new vscode.Location(uri, new vscode.Range(position, endPosition));
+    }
+
+    return new vscode.Location(uri, position);
+}
+
 export function toRange(rangeLike: { Line: number; Column: number; EndLine: number; EndColumn: number; }): vscode.Range {
     let {Line, Column, EndLine, EndColumn} = rangeLike;
     return new vscode.Range(Line - 1, Column - 1, EndLine - 1, EndColumn - 1);

--- a/src/omnisharp/typeConvertion.ts
+++ b/src/omnisharp/typeConvertion.ts
@@ -12,7 +12,7 @@ export function toLocation(location: protocol.ResourceLocation | protocol.QuickF
     return toLocationFromUri(fileName, location);
 }
 
-export function toLocationFromUri(uri:vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
+export function toLocationFromUri(uri: vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
     const position = new vscode.Position(location.Line - 1, location.Column - 1);
 
     const endLine = (<protocol.QuickFix>location).EndLine;

--- a/src/omnisharp/typeConvertion.ts
+++ b/src/omnisharp/typeConvertion.ts
@@ -9,20 +9,10 @@ import * as vscode from 'vscode';
 
 export function toLocation(location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
     const fileName = vscode.Uri.file(location.FileName);
-    const position = new vscode.Position(location.Line - 1, location.Column - 1);
-
-    const endLine = (<protocol.QuickFix>location).EndLine;
-    const endColumn = (<protocol.QuickFix>location).EndColumn;
-
-    if (endLine !== undefined && endColumn !== undefined) {
-        const endPosition = new vscode.Position(endLine - 1, endColumn - 1);
-        return new vscode.Location(fileName, new vscode.Range(position, endPosition));
-    }
-
-    return new vscode.Location(fileName, position);
+    return toLocationFromUri(fileName, location);
 }
 
-export function toUriLocation(uri:vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
+export function toLocationFromUri(uri:vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
     const position = new vscode.Position(location.Line - 1, location.Column - 1);
 
     const endLine = (<protocol.QuickFix>location).EndLine;


### PR DESCRIPTION
At the moment we have a nice story of going from `source -> metadata` and from `metadata -> other metadata`.
However, when trying to go from metadata as source file to **the same** metadata as source file, we get an error.

Albeit not a huge issue, it can be a little annoying. An example is below. 

Given the following metadata as source file (shortened for brevity), where we position the caret at `$$`:

```csharp
namespace System.Text
{
    //
    // Summary:
    //     Represents a character encoding.To browse the .NET Framework source code for
    //     this type, see the Reference Source.
    public abstract class Encoding
    {
        //
        // Summary:
        //     Gets an encoding for the UTF-7 format.
        //
        // Returns:
        //     An encoding for the UTF-7 format.
        public static Encodin$$g UTF7 { get; }
     }
}
```

When I invoke "go to definition" on `$$`, I should be taken back to `Encoding` definition within the same metadata file. Instead I get:

<img width="1180" alt="screenshot 2017-10-02 20 47 03" src="https://user-images.githubusercontent.com/1710369/31093669-c09aec42-a7b2-11e7-96df-b9f5f19d100e.png">


This PR fixes this.