### PR TITLE
Set CODE_VERSION environment variable to 1.17.2 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
 - "6"
 
+env:
+- CODE_VERSION=1.17.2
+
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;


### PR DESCRIPTION
Note: This is not a long-term solution, as we'll eventually need to update the VS Code engine version that C# for VS Code targets.