### PR TITLE
Parse envFile and pass to debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -814,6 +814,11 @@
                 "description": "Environment variables passed to the program.",
                 "default": {}
               },
+              "envFile": {
+                "type": "string",
+                "description": "Environment variables passed to the program by a file.",
+                "default": "${workspaceFolder}/.env"
+              },
               "console": {
                 "type": "string",
                 "enum": [
@@ -1875,6 +1880,11 @@
                 },
                 "description": "Environment variables passed to the program.",
                 "default": {}
+              },
+              "envFile": {
+                "type": "string",
+                "description": "Environment variables passed to the program by a file.",
+                "default": "${workspaceFolder}/.env"
               },
               "console": {
                 "type": "string",

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -317,6 +317,11 @@
           "description": "Environment variables passed to the program.",
           "default": {}
         },
+        "envFile": {
+          "type": "string",
+          "description": "Environment variables passed to the program by a file.",
+          "default": "${workspaceFolder}/.env"
+        },
         "console": {
           "type": "string",
           "enum": [ "internalConsole", "integratedTerminal", "externalTerminal" ],


### PR DESCRIPTION
Closes #1944. Adds a new option for launch.json - envFile: it will read environment variables from the given UTF8 file. This way environment variables can be passed to the debugger and launch.json stays clean of sensitive data (like passwords).

#### WIP
- [x] Remove UTF8-BOM if available
- [x] Ignore comments (using #)
- [ ] ~~Add similar logic for args~~