### PR TITLE
Enable travis to use the latest omnisharp build

### DIFF
--- a/test/integrationTests/testAssets/singleCsproj/.vscode/settings.json
+++ b/test/integrationTests/testAssets/singleCsproj/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "omnisharp.path": "latest"
+}

--- a/test/integrationTests/testAssets/slnWithCsproj/.vscode/settings.json
+++ b/test/integrationTests/testAssets/slnWithCsproj/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "omnisharp.path": "latest"
+}


### PR DESCRIPTION
Added settings.json file to the integration tests folder to enable the latest CI build of omnisharp to be consumed by Travis during testing.