### PR TITLE
move to tslint-no-unused-expression-chai

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
     "rules": {
-        "no-unused-expression-chai": true,
+        "tslint-no-unused-expression-chai": true,
         "no-unused-variable": true,
         "no-duplicate-variable": true,
         "no-var-keyword": true,


### PR DESCRIPTION
The package was already installed, but not used. This makes our tests that use chai.should() pass tslint checks