### PR TITLE
Insert new debugger with support for Symbol Server and Source Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
   * As an alternative, consider installing the [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools) extension by @tintoy.
 
+## 1.15.0 _(Not Yet Released)_
+
+#### Debugger
+
+* Adds support for [Source Link](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md), Symbol Servers and other more advanced symbol options ([#373](https://github.com/OmniSharp/omnisharp-vscode/issues/373))
+* Adds launch.json option to suppress Just-In-Time compiler optimizations.
+* Due to the previous two items and work from the .NET Team, it is now possible to easily debug into ASP.NET itself in projects running against .NET Core 2.1 preview 1. Support for debugging into all the managed code in .NET Core will come in future .NET Core 2.1 builds. Instructions are in the [wiki](https://github.com/OmniSharp/omnisharp-vscode/wiki/Debugging-into-the-.NET-Framework-itself).
+
+
 ## 1.14.0 (February 14, 2018)
 
 #### C# Language Support

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -66,11 +66,6 @@ You can optionally configure a file by file mapping by providing map following t
         "C:\\foo":"/home/me/foo"
     }
 
-## Symbol Path
-You can optionally provide paths to symbols following this schema:
-
-    "symbolPath": [ "/Volumes/symbols" ]
-
 ## Just My Code
 You can optionally disable `justMyCode` by setting it to "false". You should disable Just My Code when you are trying to debug into a library that you pulled down which doesn't have symbols or is optimized.
 
@@ -110,7 +105,103 @@ More information about pipe transport can be found [here](https://github.com/Omn
 
 You can find information on configuring pipe transport for [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about) (WSL) [here](https://github.com/OmniSharp/omnisharp-vscode/wiki/Windows-Subsystem-for-Linux).
 
-## Operating System Specific Configurations
+### Operating System Specific Configurations
 If there specific commands that need to be changed per operating system, you can use the fields: 'windows', 'osx', or 'linux'. 
 You can replace any of the fields mentioned above for the specific operating system.
 
+## Suppress JIT Optimizations
+
+The .NET Debugger supports the following option. If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. The option defaults to false.
+
+```
+    "suppressJITOptimizations": true
+```
+
+**How optimizations work in .NET:** If you are trying to debug code, it is easier when that code is **NOT** optimized. This is because when code is optimized, the compiler and runtime will make changes to the emitted CPU code so that it runs faster, but has a less direct mapping to original source code. This means that debuggers are frequently unable to tell you the value of local variables, and code stepping and breakpoints might not work as you expect.
+
+Normally the Release build configuration creates optimized code and the Debug build configuration does not. The `Optimize` MSBuild property controls whether the compiler is told to optimize code.
+
+In the .NET ecosystem, code is turned from source to CPU instructions in a two-step process: first, the C# compiler converts the text you type in to an intermediate binary form called MSIL and writes this out to .dll files. Later, the .NET Runtime converts this MSIL to CPU instructions. Both steps can optimize to some degree, but the second step performed by the .NET Runtime performs the more significant optimizations.
+
+**What does the option do:** This option controls what happens when a DLL that was compiled with optimizations enabled loads inside of the target process. If this option is false (the default value), then when the .NET Runtime compiles the MSIL code into CPU code, it leaves the optimizations enabled. If the option is true, then the debugger requests that optimizations be disabled.
+
+**When should you use this option:** This option should be used when you have downloaded dlls from another source, such as a nuget package, and you want to debug the code in this DLL. In order for this to work you must also find the symbol (.pdb) file for this DLL.
+
+If you are only interested in debugging code you are building locally, it is best to leave this option false, as, in some cases, enabling this option will significantly slow down debugging. There are two reason for this slow down --
+
+* Optimized code runs faster. If you are turning off optimizations for lots of code the time can add up.
+* If you have Just My Code enabled, the debugger will not even try and load symbols for dlls which are optimized. Finding symbols can take a long time.
+
+**Limitations of this option:** There are two situations where this option will **NOT** work:
+
+1: In situations where you are attaching the debugger to an already running process, this option will have no effect on modules that were already loaded at the time the debugger was attached.
+
+2: This option has no effect on dlls that have been pre-compiled (a.k.a ngen'ed) to native code. However, you can disable usage of pre-compiled code by starting the process with the environment variable 'COMPlus_ZapDisable' set to '1'. If you are launching under the debugger, this code be done by adding this to launch.json --
+
+```json
+    "env": {
+        "COMPlus_ZapDisable": "1"
+    }
+```
+
+## Symbol Options
+
+The `symbolOptions` element allows customization of how the debugger searches for symbols. Example:
+
+```json
+    "symbolOptions": {
+        "searchPaths": [
+            "~/src/MyOtherProject/bin/debug",
+            "https://my-companies-symbols-server"
+        ],
+        "searchMicrosoftSymbolServer": true,
+        "cachePath": "/symcache",
+        "moduleFilter": {
+            "mode": "loadAllButExcluded",
+            "excludedModules": [ "DoNotLookForThisOne*.dll" ]
+        }
+    }
+```
+
+### Properties:
+
+**searchPaths**: Array of symbol server URLs (example: https://msdl.microsoft.com/download/symbols) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.
+
+**searchMicrosoftSymbolServer**: If `true` the Microsoft Symbol server (https://msdl.microsoft.com/download/symbols) is added to the symbols search path. If unspecified, this option defaults to `false`.
+
+**cachePath**": Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.
+
+**moduleFilter.mode**: This value is either `"loadAllButExcluded"` or `"loadOnlyIncluded"`. In `"loadAllButExcluded"` mode, the debugger loads symbols for all modules unless the module is in the 'excludedModules' array. In `"loadOnlyIncluded"` mode, the debugger will not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting.
+
+#### Properties for `"loadAllButExcluded"` mode: 
+**moduleFilter.excludedModules**: Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.
+
+#### Properties for `"loadOnlyIncluded"` mode: 
+**moduleFilter.includedModules**: Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.
+
+**moduleFilter.includeSymbolsNextToModules**: If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.
+
+## Source Link options
+
+Source Link is a feature that makes it so that when you are debugging code that was built on another computer, such as code coming from a nuget package, the debugger can automatically bring up matching source code by downloading it from the web. To make this work, the .pdb files for the code you are debugging contains data that maps the source files in the DLL to a URL that the debugger can download from. More information about Source Link can be found at [https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md).
+
+The `sourceLinkOptions` element in launch.json allows customization of Source Link behavior by URL. It is a map from URL to Source Link options for that URL. Wildcards are supported in the URL name. Currently the only customization is if Source Link is enabled for that URL, but more options may be added in the future.
+
+Example:
+
+```json
+    "sourceLinkOptions": {
+        "https://raw.githubusercontent.com/*": { "enabled": true },
+        "*": { "enabled": false }
+    }
+```
+
+This example will enable Source Link for GitHub URLs, and disable Source Link for all other URLs.
+
+The default value of this option is to enable Source Link for all URLs. Similarly, Source Link will be enabled for any URL that doesn't have a rule in the `sourceLinkOptions` map.
+
+To disable Source Link for all URLs, use `"sourceLinkOptions": { "*": { "enabled": false } }`.
+
+If multiple entries cover the same URL, the more specific entry (the entry with the longer string length) will be used.
+
+Currently Source Link only works for source files that can be accessed without authentication. So, for example, the debugger can download source files from open source projects on GitHub, but it cannot download from private GitHub repos, or from Visual Studio Team Services.

--- a/package.json
+++ b/package.json
@@ -159,8 +159,8 @@
     },
     {
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/11522728/3d79abf5bc635c3b55ad2ee590c1eb0e/coreclr-debug-win7-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-14-7/coreclr-debug-win7-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/11709463/613b1473e1b85d7688b288818321b729/coreclr-debug-win7-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-15-0/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "win32"
@@ -172,8 +172,8 @@
     },
     {
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/11522728/3d79abf5bc635c3b55ad2ee590c1eb0e/coreclr-debug-osx-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-14-7/coreclr-debug-osx-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/11709463/613b1473e1b85d7688b288818321b729/coreclr-debug-osx-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-15-0/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "darwin"
@@ -189,8 +189,8 @@
     },
     {
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/11522728/3d79abf5bc635c3b55ad2ee590c1eb0e/coreclr-debug-linux-x64.zip",
-      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-14-7/coreclr-debug-linux-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/11709463/613b1473e1b85d7688b288818321b729/coreclr-debug-linux-x64.zip",
+      "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-15-0/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.14.0",
+  "version": "1.15.0-beta1",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -263,14 +263,6 @@
               "description": "Optional flag to only show user code.",
               "default": true
             },
-            "symbolPath": {
-              "type": "array",
-              "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-              "items": {
-                "type": "string"
-              },
-              "default": []
-            },
             "requireExactSource": {
               "type": "boolean",
               "description": "Optional flag to require current source code to match the pdb.",
@@ -280,11 +272,6 @@
               "type": "boolean",
               "description": "Optional flag to enable stepping over Properties and Operators.",
               "default": true
-            },
-            "debugServer": {
-              "type": "number",
-              "description": "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
-              "default": 4711
             },
             "logging": {
               "description": "Optional flags to determine what types of messages should be logged to the output window.",
@@ -319,6 +306,107 @@
                 }
               }
             },
+            "suppressJITOptimizations": {
+              "type": "boolean",
+              "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+              "default": false
+            },
+            "symbolOptions": {
+              "description": "Options to control how symbols (.pdb files) are found and loaded.",
+              "default": {
+                "searchPaths": [],
+                "searchMicrosoftSymbolServer": false
+              },
+              "type": "object",
+              "properties": {
+                "searchPaths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "default": []
+                },
+                "searchMicrosoftSymbolServer": {
+                  "type": "boolean",
+                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "default": false
+                },
+                "cachePath": {
+                  "type": "string",
+                  "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+                  "default": "~/.vsdbg/SymbolCache"
+                },
+                "moduleFilter": {
+                  "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+                  "default": {
+                    "mode": "loadAllButExcluded",
+                    "excludedModules": []
+                  },
+                  "type": "object",
+                  "required": [
+                    "mode"
+                  ],
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "loadAllButExcluded",
+                        "loadOnlyIncluded"
+                      ],
+                      "enumDescriptions": [
+                        "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+                        "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+                      ],
+                      "description": "Controls which of the two basic operating modes the module filter operates in.",
+                      "default": "loadAllButExcluded"
+                    },
+                    "excludedModules": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+                      "default": []
+                    },
+                    "includedModules": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                      "default": [
+                        "MyExampleModule.dll"
+                      ]
+                    },
+                    "includeSymbolsNextToModules": {
+                      "type": "boolean",
+                      "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                      "default": true
+                    }
+                  }
+                }
+              }
+            },
+            "sourceLinkOptions": {
+              "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+              "default": {
+                "*": {
+                  "enabled": true
+                }
+              },
+              "type": "object",
+              "additionalItems": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "title": "boolean",
+                    "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+                    "default": "true"
+                  }
+                }
+              }
+            },
             "type": {
               "type": "string",
               "enum": [
@@ -327,6 +415,11 @@
               ],
               "description": "Type type of code to debug. Can be either 'coreclr' for .NET Core debugging, or 'clr' for Desktop .NET Framework. 'clr' only works on Windows as the Desktop framework is Windows-only.",
               "default": "coreclr"
+            },
+            "debugServer": {
+              "type": "number",
+              "description": "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
+              "default": 4711
             }
           }
         },
