### PR TITLE
Revisit launch on Mono

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -197,7 +197,8 @@ export function launchOmniSharp(cwd: string, args: string[]): Promise<LaunchResu
                 setTimeout(function () {
                     resolve(result);
                 }, 0);
-            });
+            })
+            .catch(reason => reject(reason));
     });
 }
 

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -305,8 +305,8 @@ function launchNixMono(launchPath: string, cwd: string, args: string[]): Promise
     return canLaunchMono()
         .then(() => {
             let argsCopy = args.slice(0); // create copy of details args
-            argsCopy.unshift("--assembly-loader=strict");
             argsCopy.unshift(launchPath);
+            argsCopy.unshift("--assembly-loader=strict");
 
             let process = spawn('mono', argsCopy, {
                 detached: false,

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -496,6 +496,8 @@ export class OmniSharpServer {
     }
 
     private _onLineReceived(line: string) {
+        line = line.trim();
+
         if (line[0] !== '{') {
             this._logger.appendLine(line);
             return;


### PR DESCRIPTION
This change causes OmniSharp to be with the 'mono' on the path, if it is available and at least version 5.2.0. If 'mono' can't be found, we fall back to our local Mono.

In addition, I fixed a few bugs I noticed while testing:

1. STDOUT lines received from OmniSharp are trimmed before processing to ensure that they are properly handled if they start with non-printable characters.
2. Allow promise rejections from OmniSharp launch failures to propagate. If they aren't, any error messages will not be printed to the output.
3. Ensure that the `--assembly-loader=strict` argument is passed to Mono in the proper order. Since it's an argument to Mono, it needs to appear before any OmniSharp arguments.