### PR TITLE
Handling Newlines in XML Documentation

### DIFF
--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -21,7 +21,8 @@ export default class OmniSharpHoverProvider extends AbstractSupport implements H
 
         return serverUtils.typeLookup(this._server, req, token).then(value => {
             if (value && value.Type) {
-                let contents = [extractSummaryText(value.Documentation), { language: 'csharp', value: value.Type }];
+                let addLine = value.Documentation.split("\n").join("\n\n");
+                let contents = [extractSummaryText(addLine), { language: 'csharp', value: value.Type }];
                 return new Hover(contents);
             }
         });

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -1,0 +1,63 @@
+
+import * as fs from 'async-file';
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+import poll from './poll';
+import { should, expect } from 'chai';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+
+const chai = require('chai'); 
+chai.use(require('chai-arrays')); 
+chai.use(require('chai-fs')); 
+
+suite(`Test Hover Behavior ${testAssetWorkspace.description}`, function() {
+    suiteSetup(async function() { 
+        should();
+
+        let csharpExtension = vscode.extensions.getExtension("ms-vscode.csharp"); 
+        if (!csharpExtension.isActive) { 
+            await csharpExtension.activate();
+        }
+
+        testAssetWorkspace.deleteBuildArtifacts();
+        
+        await fs.rimraf(testAssetWorkspace.vsCodeDirectoryPath);
+        
+        await csharpExtension.exports.initializationFinished;
+                
+        await vscode.commands.executeCommand("dotnet.generateAssets");
+        
+        await poll(async () => await fs.exists(testAssetWorkspace.launchJsonPath), 10000, 100);
+
+    });
+
+
+    test("Hover returns the correct XML", async () => {                
+        
+        let program : string = "using System;\
+        \nnamespace hoverXmlDoc \
+        \n{\
+        \n    class testissue\
+        \n    {\
+        \n    ///<summary>Checks if object is tagged with the tag.</summary>\
+        \n    /// <param name=\"gameObject\">The game object.</param> \
+        \n    /// <param name=\"tagName\">Name of the tag </param>\
+        \n    /// <returns>Returns <c> true</c>if object is tagged with tag.</returns>\
+        \n\
+        \n        public static bool Compare(int gameObject,string tagName)\
+        \n        {\
+        \n            return gameObject.TagifyCompareTag(tagName);\
+        \n        }\
+        \n    }\
+        }";
+        let fileUri = await testAssetWorkspace.projects[0].addFileWithContents("test.cs", program); 
+        await vscode.commands.executeCommand("vscode.open", fileUri);
+
+        let c = await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri,new vscode.Position(10,30));
+        let answer:string = "Checks if object is tagged with the tag.\n\ngameObject: The game object.\n\ntagName: Name of the tag \n\nReturns: Returns trueif object is tagged with tag.";
+        expect(c[0].contents[0].value).to.equal(answer);
+        
+    });
+
+});

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -1,3 +1,7 @@
+/*--------------------------------------------------------------------------------------------- 
+ *  Copyright (c) Microsoft Corporation. All rights reserved. 
+ *  Licensed under the MIT License. See License.txt in the project root for license information. 
+ *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'async-file';
 import * as vscode from 'vscode';
@@ -19,45 +23,35 @@ suite(`Test Hover Behavior ${testAssetWorkspace.description}`, function() {
         if (!csharpExtension.isActive) { 
             await csharpExtension.activate();
         }
-
-        testAssetWorkspace.deleteBuildArtifacts();
-        
-        await fs.rimraf(testAssetWorkspace.vsCodeDirectoryPath);
         
         await csharpExtension.exports.initializationFinished;
-                
-        await vscode.commands.executeCommand("dotnet.generateAssets");
-        
-        await poll(async () => await fs.exists(testAssetWorkspace.launchJsonPath), 10000, 100);
-
     });
 
 
     test("Hover returns the correct XML", async () => {                
+
+        var program = 
+`using System;
+namespace hoverXmlDoc
+{
+    class testissue
+    {
+        ///<summary>Checks if object is tagged with the tag.</summary>
+        /// <param name="gameObject">The game object.</param>
+        /// <param name="tagName">Name of the tag </param>
+        /// <returns>Returns <c> true</c>if object is tagged with tag.</returns>
         
-        let program : string = "using System;\
-        \nnamespace hoverXmlDoc \
-        \n{\
-        \n    class testissue\
-        \n    {\
-        \n    ///<summary>Checks if object is tagged with the tag.</summary>\
-        \n    /// <param name=\"gameObject\">The game object.</param> \
-        \n    /// <param name=\"tagName\">Name of the tag </param>\
-        \n    /// <returns>Returns <c> true</c>if object is tagged with tag.</returns>\
-        \n\
-        \n        public static bool Compare(int gameObject,string tagName)\
-        \n        {\
-        \n            return gameObject.TagifyCompareTag(tagName);\
-        \n        }\
-        \n    }\
-        }";
+        public static bool Compare(int gameObject,string tagName)
+        {
+            return gameObject.TagifyCompareTag(tagName);
+        }
+    }
+}`;
         let fileUri = await testAssetWorkspace.projects[0].addFileWithContents("test.cs", program); 
         await vscode.commands.executeCommand("vscode.open", fileUri);
 
-        let c = await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri,new vscode.Position(10,30));
+        let c = await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri,new vscode.Position(10,29));
         let answer:string = "Checks if object is tagged with the tag.\n\ngameObject: The game object.\n\ntagName: Name of the tag \n\nReturns: Returns trueif object is tagged with tag.";
-        expect(c[0].contents[0].value).to.equal(answer);
-        
+        expect(c[0].contents[0].value).to.equal(answer);       
     });
-
 });

--- a/test/integrationTests/testAssets/testAssets.ts
+++ b/test/integrationTests/testAssets/testAssets.ts
@@ -31,6 +31,12 @@ export class TestAssetProject {
         await fs.rimraf(this.binDirectoryPath);
         await fs.rimraf(this.objDirectoryPath);
     }
+
+    async addFileWithContents(fileName: string, contents: string) : Promise<vscode.Uri> { 
+        let loc = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, fileName); 
+        await fs.writeTextFile(loc, contents); 
+        return vscode.Uri.file(loc); 
+    } 
 }
 
 export class TestAssetWorkspace {


### PR DESCRIPTION
Issue : https://github.com/OmniSharp/omnisharp-vscode/issues/1057

The XML Documentation being returned by omnisharp-roslyn contained newlines properly, however vscode is displaying a single newline when there are two consecutive new lines are provided. Hence a change has been made to the hoverProvider to replace a single newline with two new lines. An integration test has been added for the same. However on adding this test, the "Launch singleCsproj Workspace Tests" and "Launch slnWithCsproj Workspace Tests" are failing.

Please review @DustinCampbell  @TheRealPiotrP @rchande  