@@ -667,14 +760,6 @@
                 "description": "Optional flag to only show user code.",
                 "default": true
               },
-              "symbolPath": {
-                "type": "array",
-                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              },
               "requireExactSource": {
                 "type": "boolean",
                 "description": "Optional flag to require current source code to match the pdb.",
@@ -931,6 +1016,107 @@
                         "description": "Environment variables passed to the pipe program.",
                         "default": {}
                       }
+                    }
+                  }
+                }
+              },
+              "suppressJITOptimizations": {
+                "type": "boolean",
+                "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+                "default": false
+              },
+              "symbolOptions": {
+                "description": "Options to control how symbols (.pdb files) are found and loaded.",
+                "default": {
+                  "searchPaths": [],
+                  "searchMicrosoftSymbolServer": false
+                },
+                "type": "object",
+                "properties": {
+                  "searchPaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "default": []
+                  },
+                  "searchMicrosoftSymbolServer": {
+                    "type": "boolean",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "default": false
+                  },
+                  "cachePath": {
+                    "type": "string",
+                    "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+                    "default": "~/.vsdbg/SymbolCache"
+                  },
+                  "moduleFilter": {
+                    "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+                    "default": {
+                      "mode": "loadAllButExcluded",
+                      "excludedModules": []
+                    },
+                    "type": "object",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "loadAllButExcluded",
+                          "loadOnlyIncluded"
+                        ],
+                        "enumDescriptions": [
+                          "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+                          "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+                        ],
+                        "description": "Controls which of the two basic operating modes the module filter operates in.",
+                        "default": "loadAllButExcluded"
+                      },
+                      "excludedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+                        "default": []
+                      },
+                      "includedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": [
+                          "MyExampleModule.dll"
+                        ]
+                      },
+                      "includeSymbolsNextToModules": {
+                        "type": "boolean",
+                        "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": true
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceLinkOptions": {
+                "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+                "default": {
+                  "*": {
+                    "enabled": true
+                  }
+                },
+                "type": "object",
+                "additionalItems": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "title": "boolean",
+                      "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+                      "default": "true"
                     }
                   }
                 }
