### PR TITLE
Show the C# channel when there is an actual download

### DIFF
--- a/src/observers/CsharpChannelObserver.ts
+++ b/src/observers/CsharpChannelObserver.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, PackageInstallation, InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning } from "../omnisharp/loggingEvents";
+import { BaseEvent, InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, DownloadStart } from "../omnisharp/loggingEvents";
 
 export class CsharpChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
-            case PackageInstallation.name:
+            case DownloadStart.name:
             case InstallationFailure.name:
             case DebuggerNotInstalledFailure.name:
             case DebuggerPrerequisiteFailure.name:

--- a/test/unitTests/logging/CsharpChannelObserver.test.ts
+++ b/test/unitTests/logging/CsharpChannelObserver.test.ts
@@ -6,13 +6,13 @@
 import { should, expect } from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
 import { CsharpChannelObserver } from '../../../src/observers/CsharpChannelObserver';
-import { InstallationFailure, PackageInstallation, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, BaseEvent } from '../../../src/omnisharp/loggingEvents';
+import { InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, BaseEvent, DownloadStart } from '../../../src/omnisharp/loggingEvents';
 
 suite("CsharpChannelObserver", () => {
     suiteSetup(() => should());
     [
         new InstallationFailure("someStage", "someError"),
-        new PackageInstallation("somePackage"),
+        new DownloadStart("somePackage"),
         new DebuggerNotInstalledFailure(),
         new DebuggerPrerequisiteFailure("some failure"),
         new ProjectJsonDeprecatedWarning()


### PR DESCRIPTION
Fixes: #2176 

Stop the channel observer from listening to `PackageInstallation` event and instead listen to `DownloadStart` event.