### PR TITLE
Rename CodeLens options to match JS/TS option names

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,12 +323,12 @@
           "default": true,
           "description": "Suppress 'hidden' diagnostics (such as 'unnecessary using directives') from appearing in the editor or the Problems pane."
         },
-        "csharp.showReferencesCodeLens": {
+        "csharp.referencesCodeLens.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Specifies whether the references CodeLens should be show be shown."
         },
-        "csharp.showTestsCodeLens": {
+        "csharp.testsCodeLens.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Specifies whether the run and debug test CodeLens should be show be shown."

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -54,8 +54,8 @@ export class Options {
 
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
-        const showReferencesCodeLens = csharpConfig.get<boolean>('showReferencesCodeLens', true);
-        const showTestsCodeLens = csharpConfig.get<boolean>('showTestsCodeLens', true);
+        const showReferencesCodeLens = csharpConfig.get<boolean>('referencesCodeLens.enabled', true);
+        const showTestsCodeLens = csharpConfig.get<boolean>('testsCodeLens.enabled', true);
 
         const disableCodeActions = csharpConfig.get<boolean>('disableCodeActions', false);
 


### PR DESCRIPTION
Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/1807