### PR TITLE
Fix unit test debugging post October VSCode breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "tslint-microsoft-contrib": "^2.0.12",
     "typescript": "^2.0.3",
     "vsce": "^1.7.0",
-    "vscode": "^1.0.3"
+    "vscode": "^1.1.6"
   },
   "runtimeDependencies": [
     {
@@ -190,7 +190,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.12.0"
+    "vscode": "^1.15.0"
   },
   "activationEvents": [
     "onLanguage:csharp",

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -134,11 +134,9 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
                 toRange(node.Location),
                 { title: "run test", command: 'dotnet.test.run', arguments: [testFeature.Data, fileName, testFrameworkName] }));
 
-            if (this._server.isDebugEnable()) {
-                bucket.push(new vscode.CodeLens(
-                    toRange(node.Location),
-                    { title: "debug test", command: 'dotnet.test.debug', arguments: [testFeature.Data, fileName, testFrameworkName] }));
-            }
+            bucket.push(new vscode.CodeLens(
+                toRange(node.Location),
+                { title: "debug test", command: 'dotnet.test.debug', arguments: [testFeature.Data, fileName, testFrameworkName] }));
         }
     }
 }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -304,7 +304,10 @@ export default class TestManager extends AbstractProvider {
                 }
             })
             .then(() => this._getLaunchConfiguration(debugType, fileName, testMethod, testFrameworkName, targetFrameworkVersion, debugEventListener))
-            .then(config => vscode.commands.executeCommand('vscode.startDebug', config))
+            .then(config => {
+                const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName));
+                return vscode.debug.startDebugging(workspaceFolder, config);
+            })
             .catch(reason => {
                 vscode.window.showErrorMessage(`Failed to start debugger: ${reason}`);
                 if (debugEventListener != null) {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -78,8 +78,6 @@ export class OmniSharpServer {
     private _channel: vscode.OutputChannel;
     private _logger: Logger;
 
-    private _isDebugEnable: boolean = false;
-
     private _serverProcess: ChildProcess;
     private _options: Options;
 
@@ -144,10 +142,6 @@ export class OmniSharpServer {
 
     public getChannel(): vscode.OutputChannel {
         return this._channel;
-    }
-
-    public isDebugEnable(): boolean {
-        return this._isDebugEnable;
     }
 
     // --- eventing
@@ -285,13 +279,6 @@ export class OmniSharpServer {
             this._fireEvent(Events.ServerStart, solutionPath);
 
             return this._doConnect();
-        }).then(() => {
-            return vscode.commands.getCommands()
-                .then(commands => {
-                    if (commands.find(c => c === 'vscode.startDebug')) {
-                        this._isDebugEnable = true;
-                    }
-                });
         }).then(() => {
             // Start telemetry reporting
             this._telemetryIntervalId = setInterval(() => this._reportTelemetry(), TelemetryReportingDelay);


### PR DESCRIPTION
This checkin changes the C# extension so that unit test debugging will still work once the `vscode.StartDebug` command is removed.

To do this I changed our package.json so that we require the 1.15 (July) release of VS Code, and switched to using the new API.

This fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1787