### PR TITLE
for single character completions, treat the completion list as incomplete

### DIFF
--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -10,7 +10,7 @@ import AbstractSupport from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
 import {createRequest} from '../omnisharp/typeConvertion';
-import {CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Range, Position} from 'vscode';
+import {CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Range, Position, CompletionList} from 'vscode';
 
 export default class OmniSharpCompletionItemProvider extends AbstractSupport implements CompletionItemProvider {
 
@@ -25,7 +25,7 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         ';', '+', '-', '*', '/', '%', '&', '|', '^', '!',
         '~', '=', '<', '>', '?', '@', '#', '\'', '\"', '\\'];
 
-    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
+    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionList> {
 
         let wordToComplete = '';
         let range = document.getWordRangeAtPosition(position);
@@ -93,7 +93,9 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
                 result.push(suggestion);
             }
 
-            return result;
+            // for short completions (up to 1 character), treat the list as incomplete
+            // because the server has likely witheld some matches due to performance constraints
+            return new CompletionList(result, wordToComplete.length > 1 ? false : true);
         });
     }
 }


### PR DESCRIPTION
Since we now have https://github.com/OmniSharp/omnisharp-roslyn/pull/990, which will offer good subsequence matching, we should treat completion lists for short words (empty and single letters) as incomplete. At the moment every completion list is considered complete and VS Code doesn't go back to the server for better matches as we type more characters.

This will force the editor to go again to the server with 2 letters, at which point the server will offer a much better result (as it will include the subsequence matches originally withheld for performance reasons). We may want to change that to 3 letters or more if the length of 2 is still too aggressive.