### PR TITLE
Ensure that we listen for file changes

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -51,11 +51,9 @@ function forwardFileChanges(server: OmniSharpServer): Disposable {
     const watcher = workspace.createFileSystemWatcher('**/*.*');
     let d1 = watcher.onDidCreate(onFileSystemEvent(FileChangeType.Create));
     let d2 = watcher.onDidDelete(onFileSystemEvent(FileChangeType.Delete));
+    let d3 = watcher.onDidChange(onFileSystemEvent(FileChangeType.Change));
 
-    // In theory we don't need to subscribe to "change" notifications
-    // because we already get them through the buffer update request
-
-    return Disposable.from(watcher, d1, d2);
+    return Disposable.from(watcher, d1, d2, d3);
 }
 
 export default function forwardChanges(server: OmniSharpServer): Disposable {


### PR DESCRIPTION
It's entirely possible for files to change without being opened and edited by VS Code. We need to watch for such changes.