### PR TITLE
Support workspace folders in OmniSharp launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "activationEvents": [
     "onLanguage:csharp",


### PR DESCRIPTION
This PR expands the OmniSharp launcher code to allow OmniSharp to be launched on workspace folders and launch targets within solution folders.