@@ -975,14 +1161,6 @@
                 "description": "Optional flag to only show user code.",
                 "default": true
               },
-              "symbolPath": {
-                "type": "array",
-                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              },
               "requireExactSource": {
                 "type": "boolean",
                 "description": "Optional flag to require current source code to match the pdb.",
@@ -1239,6 +1417,107 @@
                         "description": "Environment variables passed to the pipe program.",
                         "default": {}
                       }
+                    }
+                  }
+                }
+              },
+              "suppressJITOptimizations": {
+                "type": "boolean",
+                "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+                "default": false
+              },
+              "symbolOptions": {
+                "description": "Options to control how symbols (.pdb files) are found and loaded.",
+                "default": {
+                  "searchPaths": [],
+                  "searchMicrosoftSymbolServer": false
+                },
+                "type": "object",
+                "properties": {
+                  "searchPaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "default": []
+                  },
+                  "searchMicrosoftSymbolServer": {
+                    "type": "boolean",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "default": false
+                  },
+                  "cachePath": {
+                    "type": "string",
+                    "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+                    "default": "~/.vsdbg/SymbolCache"
+                  },
+                  "moduleFilter": {
+                    "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+                    "default": {
+                      "mode": "loadAllButExcluded",
+                      "excludedModules": []
+                    },
+                    "type": "object",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "loadAllButExcluded",
+                          "loadOnlyIncluded"
+                        ],
+                        "enumDescriptions": [
+                          "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+                          "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+                        ],
+                        "description": "Controls which of the two basic operating modes the module filter operates in.",
+                        "default": "loadAllButExcluded"
+                      },
+                      "excludedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+                        "default": []
+                      },
+                      "includedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": [
+                          "MyExampleModule.dll"
+                        ]
+                      },
+                      "includeSymbolsNextToModules": {
+                        "type": "boolean",
+                        "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": true
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceLinkOptions": {
+                "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+                "default": {
+                  "*": {
+                    "enabled": true
+                  }
+                },
+                "type": "object",
+                "additionalItems": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "title": "boolean",
+                      "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+                      "default": "true"
                     }
                   }
                 }
@@ -1543,14 +1822,6 @@
                 "description": "Optional flag to only show user code.",
                 "default": true
               },
-              "symbolPath": {
-                "type": "array",
-                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              },
               "requireExactSource": {
                 "type": "boolean",
                 "description": "Optional flag to require current source code to match the pdb.",
@@ -1807,6 +2078,107 @@
                         "description": "Environment variables passed to the pipe program.",
                         "default": {}
                       }
