### PR TITLE
Change build task description to use label

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -204,7 +204,7 @@ export class AssetGenerator {
         }
 
         return {
-            taskName: 'build',
+            label: 'build',
             command: 'dotnet',
             type: 'process',
             args: ['build', util.convertNativePathToPosix(buildPath)],

--- a/typings/vscode-tasks.d.ts
+++ b/typings/vscode-tasks.d.ts
@@ -121,7 +121,7 @@ declare module "vscode-tasks" {
         /**
          * The task's name
          */
-        taskName: string;
+        label: string;
 
         /**
          * The type of a custom task. Tasks of type "shell" are executed


### PR DESCRIPTION
In vscode 1.18 `taskName` was deprecated in favor of `label`.
This updates the generated description to comply with that update.

https://code.visualstudio.com/updates/v1_18#_schema-improvements