### PR TITLE
Eliminate Thennable<any>

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 100%

--- a/src/CSharpExtensionExports.ts
+++ b/src/CSharpExtensionExports.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+ export default interface CSharpExtensionExports {
+    initializationFinished: Promise<void>;
+ }

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -10,10 +10,11 @@ import { CoreClrDebugUtil, DotnetInfo, } from './util';
 import { PlatformInformation } from './../platform';
 import { DebuggerPrerequisiteWarning, DebuggerPrerequisiteFailure, DebuggerNotInstalledFailure } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
+import CSharpExtensionExports from '../CSharpExtensionExports';
 
 let _debugUtil: CoreClrDebugUtil = null;
 
-export async function activate(thisExtension: vscode.Extension<any>, context: vscode.ExtensionContext, platformInformation: PlatformInformation, eventStream: EventStream) {
+export async function activate(thisExtension: vscode.Extension<CSharpExtensionExports>, context: vscode.ExtensionContext, platformInformation: PlatformInformation, eventStream: EventStream) {
     _debugUtil = new CoreClrDebugUtil(context.extensionPath);
 
     if (!CoreClrDebugUtil.existsSync(_debugUtil.debugAdapterDir())) {

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -104,7 +104,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         });
     }
 
-    private async _runCodeAction(req: protocol.V2.RunCodeActionRequest): Promise<any> {
+    private async _runCodeAction(req: protocol.V2.RunCodeActionRequest): Promise<boolean | string | {}> {
 
         return serverUtils.runCodeAction(this._server, req).then(response => {
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -89,7 +89,7 @@ function pickProjectAndStart(server: OmniSharpServer) {
 interface Command {
     label: string;
     description: string;
-    execute(): Thenable<any>;
+    execute(): Thenable<void>;
 }
 
 function projectsToCommands(projects: protocol.ProjectDescriptor[], eventStream: EventStream): Promise<Command>[] {

--- a/src/features/json/NuGetFlatContainerPackageResponse.ts
+++ b/src/features/json/NuGetFlatContainerPackageResponse.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+ // Sample Request: https://api.nuget.org/v3-flatcontainer/FluentAssertions/index.json
+ 
+export default interface NuGetFlatContainerPackageResponse {
+    versions: string[];
+}

--- a/src/features/json/NuGetIndexResponse.ts
+++ b/src/features/json/NuGetIndexResponse.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Sample Request: https://api.nuget.org/v3/index.json
+ export default interface NuGetIndexResponse {
+     resources: NuGetResource[];
+ }
+
+ interface NuGetResource {
+     '@type': string;
+     '@id': string;
+ }

--- a/src/features/json/NuGetSearchAutocompleteServiceResponse.ts
+++ b/src/features/json/NuGetSearchAutocompleteServiceResponse.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Sample Query: https://api-v2v3search-0.nuget.org/autocomplete
+
+ export default interface NuGetSearchAutocompleteServiceResponse {
+    data: string[];
+}

--- a/src/features/json/NuGetSearchQueryServiceResponse.ts
+++ b/src/features/json/NuGetSearchQueryServiceResponse.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Sample Request: https://api-v2v3search-0.nuget.org/query?q=newtonsoft.json&take=5
+
+export default interface NuGetSearchQueryServiceResponse {
+    data: NuGetSearchQueryServiceDataElement[];
+}
+
+interface NuGetSearchQueryServiceDataElement {
+    id: string;
+    description: string;
+    version: string;
+}

--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -22,9 +22,9 @@ export interface ISuggestionsCollector {
 export interface IJSONContribution {
     getDocumentSelector(): DocumentSelector;
     getInfoContribution(fileName: string, location: Location): Thenable<MarkedString[]>;
-    collectPropertySuggestions(fileName: string, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<any>;
-    collectValueSuggestions(fileName: string, location: Location, result: ISuggestionsCollector): Thenable<any>;
-    collectDefaultSuggestions(fileName: string, result: ISuggestionsCollector): Thenable<any>;
+    collectPropertySuggestions(fileName: string, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<void>;
+    collectValueSuggestions(fileName: string, location: Location, result: ISuggestionsCollector): Thenable<void>;
+    collectDefaultSuggestions(fileName: string, result: ISuggestionsCollector): Thenable<void>;
     resolveSuggestion?(item: CompletionItem): Thenable<CompletionItem>;
 }
 
@@ -126,7 +126,7 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
             log: (message: string) => console.log(message)
         };
 
-        let collectPromise: Thenable<any> = null;
+        let collectPromise: Thenable<void> = null;
 
         if (location.isAtPropertyKey) {
             let addValue = !location.previousNode || !location.previousNode.columnOffset && (offset == (location.previousNode.offset + location.previousNode.length));

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -10,6 +10,10 @@ import { IJSONContribution, ISuggestionsCollector } from './jsonContributions';
 import { XHRRequest, XHRResponse, getErrorStatusDescription } from 'request-light';
 
 import { Location } from 'jsonc-parser';
+import NuGetIndexResponse from './NuGetIndexResponse';
+import NuGetSearchAutocompleteServiceResponse from './NuGetSearchAutocompleteServiceResponse';
+import NuGetFlatContainerPackageResponse from './NuGetFlatContainerPackageResponse';
+import NuGetSearchQueryServiceResponse from './NuGetSearchQueryServiceResponse';
 
 const localize = nls.loadMessageBundle();
 
@@ -36,10 +40,10 @@ export class ProjectJSONContribution implements IJSONContribution {
 
     private getNugetIndex(): Thenable<NugetServices> {
         if (!this.nugetIndexPromise) {
-            this.nugetIndexPromise = this.makeJSONRequest<any>(FEED_INDEX_URL).then(indexContent => {
+            this.nugetIndexPromise = this.makeJSONRequest<NuGetIndexResponse>(FEED_INDEX_URL).then(indexContent => {
                 let services: NugetServices = {};
                 if (indexContent && Array.isArray(indexContent.resources)) {
-                    let resources = <any[]>indexContent.resources;
+                    let resources = indexContent.resources;
                     for (let i = resources.length - 1; i >= 0; i--) {
                         let type = resources[i]['@type'];
                         let id = resources[i]['@id'];
@@ -81,7 +85,13 @@ export class ProjectJSONContribution implements IJSONContribution {
         });
     }
 
-    public collectPropertySuggestions(resource: string, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<any> {
+    public collectPropertySuggestions(
+        resource: string, 
+        location: Location, 
+        currentWord: string, 
+        addValue: boolean, 
+        isLast: boolean, 
+        result: ISuggestionsCollector): Thenable<void> {
         if ((location.matches(['dependencies']) || location.matches(['frameworks', '*', 'dependencies']) || location.matches(['frameworks', '*', 'frameworkAssemblies']))) {
 
             return this.getNugetService('SearchAutocompleteService').then(service => {
@@ -91,9 +101,9 @@ export class ProjectJSONContribution implements IJSONContribution {
                 } else {
                     queryUrl = service + '?take=' + LIMIT;
                 }
-                return this.makeJSONRequest<any>(queryUrl).then(resultObj => {
+                return this.makeJSONRequest<NuGetSearchAutocompleteServiceResponse>(queryUrl).then(resultObj => {
                     if (Array.isArray(resultObj.data)) {
-                        let results = <any[]>resultObj.data;
+                        let results = resultObj.data;
                         for (let i = 0; i < results.length; i++) {
                             let name = results[i];
                             let insertText = JSON.stringify(name);
@@ -123,15 +133,15 @@ export class ProjectJSONContribution implements IJSONContribution {
         return null;
     }
 
-    public collectValueSuggestions(resource: string, location: Location, result: ISuggestionsCollector): Thenable<any> {
+    public collectValueSuggestions(resource: string, location: Location, result: ISuggestionsCollector): Thenable<void> {
         if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
             return this.getNugetService('PackageBaseAddress/3.0.0').then(service => {
                 let currentKey = location.path[location.path.length - 1];
                 if (typeof currentKey === 'string') {
                     let queryUrl = service + currentKey + '/index.json';
-                    return this.makeJSONRequest<any>(queryUrl).then(obj => {
+                    return this.makeJSONRequest<NuGetFlatContainerPackageResponse>(queryUrl).then(obj => {
                         if (Array.isArray(obj.versions)) {
-                            let results = <any[]>obj.versions;
+                            let results = obj.versions;
                             for (let i = 0; i < results.length; i++) {
                                 let curr = results[i];
                                 let name = JSON.stringify(curr);
@@ -156,7 +166,7 @@ export class ProjectJSONContribution implements IJSONContribution {
         return null;
     }
 
-    public collectDefaultSuggestions(resource: string, result: ISuggestionsCollector): Thenable<any> {
+    public collectDefaultSuggestions(resource: string, result: ISuggestionsCollector): Thenable<null> {
         let defaultValue = {
             'version': '{{1.0.0-*}}',
             'dependencies': {},
@@ -192,9 +202,9 @@ export class ProjectJSONContribution implements IJSONContribution {
     private getInfo(pack: string): Thenable<{ description?: string; version?: string }> {
         return this.getNugetService('SearchQueryService').then(service => {
             let queryUrl = service + '?q=' + encodeURIComponent(pack) + '&take=' + 5;
-            return this.makeJSONRequest<any>(queryUrl).then(resultObj => {
+            return this.makeJSONRequest<NuGetSearchQueryServiceResponse>(queryUrl).then(resultObj => {
                 if (Array.isArray(resultObj.data)) {
-                    let results = <any[]>resultObj.data;
+                    let results = resultObj.data;
                     let info: { description?: string; version?: string } = {};
                     for (let i = 0; i < results.length; i++) {
                         let res = results[i];

--- a/src/features/launchConfiguration.ts
+++ b/src/features/launchConfiguration.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DebugConfiguration } from "vscode";
+
+export default interface LaunchConfiguration extends DebugConfiguration {
+    debuggerEventsPipeName?: string;
+    program?: string;
+    args?: string;
+    cwd?: string;
+}

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -504,7 +504,7 @@ async function execChildProcess(process: string, workingDirectory: string): Prom
 // VSCode cannot find the path "c:\windows\system32\bash.exe" as bash.exe is only available on 64bit OS. 
 // It can be invoked from "c:\windows\sysnative\bash.exe", so adding "c:\windows\sysnative" to path if we identify
 // VSCode is running in windows and doesn't have it in the path.
-async function GetSysNativePathIfNeeded(): Promise<any> {
+async function GetSysNativePathIfNeeded(): Promise<NodeJS.ProcessEnv> {
     return PlatformInformation.GetCurrent().then(platformInfo => {
         let env = process.env;
         if (platformInfo.isWindows() && platformInfo.architecture === "x86_64") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,11 +27,12 @@ import { TelemetryObserver } from './observers/TelemetryObserver';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { addJSONProviders } from './features/json/jsonContributions';
 import { ProjectStatusBarObserver } from './observers/ProjectStatusBarObserver';
+import CSharpExtensionExports from './CSharpExtensionExports';
 
-export async function activate(context: vscode.ExtensionContext): Promise<{ initializationFinished: Promise<void> }> {
+export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
     const extensionId = 'ms-vscode.csharp';
-    const extension = vscode.extensions.getExtension(extensionId);
+    const extension = vscode.extensions.getExtension<CSharpExtensionExports>(extensionId);
     const extensionVersion = extension.packageJSON.version;
     const aiKey = extension.packageJSON.contributes.debuggers[0].aiKey;
     const reporter = new TelemetryReporter(extensionId, extensionVersion, aiKey);
@@ -115,7 +116,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
     };
 }
 
-async function ensureRuntimeDependencies(extension: vscode.Extension<any>, eventStream: EventStream, platformInfo: PlatformInformation): Promise<boolean> {
+async function ensureRuntimeDependencies(extension: vscode.Extension<CSharpExtensionExports>, eventStream: EventStream, platformInfo: PlatformInformation): Promise<boolean> {
     return util.installFileExists(util.InstallFileType.Lock)
         .then(exists => {
             if (!exists) {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -294,7 +294,7 @@ function launchWindows(launchPath: string, cwd: string, args: string[]): LaunchR
         '"' + argsCopy.map(escapeIfNeeded).join(' ') + '"'
     ].join(' ')];
 
-    let process = spawn('cmd', argsCopy, <any>{
+    let process = spawn('cmd', argsCopy, {
         windowsVerbatimArguments: true,
         detached: false,
         cwd: cwd

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -181,10 +181,9 @@ export class PlatformInformation {
                 throw new Error(`Unsupported platform: ${platform}`);
         }
 
-        return Promise.all<any>([architecturePromise, distributionPromise])
-            .then(([arch, distro]) => {
-                return new PlatformInformation(platform, arch, distro);
-            });
+        const platformData: [string, LinuxDistribution] = await Promise.all([architecturePromise, distributionPromise]);
+        
+        return new PlatformInformation(platform, platformData[0], platformData[1]);
     }
 
     private static async GetWindowsArchitecture(): Promise<string> {


### PR DESCRIPTION
Provides strong typing for the repo's Thennables. This is a step towards eliminating promises and will provide compiler support for validating that the refactored code has not changed its final return type.