### PR TITLE
Fixed disabling of code lens references

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,11 @@
           "default": true,
           "description": "Specifies whether the references CodeLens show be shown."
         },
+        "csharp.showTestsCodeLens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether the run and debug test CodeLens show be shown."
+        },
         "omnisharp.path": {
           "type": [
             "string",

--- a/package.json
+++ b/package.json
@@ -326,12 +326,12 @@
         "csharp.showReferencesCodeLens": {
           "type": "boolean",
           "default": true,
-          "description": "Specifies whether the references CodeLens show be shown."
+          "description": "Specifies whether the references CodeLens should be show be shown."
         },
         "csharp.showTestsCodeLens": {
           "type": "boolean",
           "default": true,
-          "description": "Specifies whether the run and debug test CodeLens show be shown."
+          "description": "Specifies whether the run and debug test CodeLens should be show be shown."
         },
         "omnisharp.path": {
           "type": [

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -35,6 +35,13 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         super(server, reporter);
 
         this._testManager = testManager;
+        this._checkOptions();
+
+        let configChangedDisposable = vscode.workspace.onDidChangeConfiguration(this._checkOptions, this);
+        this.addDisposables(configChangedDisposable);
+    }
+
+    private _checkOptions(): void {
         this._options = Options.Read();
     }
 

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -16,7 +16,8 @@ export class Options {
         public maxProjectResults?: number,
         public useEditorFormattingSettings?: boolean,
         public useFormatting?: boolean,
-        public showReferencesCodeLens?: boolean) { }
+        public showReferencesCodeLens?: boolean,
+        public showTestsCodeLens?: boolean) { }
 
     public static Read(): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -53,6 +54,7 @@ export class Options {
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
         const showReferencesCodeLens = csharpConfig.get<boolean>('showReferencesCodeLens', true);
+        const showTestsCodeLens = csharpConfig.get<boolean>('showTestsCodeLens', true);
 
         return new Options(path, 
             useMono, 
@@ -63,6 +65,7 @@ export class Options {
             maxProjectResults, 
             useEditorFormattingSettings, 
             useFormatting,
-            showReferencesCodeLens);
+            showReferencesCodeLens,
+            showTestsCodeLens);
     }
 }


### PR DESCRIPTION
This is a follow up to #1781.
The setting to disable references code lens inadvertently also disabled the run/debug test code lens. 

This PR fixes that - so setting `csharp.showReferencesCodeLens` doesn't affect the test code lens.
It also introduces a sibling setting - `csharp.showTestsCodeLens`, which controls toggling the test code lens, without affecting the references code lens.