+                    }
+                  }
+                }
+              },
+              "suppressJITOptimizations": {
+                "type": "boolean",
+                "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+                "default": false
+              },
+              "symbolOptions": {
+                "description": "Options to control how symbols (.pdb files) are found and loaded.",
+                "default": {
+                  "searchPaths": [],
+                  "searchMicrosoftSymbolServer": false
+                },
+                "type": "object",
+                "properties": {
+                  "searchPaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "default": []
+                  },
+                  "searchMicrosoftSymbolServer": {
+                    "type": "boolean",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "default": false
+                  },
+                  "cachePath": {
+                    "type": "string",
+                    "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+                    "default": "~/.vsdbg/SymbolCache"
+                  },
+                  "moduleFilter": {
+                    "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+                    "default": {
+                      "mode": "loadAllButExcluded",
+                      "excludedModules": []
+                    },
+                    "type": "object",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "loadAllButExcluded",
+                          "loadOnlyIncluded"
+                        ],
+                        "enumDescriptions": [
+                          "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+                          "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+                        ],
+                        "description": "Controls which of the two basic operating modes the module filter operates in.",
+                        "default": "loadAllButExcluded"
+                      },
+                      "excludedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+                        "default": []
+                      },
+                      "includedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": [
+                          "MyExampleModule.dll"
+                        ]
+                      },
+                      "includeSymbolsNextToModules": {
+                        "type": "boolean",
+                        "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": true
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceLinkOptions": {
+                "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+                "default": {
+                  "*": {
+                    "enabled": true
+                  }
+                },
+                "type": "object",
+                "additionalItems": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "title": "boolean",
+                      "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+                      "default": "true"
                     }
                   }
                 }
@@ -1851,14 +2223,6 @@
                 "description": "Optional flag to only show user code.",
                 "default": true
               },
