### PR TITLE
Update "Installing C# dependencies" message

### DIFF
--- a/src/CSharpExtDownloader.ts
+++ b/src/CSharpExtDownloader.ts
@@ -23,7 +23,7 @@ export class CSharpExtDownloader
     }
 
     public installRuntimeDependencies(): Promise<boolean> {
-        this.logger.append('Updating C# dependencies...');
+        this.logger.append('Installing C# dependencies...');
         this.channel.show();
 
         let statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);


### PR DESCRIPTION
When we start downloading our dependencies we would print a message about updating our dependencies which makes it sound like we already have version X installed and we are trying to update to Y. This changes the message to "Installing".