### PR TITLE
Fix year in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
   * As an alternative, consider installing the [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools) extension by @tintoy.
 
-## 1.14.0 (February 14, 2017)
+## 1.14.0 (February 14, 2018)
 
 #### C# Language Support
 


### PR DESCRIPTION
Fixes wrong year for 1.14.0 in changelog.

Spent a minute trying to figure out why I had a year old extension installed into vscode, then figured the change log may be wrong.