-              "symbolPath": {
-                "type": "array",
-                "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              },
               "requireExactSource": {
                 "type": "boolean",
                 "description": "Optional flag to require current source code to match the pdb.",
@@ -2115,6 +2479,107 @@
                         "description": "Environment variables passed to the pipe program.",
                         "default": {}
                       }
+                    }
+                  }
+                }
+              },
+              "suppressJITOptimizations": {
+                "type": "boolean",
+                "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+                "default": false
+              },
+              "symbolOptions": {
+                "description": "Options to control how symbols (.pdb files) are found and loaded.",
+                "default": {
+                  "searchPaths": [],
+                  "searchMicrosoftSymbolServer": false
+                },
+                "type": "object",
+                "properties": {
+                  "searchPaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "default": []
+                  },
+                  "searchMicrosoftSymbolServer": {
+                    "type": "boolean",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "default": false
+                  },
+                  "cachePath": {
+                    "type": "string",
+                    "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+                    "default": "~/.vsdbg/SymbolCache"
+                  },
+                  "moduleFilter": {
+                    "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+                    "default": {
+                      "mode": "loadAllButExcluded",
+                      "excludedModules": []
+                    },
+                    "type": "object",
+                    "required": [
+                      "mode"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "loadAllButExcluded",
+                          "loadOnlyIncluded"
+                        ],
+                        "enumDescriptions": [
+                          "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+                          "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+                        ],
+                        "description": "Controls which of the two basic operating modes the module filter operates in.",
+                        "default": "loadAllButExcluded"
+                      },
+                      "excludedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+                        "default": []
+                      },
+                      "includedModules": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": [
+                          "MyExampleModule.dll"
+                        ]
+                      },
+                      "includeSymbolsNextToModules": {
+                        "type": "boolean",
+                        "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+                        "default": true
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceLinkOptions": {
+                "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+                "default": {
+                  "*": {
+                    "enabled": true
+                  }
+                },
+                "type": "object",
+                "additionalItems": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "title": "boolean",
+                      "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+                      "default": "true"
                     }
                   }
                 }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -1,446 +1,484 @@
 {
-    "_comment": "See README.md for information about this file",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "VS Code launch/attach options",
-    "description": "A json schema for the VS Code attach and launch options",
-    "type": "object",
-    "definitions": {
-        "PipeConfigurations": {
-            "type": "object",
-            "description": "Platform-specific pipe launch configuration options",
-            "default": {
-                "pipeCwd": "${workspaceFolder}",
-                "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                "pipeArgs": []
+  "_comment": "See README.md for information about this file",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "VS Code launch/attach options",
+  "description": "A json schema for the VS Code attach and launch options",
+  "type": "object",
+  "definitions": {
+    "PipeConfigurations": {
+      "type": "object",
+      "description": "Platform-specific pipe launch configuration options",
+      "default": {
+        "pipeCwd": "${workspaceFolder}",
+        "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+        "pipeArgs": []
+      },
+      "properties": {
+        "pipeCwd": {
+          "type": "string",
+          "description": "The fully qualified path to the working directory for the pipe program.",
+          "default": "${workspaceFolder}"
+        },
+        "pipeProgram": {
+          "type": "string",
+          "description": "The fully qualified pipe command to execute.",
+          "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
+        },
+        "pipeArgs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "description": "Command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
+              "items": {
+                "type": "string"
+              },
+              "default": []
             },
-            "properties": {
-                "pipeCwd": {
-                    "type": "string",
-                    "description": "The fully qualified path to the working directory for the pipe program.",
-                    "default": "${workspaceFolder}"
-                },
-                "pipeProgram": {
-                    "type": "string",
-                    "description": "The fully qualified pipe command to execute.",
-                    "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
-                },
-                "pipeArgs": {
-                    "anyOf": [
-                        {
-                            "type": "array",
-                            "description": "Command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": []
-                        },
-                        {
-                            "type": "string",
-                            "description": "Stringified version of command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
-                            "default": ""
-                        }
-                    ]
-                },
-                "quoteArgs": {
-                    "type": "boolean",
-                    "description": "Should arguments that contain characters that need to be quoted (example: spaces) be quoted? Defaults to 'true'. If set to false, the debugger command will no longer be automatically quoted.",
-                    "default": true
-                },
-                "pipeEnv": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Environment variables passed to the pipe program.",
-                    "default": {}
-                }
+            {
+              "type": "string",
+              "description": "Stringified version of command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
+              "default": ""
             }
+          ]
         },
-        "PipeTransport": {
-            "type": "object",
-            "required": ["debuggerPath"],
-            "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
-            "default": {
-                "pipeCwd": "${workspaceFolder}",
-                "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                "pipeArgs": [],
-                "debuggerPath" : "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
-            },
-            "properties": {
-                "pipeCwd": {
-                    "type": "string",
-                    "description": "The fully qualified path to the working directory for the pipe program.",
-                    "default": "${workspaceFolder}"
-                },
-                "pipeProgram": {
-                    "type": "string",
-                    "description": "The fully qualified pipe command to execute.",
-                    "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
-                },
-                "pipeArgs": {
-                    "anyOf": [
-                        {
-                            "type": "array",
-                            "description": "Command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": []
-                        },
-                        {
-                            "type": "string",
-                            "description": "Stringified version of command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
-                            "default": ""
-                        }
-                    ]
-                },
-                "debuggerPath" : {
-                    "type" : "string",
-                    "description" : "The full path to the debugger on the target machine.",
-                    "default" : "~/vsdbg/vsdbg"
-                },
-                "pipeEnv": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Environment variables passed to the pipe program.",
-                    "default": {}
-                },
-                "quoteArgs": {
-                    "type": "boolean",
-                    "description": "Should arguments that contain characters that need to be quoted (example: spaces) be quoted? Defaults to 'true'. If set to false, the debugger command will no longer be automatically quoted.",
-                    "default": true
-                },
-                "windows": {
-                    "$ref": "#/definitions/PipeConfigurations",
-                    "description": "Windows-specific pipe launch configuration options",
-                    "default": {
-                        "pipeCwd": "${workspaceFolder}",
-                        "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
-                        "pipeArgs": []
-                    }
-                },
-                "osx": {
-                    "$ref": "#/definitions/PipeConfigurations",
-                    "description": "OSX-specific pipe launch configuration options",
-                    "default": {
-                        "pipeCwd": "${workspaceFolder}",
-                        "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                        "pipeArgs": []
-                    }
-                },
-                "linux": {
-                    "$ref": "#/definitions/PipeConfigurations",
-                    "description": "Linux-specific pipe launch configuration options",
-                    "default": {
-                        "pipeCwd": "${workspaceFolder}",
-                        "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
-                        "pipeArgs": []
-                    }
-                }
-            }
+        "quoteArgs": {
+          "type": "boolean",
+          "description": "Should arguments that contain characters that need to be quoted (example: spaces) be quoted? Defaults to 'true'. If set to false, the debugger command will no longer be automatically quoted.",
+          "default": true
         },
-        "Logging": {
-            "type": "object",
-            "required": [],
-            "default": {},
-            "description": "Optional flags to determine what types of messages should be logged to the output window.",
-            "properties": {
-                "exceptions": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether exception messages should be logged to the output window.",
-                    "default": true
-                },
-                "moduleLoad": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether module load events should be logged to the output window.",
-                    "default": true
-                },
-                "programOutput": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
-                    "default": true
-                },
-                "engineLogging": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
-                    "default": false
-                },
-                "browserStdOut": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
-                    "default": true
-                }
-            }
-        },
-        "LaunchBrowserPlatformOptions": {
-            "type": "object",
-            "properties": {
-                "command": {
-                    "type": "string",
-                    "description": "The command to execute for launching the web browser",
-                    "default": "open"
-                },
-                "args": {
-                    "type": "string",
-                    "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
-                    "default": "${auto-detect-url}"
-                }
-            }
-        },
-        "LaunchBrowser": {
-            "type": "object",
-            "description": "Describes options to launch a web browser as part of launch",
-            "default": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Whether web browser launch is enabled",
-                    "default": true
-                },
-                "args": {
-                    "anyOf": [
-                        {
-                            "type": "array",
-                            "description": "Command line arguments passed to the program.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": []
-                        },
-                        {
-                            "type": "string",
-                            "description": "Stringified version of command line arguments passed to the program.",
-                            "default": ""
-                        }
-                    ]
-                },
-                "osx": {
-                    "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-                    "description": "OSX-specific web launch configuration options",
-                    "default": {
-                        "command": "open"
-                    }
-                },
-                "linux": {
-                    "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-                    "description": "Linux-specific web launch configuration options",
-                    "default": {
-                        "command": "xdg-open"
-                    }
-                },
-                "windows": {
-                    "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-                    "description": "Windows-specific web launch configuration options",
-                    "default": {
-                        "command": "cmd.exe",
-                        "args": "/C start ${auto-detect-url}"
-                    }
-                }
-            }
-        },
-        "LaunchOptions": {
-            "type": "object",
-            "required": [
-                "program"
-            ],
-            "properties": {
-                "program": {
-                    "type": "string",
-                    "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceFolder}/bin/Debug/(target-framework)/(project-name.dll)'\nExample: '${workspaceFolder}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n(target-framework) is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n(project-name.dll) is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
-                    "default": "${workspaceFolder}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
-                },
-                "cwd": {
-                    "type": "string",
-                    "description": "Path to the working directory of the program being debugged. Default is the current workspace.",
-                    "default": "${workspaceFolder}"
-                },
-                "args": {
-                    "anyOf": [
-                        {
-                            "type": "array",
-                            "description": "Command line arguments passed to the program.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": []
-                        },
-                        {
-                            "type": "string",
-                            "description": "Stringified version of command line arguments passed to the program.",
-                            "default": ""
-                        }
-                    ]
-                },
-                "stopAtEntry": {
-                    "type": "boolean",
-                    "description": "If true, the debugger should stop at the entry point of the target.",
-                    "default": false
-                },
-                "launchBrowser": {
-                    "$ref": "#/definitions/LaunchBrowser",
-                    "description": "Describes options to launch a web browser as part of launch",
-                    "default": {
-                        "enabled": true,
-                        "args": "${auto-detect-url}",
-                        "windows": {
-                            "command": "cmd.exe",
-                            "args": "/C start ${auto-detect-url}"
-                        },
-                        "osx": {
-                            "command": "open"
-                        },
-                        "linux": {
-                            "command": "xdg-open"
-                        }
-                    }
-                },
-                "env": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Environment variables passed to the program.",
-                    "default": {}
-                },
-                "console": {
-                    "type": "string",
-                    "enum": [ "internalConsole", "integratedTerminal", "externalTerminal" ],
-                    "enumDescriptions": [
-                        "Output to the VS Code Debug Console. This doesn't support reading console input (ex:Console.ReadLine)",
-                        "VS Code's integrated terminal",
-                        "External terminal that can be configured via user settings"
-                    ],
-                    "description": "Where to launch the debug target.",
-                    "default": "internalConsole"
-                },
-                "externalConsole": {
-                    "type": "boolean",
-                    "description": "Attribute 'externalConsole' is deprecated, use 'console' instead.",
-                    "default": false
-                },
-                "sourceFileMap": {
-                    "type": "object",
-                    "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {
-                        "<insert-source-path-here>": "<insert-target-path-here>"
-                    }
-                },
-                "justMyCode": {
-                    "type": "boolean",
-                    "description": "Optional flag to only show user code.",
-                    "default": true
-                },
-                "symbolPath": {
-                    "type": "array",
-                    "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": []
-                },
-                "requireExactSource": {
-                    "type": "boolean",
-                    "description": "Optional flag to require current source code to match the pdb.",
-                    "default": true
-                },
-                "enableStepFiltering": {
-                    "type": "boolean",
-                    "description": "Optional flag to enable stepping over Properties and Operators.",
-                    "default": true
-                },
-                "logging": {
-                    "$ref": "#/definitions/Logging",
-                    "description": "Optional flags to determine what types of messages should be logged to the output window."
-                },
-                "pipeTransport": {
-                    "$ref": "#/definitions/PipeTransport",
-                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
-                }
-            }
-        },
-        "AttachOptions": {
-            "type": "object",
-            "required": [],
-            "properties": {
-                "processName": {
-                    "type": "string",
-                    "description": "",
-                    "default": "The process name to attach to. If this is used, 'processId' should not be used."
-                },
-                "processId": {
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
-                            "default": "${command:pickProcess}"
-                        },
-                        {
-                            "type": "integer",
-                            "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
-                            "default": 0
-                        }
-                    ]
-                },
-                "sourceFileMap": {
-                    "type": "object",
-                    "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "default": {
-                        "<insert-source-path-here>": "<insert-target-path-here>"
-                    }
-                },
-                "justMyCode": {
-                    "type": "boolean",
-                    "description": "Optional flag to only show user code.",
-                    "default": true
-                },
-                "symbolPath": {
-                    "type": "array",
-                    "description": "Array of directories to use to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to. Example: '[ \"/Volumes/symbols\" ]",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": []
-                },
-                "requireExactSource": {
-                    "type": "boolean",
-                    "description": "Optional flag to require current source code to match the pdb.",
-                    "default": true
-                },
-                "enableStepFiltering": {
-                    "type": "boolean",
-                    "description": "Optional flag to enable stepping over Properties and Operators.",
-                    "default": true
-                },
-                "logging": {
-                    "$ref": "#/definitions/Logging",
-                    "description": "Optional flags to determine what types of messages should be logged to the output window."
-                },
-                "pipeTransport": {
-                    "$ref": "#/definitions/PipeTransport",
-                    "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
-                }
-            }
+        "pipeEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment variables passed to the pipe program.",
+          "default": {}
         }
