### PR TITLE
Enable Integration Tests to expose Logger output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ install.*
 obj/
 bin/
 test/**/.vscode
+.logs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,12 @@ install:
 script:
   - npm test --silent
 
+after_failure:
+  - ./.travis/printLogs.sh
+
+after_success:
+  - ./.travis/printLogs.sh
+
 deploy:
   provider: releases
   api_key:

--- a/.travis/printLogs.sh
+++ b/.travis/printLogs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# ---------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+fold_start() {
+  echo -e "travis_fold:start:$1\033[33;1m$2\033[0m"
+}
+
+fold_end() {
+  echo -e "\ntravis_fold:end:$1\r"
+}
+
+fold_start testLogs "Test Logs"
+
+for f in ./.logs/*.log
+do
+  fold_start logFile $f
+  cat $f
+  fold_end logFile
+done
+
+fold_end testLogs

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,11 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+let Subscriber: (message: string) => void;
+
+export function SubscribeToAllLoggers(subscriber: (message:string) => void) {
+    Subscriber = subscriber;
+}
 
 export class Logger {
     private _writer: (message: string) => void;
@@ -20,17 +25,17 @@ export class Logger {
         if (this._atLineStart) {
             if (this._indentLevel > 0) {
                 const indent = " ".repeat(this._indentLevel * this._indentSize);
-                this._writer(indent);
+                this.write(indent);
             }
 
             if (this._prefix) {
-                this._writer(`[${this._prefix}] `);
+                this.write(`[${this._prefix}] `);
             }
 
             this._atLineStart = false;
         }
 
-        this._writer(message); 
+        this.write(message); 
     }
 
     public increaseIndent(): void {
@@ -52,5 +57,13 @@ export class Logger {
         message = message || "";
         this._appendCore(message + '\n');
         this._atLineStart = true;
+    }
+
+    private write(message: string) {
+        this._writer(message);
+
+        if (Subscriber) {
+            Subscriber(message);
+        }
     }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
 let Subscriber: (message: string) => void;
 
 export function SubscribeToAllLoggers(subscriber: (message:string) => void) {

--- a/test/integrationTests/index.ts
+++ b/test/integrationTests/index.ts
@@ -3,7 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from "fs";
+
 import { SubscribeToAllLoggers } from "../../src/logger";
+
 //
 // PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
 //
@@ -16,7 +19,7 @@ import { SubscribeToAllLoggers } from "../../src/logger";
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+let testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
@@ -27,6 +30,14 @@ testRunner.configure({
     useColors: true // colored output from test results
 });
 
-SubscribeToAllLoggers(message => console.log(message));
+if (process.env.OSVC_SUITE) {
+    if (!fs.existsSync("./.logs")) {
+        fs.mkdirSync("./.logs");
+    }
+    
+    let logFilePath = `./.logs/${process.env.OSVC_SUITE}.log`;
+
+    SubscribeToAllLoggers(message => fs.appendFileSync(logFilePath, message));
+}
 
 module.exports = testRunner;

--- a/test/integrationTests/index.ts
+++ b/test/integrationTests/index.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SubscribeToAllLoggers } from "../../src/logger";
 //
 // PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
 //
@@ -25,5 +26,7 @@ testRunner.configure({
     ui: 'tdd',      // the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
 });
+
+SubscribeToAllLoggers(message => console.log(message));
 
 module.exports = testRunner;

--- a/test/unitTests/index.ts
+++ b/test/unitTests/index.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SubscribeToAllLoggers } from "../../src/logger";
 //
 // PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
 //
@@ -25,5 +26,7 @@ testRunner.configure({
     ui: 'tdd',      // the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
 });
+
+SubscribeToAllLoggers(message => console.log(message));
 
 module.exports = testRunner;

--- a/test/unitTests/index.ts
+++ b/test/unitTests/index.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SubscribeToAllLoggers } from "../../src/logger";
 //
 // PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
 //
@@ -16,7 +15,7 @@ import { SubscribeToAllLoggers } from "../../src/logger";
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+let testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
@@ -26,7 +25,5 @@ testRunner.configure({
     ui: 'tdd',      // the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
 });
-
-SubscribeToAllLoggers(message => console.log(message));
 
 module.exports = testRunner;


### PR DESCRIPTION
Enables subscribing a logging callback that will be invoked by all instances of Logger.