### PR TITLE
Add Debug Launch integration test

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,10 +30,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
     let logger = new Logger(text => _channel.append(text));
 
     let runtimeDependenciesExist = await ensureRuntimeDependencies(extension, logger, reporter);
-
-    if (!runtimeDependenciesExist) {
-        //do something
-    }
     
     // activate language services
     let omniSharpPromise = OmniSharp.activate(context, reporter, _channel);
@@ -41,9 +37,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
     // register JSON completion & hover providers for project.json
     context.subscriptions.push(addJSONProviders());
     
-    // activate coreclr-debug
-    let coreClrDebugPromise = coreclrdebug.activate(extension, context, reporter, logger, _channel);
-
+    let coreClrDebugPromise = Promise.resolve();
+    if (runtimeDependenciesExist) {
+        // activate coreclr-debug
+        coreClrDebugPromise = coreclrdebug.activate(extension, context, reporter, logger, _channel);
+    }
+    
     return {
         initializationFinished: Promise.all([omniSharpPromise, coreClrDebugPromise])
         .then(a => {})

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -157,4 +157,6 @@ export function activate(context: vscode.ExtensionContext, reporter: TelemetryRe
     disposables.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new CSharpConfigurationProvider(server)));
 
     context.subscriptions.push(...disposables);
+    
+    return new Promise<string>(resolve => server.onServerStart(e => resolve(e)));
 }

--- a/test/integrationTests/index.ts
+++ b/test/integrationTests/index.ts
@@ -21,7 +21,7 @@ var testRunner = require('vscode/lib/testrunner');
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 
 testRunner.configure({
-    timeout: 10000,
+    timeout: 60000,
     ui: 'tdd',      // the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
 });

--- a/test/integrationTests/launchConfiguration.integration.test.ts
+++ b/test/integrationTests/launchConfiguration.integration.test.ts
@@ -1,0 +1,48 @@
+/*--------------------------------------------------------------------------------------------- 
+ *  Copyright (c) Microsoft Corporation. All rights reserved. 
+ *  Licensed under the MIT License. See License.txt in the project root for license information. 
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'async-file';
+import * as vscode from 'vscode';
+
+import poll from './poll';
+import { should } from 'chai';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+
+const chai = require('chai'); 
+chai.use(require('chai-arrays')); 
+chai.use(require('chai-fs')); 
+ 
+suite(`Tasks generation: ${testAssetWorkspace.description}`, function() {
+    suiteSetup(async function() { 
+        should();
+
+        let csharpExtension = vscode.extensions.getExtension("ms-vscode.csharp"); 
+        if (!csharpExtension.isActive) { 
+            await csharpExtension.activate(); 
+        }
+
+        testAssetWorkspace.deleteBuildArtifacts();
+
+        await fs.rimraf(testAssetWorkspace.vsCodeDirectoryPath);
+
+        await csharpExtension.exports.initializationFinished;
+        
+        await vscode.commands.executeCommand("dotnet.generateAssets");
+
+        await poll(async () => await fs.exists(testAssetWorkspace.launchJsonPath), 10000, 100);
+    }); 
+ 
+    test("Starting .NET Core Launch (console) from the workspace root should create an Active Debug Session", async () => { 
+        await vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], ".NET Core Launch (console)");
+
+        let debugSessionTerminated = new Promise(resolve => {
+            vscode.debug.onDidTerminateDebugSession((e) => resolve());
+        });
+        
+        vscode.debug.activeDebugSession.type.should.equal("coreclr");
+
+        await debugSessionTerminated;
+    });
+}); 

--- a/test/integrationTests/poll.ts
+++ b/test/integrationTests/poll.ts
@@ -1,0 +1,24 @@
+/*--------------------------------------------------------------------------------------------- 
+ *  Copyright (c) Microsoft Corporation. All rights reserved. 
+ *  Licensed under the MIT License. See License.txt in the project root for license information. 
+ *--------------------------------------------------------------------------------------------*/ 
+ 
+export default async function poll<T>(getValue: () => T, duration: number, step: number): Promise<T> { 
+    while (duration > 0) { 
+        let value = await getValue();
+ 
+        if (value) { 
+            return value; 
+        } 
+ 
+        await sleep(step); 
+ 
+        duration -= step; 
+    } 
+ 
+    throw new Error("Polling did not succeed within the alotted duration."); 
+} 
+ 
+function sleep(ms = 0) {
+    return new Promise(r => setTimeout(r, ms)); 
+}

--- a/test/integrationTests/testAssets/testAssets.ts
+++ b/test/integrationTests/testAssets/testAssets.ts
@@ -45,6 +45,18 @@ export class TestAssetWorkspace {
     async deleteBuildArtifacts(): Promise<void> {
         this.projects.forEach(async p => await p.deleteBuildArtifacts());
     }
+    
+    get vsCodeDirectoryPath(): string {
+        return path.join(vscode.workspace.rootPath, ".vscode");;
+    }
+
+    get launchJsonPath(): string {
+        return path.join(this.vsCodeDirectoryPath, "launch.json");
+    }
+    
+    get tasksJsonPath(): string {
+        return path.join(this.vsCodeDirectoryPath, "tasks.json");
+    }
 
     description: string;
 


### PR DESCRIPTION
The integration test:
 - deletes the .vscode directory
 - deletes existing build artifacts
 - issues the `dotnet.generateAssets` command
 - executes the `.NET Core Launch (console)` debug configuration
 - validates that a debugSession becomes active
 - waits for debugging to stop

To enable this, and other integration tests, I exposed an export on the csharp extension which can be awaited until the extension is initialized. Initialized is defined as omnisharp and the debugger being ready for invocation. Without awaiting this promise, commands issues to the extension have unpredictable behaviors since they are registered but not yet able to be handled.