+      }
+    },
+    "PipeTransport": {
+      "type": "object",
+      "required": [ "debuggerPath" ],
+      "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+      "default": {
+        "pipeCwd": "${workspaceFolder}",
+        "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+        "pipeArgs": [],
+        "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+      },
+      "properties": {
+        "pipeCwd": {
+          "type": "string",
+          "description": "The fully qualified path to the working directory for the pipe program.",
+          "default": "${workspaceFolder}"
+        },
+        "pipeProgram": {
+          "type": "string",
+          "description": "The fully qualified pipe command to execute.",
+          "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
+        },
+        "pipeArgs": {
+          "anyOf": [
+            {
+              "type": "array",
+              "description": "Command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            {
+              "type": "string",
+              "description": "Stringified version of command line arguments passed to the pipe program. Token ${debuggerCommand} in pipeArgs will get replaced by the full debugger command, this token can be specified inline with other arguments. If ${debuggerCommand} isn’t used in any argument, the full debugger command will be instead be added to the end of the argument list.",
+              "default": ""
+            }
+          ]
+        },
+        "debuggerPath": {
+          "type": "string",
+          "description": "The full path to the debugger on the target machine.",
+          "default": "~/vsdbg/vsdbg"
+        },
+        "pipeEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment variables passed to the pipe program.",
+          "default": {}
+        },
+        "quoteArgs": {
+          "type": "boolean",
+          "description": "Should arguments that contain characters that need to be quoted (example: spaces) be quoted? Defaults to 'true'. If set to false, the debugger command will no longer be automatically quoted.",
+          "default": true
+        },
+        "windows": {
+          "$ref": "#/definitions/PipeConfigurations",
+          "description": "Windows-specific pipe launch configuration options",
+          "default": {
+            "pipeCwd": "${workspaceFolder}",
+            "pipeProgram": "enter the fully qualified path for the pipe program name, for example 'c:\\tools\\plink.exe'",
+            "pipeArgs": []
+          }
+        },
+        "osx": {
+          "$ref": "#/definitions/PipeConfigurations",
+          "description": "OSX-specific pipe launch configuration options",
+          "default": {
+            "pipeCwd": "${workspaceFolder}",
+            "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+            "pipeArgs": []
+          }
+        },
+        "linux": {
+          "$ref": "#/definitions/PipeConfigurations",
+          "description": "Linux-specific pipe launch configuration options",
+          "default": {
+            "pipeCwd": "${workspaceFolder}",
+            "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+            "pipeArgs": []
+          }
+        }
+      }
+    },
+    "Logging": {
+      "type": "object",
+      "required": [],
+      "default": {},
+      "description": "Optional flags to determine what types of messages should be logged to the output window.",
+      "properties": {
+        "exceptions": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+          "default": true
+        },
+        "moduleLoad": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether module load events should be logged to the output window.",
+          "default": true
+        },
+        "programOutput": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+          "default": true
+        },
+        "engineLogging": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+          "default": false
+        },
+        "browserStdOut": {
+          "type": "boolean",
+          "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
+          "default": true
+        }
+      }
+    },
+    "LaunchBrowserPlatformOptions": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command to execute for launching the web browser",
+          "default": "open"
+        },
+        "args": {
+          "type": "string",
+          "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+          "default": "${auto-detect-url}"
+        }
+      }
+    },
+    "LaunchBrowser": {
+      "type": "object",
+      "description": "Describes options to launch a web browser as part of launch",
+      "default": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
+        },
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
+        }
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether web browser launch is enabled",
+          "default": true
+        },
+        "args": {
+          "anyOf": [
+            {
+              "type": "array",
+              "description": "Command line arguments passed to the program.",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            {
+              "type": "string",
+              "description": "Stringified version of command line arguments passed to the program.",
+              "default": ""
+            }
+          ]
+        },
+        "osx": {
+          "$ref": "#/definitions/LaunchBrowserPlatformOptions",
+          "description": "OSX-specific web launch configuration options",
+          "default": {
+            "command": "open"
+          }
+        },
+        "linux": {
+          "$ref": "#/definitions/LaunchBrowserPlatformOptions",
+          "description": "Linux-specific web launch configuration options",
+          "default": {
+            "command": "xdg-open"
+          }
+        },
+        "windows": {
+          "$ref": "#/definitions/LaunchBrowserPlatformOptions",
+          "description": "Windows-specific web launch configuration options",
+          "default": {
+            "command": "cmd.exe",
+            "args": "/C start ${auto-detect-url}"
+          }
+        }
+      }
+    },
+    "LaunchOptions": {
+      "type": "object",
+      "required": [
+        "program"
+      ],
+      "properties": {
+        "program": {
+          "type": "string",
+          "description": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: '${workspaceFolder}/bin/Debug/(target-framework)/(project-name.dll)'\nExample: '${workspaceFolder}/bin/Debug/netcoreapp1.1/MyProject.dll'\n\nWhere:\n(target-framework) is the framework that the debugged project is being built for. This is normally found in the project file as the 'TargetFramework' property.\n(project-name.dll) is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
+          "default": "${workspaceFolder}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll"
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Path to the working directory of the program being debugged. Default is the current workspace.",
+          "default": "${workspaceFolder}"
+        },
+        "args": {
+          "anyOf": [
+            {
+              "type": "array",
+              "description": "Command line arguments passed to the program.",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            {
+              "type": "string",
+              "description": "Stringified version of command line arguments passed to the program.",
+              "default": ""
+            }
+          ]
+        },
+        "stopAtEntry": {
+          "type": "boolean",
+          "description": "If true, the debugger should stop at the entry point of the target.",
+          "default": false
+        },
+        "launchBrowser": {
+          "$ref": "#/definitions/LaunchBrowser",
+          "description": "Describes options to launch a web browser as part of launch",
+          "default": {
+            "enabled": true,
+            "args": "${auto-detect-url}",
+            "windows": {
+              "command": "cmd.exe",
+              "args": "/C start ${auto-detect-url}"
+            },
+            "osx": {
+              "command": "open"
+            },
+            "linux": {
+              "command": "xdg-open"
+            }
+          }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment variables passed to the program.",
+          "default": {}
+        },
+        "console": {
+          "type": "string",
+          "enum": [ "internalConsole", "integratedTerminal", "externalTerminal" ],
+          "enumDescriptions": [
+            "Output to the VS Code Debug Console. This doesn't support reading console input (ex:Console.ReadLine)",
+            "VS Code's integrated terminal",
+            "External terminal that can be configured via user settings"
+          ],
+          "description": "Where to launch the debug target.",
+          "default": "internalConsole"
+        },
+        "externalConsole": {
+          "type": "boolean",
+          "description": "Attribute 'externalConsole' is deprecated, use 'console' instead.",
+          "default": false
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "<insert-source-path-here>": "<insert-target-path-here>"
+          }
+        },
+        "justMyCode": {
+          "type": "boolean",
+          "description": "Optional flag to only show user code.",
+          "default": true
+        },
+        "requireExactSource": {
+          "type": "boolean",
+          "description": "Optional flag to require current source code to match the pdb.",
+          "default": true
+        },
+        "enableStepFiltering": {
+          "type": "boolean",
+          "description": "Optional flag to enable stepping over Properties and Operators.",
+          "default": true
+        },
+        "logging": {
+          "$ref": "#/definitions/Logging",
+          "description": "Optional flags to determine what types of messages should be logged to the output window."
+        },
+        "pipeTransport": {
+          "$ref": "#/definitions/PipeTransport",
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
+        },
+        "suppressJITOptimizations": {
+          "type": "boolean",
+          "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+          "default": false
+        },
+        "symbolOptions": {
+          "$ref": "#/definitions/VSSymbolOptions",
+          "description": "Options to control how symbols (.pdb files) are found and loaded.",
+          "default": {
+            "searchPaths": [],
+            "searchMicrosoftSymbolServer": false
+          }
+        },
+        "sourceLinkOptions": {
+          "$ref": "#/definitions/SourceLinkOptions",
+          "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+          "default": {
+            "*": { "enabled": true }
+          }
+        }
+      }
+    },
+    "AttachOptions": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "processName": {
+          "type": "string",
+          "description": "",
+          "default": "The process name to attach to. If this is used, 'processId' should not be used."
+        },
+        "processId": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+              "default": "${command:pickProcess}"
+            },
+            {
+              "type": "integer",
+              "description": "The process id to attach to. Use \"${command:pickProcesss}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+              "default": 0
+            }
+          ]
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "<insert-source-path-here>": "<insert-target-path-here>"
+          }
+        },
+        "justMyCode": {
+          "type": "boolean",
+          "description": "Optional flag to only show user code.",
+          "default": true
+        },
+        "requireExactSource": {
+          "type": "boolean",
+          "description": "Optional flag to require current source code to match the pdb.",
+          "default": true
+        },
+        "enableStepFiltering": {
+          "type": "boolean",
+          "description": "Optional flag to enable stepping over Properties and Operators.",
+          "default": true
+        },
+        "logging": {
+          "$ref": "#/definitions/Logging",
+          "description": "Optional flags to determine what types of messages should be logged to the output window."
+        },
+        "pipeTransport": {
+          "$ref": "#/definitions/PipeTransport",
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
+        },
+        "suppressJITOptimizations": {
+          "type": "boolean",
+          "description": "If true, when an optimized module (.dll compiled in the Release configuration) loads in the target process, the debugger will ask the Just-In-Time compiler to generate code with optimizations disabled. For more information: https://aka.ms/VSCode-CS-LaunchJson#suppress-jit-optimizations",
+          "default": false
+        },
+        "symbolOptions": {
+          "$ref": "#/definitions/VSSymbolOptions",
+          "description": "Options to control how symbols (.pdb files) are found and loaded.",
+          "default": {
+            "searchPaths": [],
+            "searchMicrosoftSymbolServer": false
+          }
+        },
+        "sourceLinkOptions": {
+          "$ref": "#/definitions/SourceLinkOptions",
+          "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+          "default": {
+            "*": { "enabled": true }
+          }
+        }
+      }
+    },
+    "SourceLinkOptions": {
+      "type": "object",
+      "description": "Options to control how Source Link connects to web servers. For more information: https://aka.ms/VSCode-CS-LaunchJson#source-link-options",
+      "additionalItems": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "boolean",
+            "description": "Is Source Link enabled for this URL?  If unspecified, this option defaults to 'true'.",
+            "default": "true"
+          }
+        }
+      }
     }
+  }
 }

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -77,6 +77,11 @@ export function updatePackageDependencies() {
     if (os.platform() === 'win32') {
         content = content.replace(/\n/gm, "\r\n");
     }
+
+    // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
+    // convert that from the readable espace sequence, to just an invisible character. Convert it back to the visible espace sequence.
+    content = content.replace(/\u200b/gm, "\\u200b");
+
     fs.writeFileSync('package.json', content);
 }
 

--- a/src/tools/VSSymbolSettings.json
+++ b/src/tools/VSSymbolSettings.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+    "VSSymbolOptions": {
+      "type": "object",
+      "properties": {
+        "searchPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+          "default": []
+        },
+        "searchMicrosoftSymbolServer": {
+          "type": "boolean",
+          "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+          "default": false
+        },
+        "cachePath": {
+          "type": "string",
+          "description": "Directory where symbols downloaded from symbol servers should be cached. If unspecified, on Windows the debugger will default to %TEMP%\\SymbolCache, and on Linux and macOS the debugger will default to ~/.vsdbg/SymbolCache.",
+          "default": "~/.vsdbg/SymbolCache"
+        },
+        "moduleFilter": {
+          "$ref": "#/definitions/VSSymbolOptionsModuleFilter",
+          "description": "Provides options to control which modules (.dll files) the debugger will attempt to load symbols (.pdb files) for.",
+          "default": {
+            "mode": "loadAllButExcluded",
+            "excludedModules": [
+            ]
+          }
+        }
+      }
+    },
+    "VSSymbolOptionsModuleFilter": {
+      "type": "object",
+      "required": [ "mode" ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [ "loadAllButExcluded", "loadOnlyIncluded" ],
+          "enumDescriptions": [
+            "Load symbols for all modules unless the module is in the 'excludedModules' array.",
+            "Do not attempt to load symbols for ANY module unless it is in the 'includedModules' array, or it is included through the 'includeSymbolsNextToModules' setting."
+          ],
+          "description": "Controls which of the two basic operating modes the module filter operates in.",
+          "default": "loadAllButExcluded"
+        },
+        "excludedModules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of modules that the debugger should NOT load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadAllButExcluded'.",
+          "default": [ "MyExampleModule.dll" ]
+        },
+        "includedModules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of modules that the debugger should load symbols for. Wildcards (example: MyCompany.*.dll) are supported.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+          "default": [ "MyExampleModule.dll" ]
+        },
+        "includeSymbolsNextToModules": {
+          "type": "boolean",
+          "description": "If true, for any module NOT in the 'includedModules' array, the debugger will still check next to the module itself and the launching executable, but it will not check paths on the symbol search list. This option defaults to 'true'.\n\nThis property is ignored unless 'mode' is set to 'loadOnlyIncluded'.",
+          "default": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR inserts a new debugger with all the of Symbol Server, Source Link, and suppressJITOptimizations work.

This updates the launch.json schema, and documentation for all the new options as well.
