### PR TITLE
Ensure that OmniSharp is launched on global mono even when a version or 'latest' specifed

### DIFF
--- a/src/observers/OmnisharpLoggerObserver.ts
+++ b/src/observers/OmnisharpLoggerObserver.ts
@@ -54,8 +54,8 @@ export class OmnisharpLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpLaunch(event: OmnisharpLaunch) {
-        if (event.usingMono) {
-            this.logger.appendLine(`OmniSharp server started with Mono`);
+        if (event.monoVersion) {
+            this.logger.appendLine(`OmniSharp server started with Mono ${event.monoVersion}`);
         }
         else {
             this.logger.appendLine(`OmniSharp server started`);

--- a/src/omnisharp/OmnisharpManager.ts
+++ b/src/omnisharp/OmnisharpManager.ts
@@ -48,7 +48,7 @@ export class OmnisharpManager {
             return GetLaunchPathForVersion(this.platformInfo, version, installPath, extensionPath, useMono);
         }
         else {
-            throw new Error(`Invalid omnisharp version - ${version}`);
+            throw new Error(`Invalid OmniSharp version - ${version}`);
         }
     }
 }

--- a/src/omnisharp/OmnisharpManager.ts
+++ b/src/omnisharp/OmnisharpManager.ts
@@ -9,17 +9,21 @@ import * as util from '../common';
 import { OmnisharpDownloader } from './OmnisharpDownloader';
 import { PlatformInformation } from '../platform';
 
+export interface OmniSharpLaunchInfo {
+    LaunchPath: string;
+}
+
 export class OmnisharpManager {
     public constructor(
         private downloader: OmnisharpDownloader,
         private platformInfo: PlatformInformation) {
     }
 
-    public async GetOmnisharpPath(omnisharpPath: string, useMono: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string): Promise<string> {
+    public async GetOmnisharpPath(omnisharpPath: string, useMono: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string): Promise<OmniSharpLaunchInfo> {
         // Looks at the options path, installs the dependencies and returns the path to be loaded by the omnisharp server
         if (path.isAbsolute(omnisharpPath)) {
             if (await util.fileExists(omnisharpPath)) {
-                return omnisharpPath;
+                return { LaunchPath: omnisharpPath };
             }
             else {
                 throw new Error('The system could not find the specified path');
@@ -33,7 +37,7 @@ export class OmnisharpManager {
         return await this.InstallVersionAndReturnLaunchPath(omnisharpPath, useMono, serverUrl, installPath, extensionPath);
     }
 
-    private async InstallLatestAndReturnLaunchPath(useMono: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string) {
+    private async InstallLatestAndReturnLaunchPath(useMono: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string): Promise<OmniSharpLaunchInfo> {
         let version = await this.downloader.GetLatestVersion(serverUrl, latestVersionFileServerPath);
         return await this.InstallVersionAndReturnLaunchPath(version, useMono, serverUrl, installPath, extensionPath);
     }
@@ -49,7 +53,7 @@ export class OmnisharpManager {
     }
 }
 
-function GetLaunchPathForVersion(platformInfo: PlatformInformation, version: string, installPath: string, extensionPath: string, useMono: boolean) {
+function GetLaunchPathForVersion(platformInfo: PlatformInformation, version: string, installPath: string, extensionPath: string, useMono: boolean): OmniSharpLaunchInfo {
     if (!version) {
         throw new Error('Invalid Version');
     }
@@ -57,12 +61,12 @@ function GetLaunchPathForVersion(platformInfo: PlatformInformation, version: str
     let basePath = path.resolve(extensionPath, installPath, version);
 
     if (platformInfo.isWindows()) {
-        return path.join(basePath, 'OmniSharp.exe');
+        return { LaunchPath: path.join(basePath, 'OmniSharp.exe') };
     }
     if (useMono) {
-        return path.join(basePath, 'omnisharp', 'OmniSharp.exe');
+        return { LaunchPath: path.join(basePath, 'omnisharp', 'OmniSharp.exe') };
     }
 
-    return path.join(basePath, 'run');
+    return { LaunchPath: path.join(basePath, 'run') };
 }
 

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as util from '../common';
 import { Options } from './options';
+import { OmniSharpLaunchInfo } from './OmnisharpManager';
 
 export enum LaunchTargetKind {
     Solution,
@@ -204,9 +205,9 @@ export interface LaunchResult {
     usingMono: boolean;
 }
 
-export async function launchOmniSharp(cwd: string, args: string[], launchPath: string): Promise<LaunchResult> {
+export async function launchOmniSharp(cwd: string, args: string[], launchInfo: OmniSharpLaunchInfo): Promise<LaunchResult> {
     return new Promise<LaunchResult>((resolve, reject) => {
-        launch(cwd, args, launchPath)
+        launch(cwd, args, launchInfo)
             .then(result => {
                 // async error - when target not not ENEOT
                 result.process.on('error', err => {
@@ -222,7 +223,7 @@ export async function launchOmniSharp(cwd: string, args: string[], launchPath: s
     });
 }
 
-async function launch(cwd: string, args: string[], launchPath: string): Promise<LaunchResult> {
+async function launch(cwd: string, args: string[], launchInfo: OmniSharpLaunchInfo): Promise<LaunchResult> {
     return PlatformInformation.GetCurrent().then(platformInfo => {
         const options = Options.Read();
 
@@ -236,17 +237,17 @@ async function launch(cwd: string, args: string[], launchPath: string): Promise<
         }
 
         // If the user has provided an absolute path or the specified version has been installed successfully, we'll use the path.
-        if (launchPath) {
+        if (launchInfo.LaunchPath) {
             if (platformInfo.isWindows()) {
-                return launchWindows(launchPath, cwd, args);
+                return launchWindows(launchInfo.LaunchPath, cwd, args);
             }
 
             // If we're launching on macOS/Linux, we have two possibilities:
             //   1. Launch using Mono
             //   2. Launch process directly (e.g. a 'run' script)
             return options.useMono
-                ? launchNixMono(launchPath, cwd, args)
-                : launchNix(launchPath, cwd, args);
+                ? launchNixMono(launchInfo.LaunchPath, cwd, args)
+                : launchNix(launchInfo.LaunchPath, cwd, args);
         }
 
         // If the user has not provided a path, we'll use the locally-installed OmniSharp

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as util from '../common';
 import { Options } from './options';
-import { OmniSharpLaunchInfo } from './OmnisharpManager';
+import { LaunchInfo } from './OmnisharpManager';
 
 export enum LaunchTargetKind {
     Solution,
@@ -205,7 +205,7 @@ export interface LaunchResult {
     usingMono: boolean;
 }
 
-export async function launchOmniSharp(cwd: string, args: string[], launchInfo: OmniSharpLaunchInfo): Promise<LaunchResult> {
+export async function launchOmniSharp(cwd: string, args: string[], launchInfo: LaunchInfo): Promise<LaunchResult> {
     return new Promise<LaunchResult>((resolve, reject) => {
         launch(cwd, args, launchInfo)
             .then(result => {
@@ -223,7 +223,7 @@ export async function launchOmniSharp(cwd: string, args: string[], launchInfo: O
     });
 }
 
-async function launch(cwd: string, args: string[], launchInfo: OmniSharpLaunchInfo): Promise<LaunchResult> {
+async function launch(cwd: string, args: string[], launchInfo: LaunchInfo): Promise<LaunchResult> {
     return PlatformInformation.GetCurrent().then(platformInfo => {
         const options = Options.Read();
 

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -8,7 +8,6 @@ import { satisfies } from 'semver';
 import { PlatformInformation } from '../platform';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as util from '../common';
 import { Options } from './options';
 import { LaunchInfo } from './OmnisharpManager';
 
@@ -202,7 +201,7 @@ function isCake(resource: vscode.Uri): boolean {
 export interface LaunchResult {
     process: ChildProcess;
     command: string;
-    usingMono: boolean;
+    monoVersion?: string;
 }
 
 export async function launchOmniSharp(cwd: string, args: string[], launchInfo: LaunchInfo): Promise<LaunchResult> {
@@ -224,49 +223,41 @@ export async function launchOmniSharp(cwd: string, args: string[], launchInfo: L
 }
 
 async function launch(cwd: string, args: string[], launchInfo: LaunchInfo): Promise<LaunchResult> {
-    return PlatformInformation.GetCurrent().then(platformInfo => {
-        const options = Options.Read();
+    const platformInfo = await PlatformInformation.GetCurrent();
+    const options = Options.Read();
 
-        if (options.useEditorFormattingSettings) {
-            let globalConfig = vscode.workspace.getConfiguration();
-            let csharpConfig = vscode.workspace.getConfiguration('[csharp]');
+    if (options.useEditorFormattingSettings) {
+        let globalConfig = vscode.workspace.getConfiguration();
+        let csharpConfig = vscode.workspace.getConfiguration('[csharp]');
 
-            args.push(`formattingOptions:useTabs=${!getConfigurationValue(globalConfig, csharpConfig, 'editor.insertSpaces', true)}`);
-            args.push(`formattingOptions:tabSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
-            args.push(`formattingOptions:indentationSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
+        args.push(`formattingOptions:useTabs=${!getConfigurationValue(globalConfig, csharpConfig, 'editor.insertSpaces', true)}`);
+        args.push(`formattingOptions:tabSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
+        args.push(`formattingOptions:indentationSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);
+    }
+
+    if (platformInfo.isWindows()) {
+        return launchWindows(launchInfo.LaunchPath, cwd, args);
+    }
+
+    let monoVersion = await getMonoVersion();
+    let isValidMonoAvailable = await satisfies(monoVersion, '>=5.2.0');
+
+    // If the user specifically said that they wanted to launch on Mono, respect their wishes.
+    if (options.useMono) {
+        if (!isValidMonoAvailable) {
+            throw new Error('Cannot start OmniSharp because Mono version >=5.2.0 is required.');
         }
 
-        // If the user has provided an absolute path or the specified version has been installed successfully, we'll use the path.
-        if (launchInfo.LaunchPath) {
-            if (platformInfo.isWindows()) {
-                return launchWindows(launchInfo.LaunchPath, cwd, args);
-            }
+        return launchNixMono(launchInfo.LaunchPath, monoVersion, cwd, args);
+    }
 
-            // If we're launching on macOS/Linux, we have two possibilities:
-            //   1. Launch using Mono
-            //   2. Launch process directly (e.g. a 'run' script)
-            return options.useMono
-                ? launchNixMono(launchInfo.LaunchPath, cwd, args)
-                : launchNix(launchInfo.LaunchPath, cwd, args);
-        }
-
-        // If the user has not provided a path, we'll use the locally-installed OmniSharp
-        const basePath = path.resolve(util.getExtensionPath(), '.omnisharp');
-
-        if (platformInfo.isWindows()) {
-            return launchWindows(path.join(basePath, 'OmniSharp.exe'), cwd, args);
-        }
-
-        // If it's possible to launch on a global Mono, we'll do that. Otherwise, run with our
-        // locally installed Mono runtime.
-        return canLaunchMono()
-            .then(async () => {
-                return launchNixMono(path.join(basePath, 'omnisharp', 'OmniSharp.exe'), cwd, args);
-            })
-            .catch(_ => {
-                return launchNix(path.join(basePath, 'run'), cwd, args);
-            });
-    });
+    // If we can launch on the global Mono, do so; otherwise, launch directly;
+    if (isValidMonoAvailable && launchInfo.MonoLaunchPath) {
+        return launchNixMono(launchInfo.MonoLaunchPath, monoVersion, cwd, args);
+    }
+    else {
+        return launchNix(launchInfo.LaunchPath, cwd, args);
+    }
 }
 
 function getConfigurationValue(globalConfig: vscode.WorkspaceConfiguration, csharpConfig: vscode.WorkspaceConfiguration,
@@ -304,7 +295,6 @@ function launchWindows(launchPath: string, cwd: string, args: string[]): LaunchR
     return {
         process,
         command: launchPath,
-        usingMono: false
     };
 }
 
@@ -316,58 +306,41 @@ function launchNix(launchPath: string, cwd: string, args: string[]): LaunchResul
 
     return {
         process,
-        command: launchPath,
-        usingMono: true
+        command: launchPath
     };
 }
 
-async function launchNixMono(launchPath: string, cwd: string, args: string[]): Promise<LaunchResult> {
-    return canLaunchMono()
-        .then(() => {
-            let argsCopy = args.slice(0); // create copy of details args
-            argsCopy.unshift(launchPath);
-            argsCopy.unshift("--assembly-loader=strict");
+function launchNixMono(launchPath: string, monoVersion: string, cwd: string, args: string[]): LaunchResult {
+    let argsCopy = args.slice(0); // create copy of details args
+    argsCopy.unshift(launchPath);
+    argsCopy.unshift("--assembly-loader=strict");
 
-            let process = spawn('mono', argsCopy, {
-                detached: false,
-                cwd: cwd
-            });
-
-            return {
-                process,
-                command: launchPath,
-                usingMono: true
-            };
-        });
-}
-
-async function canLaunchMono(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        hasMono('>=5.2.0').then(success => {
-            if (success) {
-                resolve();
-            }
-            else {
-                reject(new Error('Cannot start Omnisharp because Mono version >=5.2.0 is required.'));
-            }
-        });
+    let process = spawn('mono', argsCopy, {
+        detached: false,
+        cwd: cwd
     });
+
+    return {
+        process,
+        command: launchPath,
+        monoVersion, 
+    };
 }
 
-export async function hasMono(range?: string): Promise<boolean> {
+async function getMonoVersion(): Promise<string> {
     const versionRegexp = /(\d+\.\d+\.\d+)/;
 
-    return new Promise<boolean>((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
         let childprocess: ChildProcess;
         try {
             childprocess = spawn('mono', ['--version']);
         }
         catch (e) {
-            return resolve(false);
+            return resolve(undefined);
         }
 
         childprocess.on('error', function (err: any) {
-            resolve(false);
+            resolve(undefined);
         });
 
         let stdout = '';
@@ -376,20 +349,14 @@ export async function hasMono(range?: string): Promise<boolean> {
         });
 
         childprocess.stdout.on('close', () => {
-            let match = versionRegexp.exec(stdout),
-                ret: boolean;
+            let match = versionRegexp.exec(stdout);
 
-            if (!match) {
-                ret = false;
-            }
-            else if (!range) {
-                ret = true;
+            if (match && match.length > 1) {
+                resolve(match[1]);
             }
             else {
-                ret = satisfies(match[1], range);
+                resolve(undefined);
             }
-
-            resolve(ret);
         });
     });
 }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -27,7 +27,7 @@ export class OmnisharpInitialisation implements BaseEvent {
 }
 
 export class OmnisharpLaunch implements BaseEvent {
-    constructor(public usingMono: boolean, public command: string, public pid: number) { }
+    constructor(public monoVersion: string, public command: string, public pid: number) { }
 }
 
 export class PackageInstallation implements BaseEvent {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -15,7 +15,7 @@ import { ReadLine, createInterface } from 'readline';
 import { Request, RequestQueueCollection } from './requestQueue';
 import { DelayTracker } from './delayTracker';
 import { EventEmitter } from 'events';
-import { OmnisharpManager } from './OmnisharpManager';
+import { OmnisharpManager, OmniSharpLaunchInfo } from './OmnisharpManager';
 import { Options } from './options';
 import { PlatformInformation } from '../platform';
 import { launchOmniSharp } from './launcher';
@@ -312,11 +312,11 @@ export class OmniSharpServer {
             args.push('--debug');
         }
 
-        let launchPath: string;
+        let launchInfo: OmniSharpLaunchInfo;
         if (this._options.path) {
             try {
                 let extensionPath = utils.getExtensionPath();
-                launchPath = await this._omnisharpManager.GetOmnisharpPath(this._options.path, this._options.useMono, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
+                launchInfo = await this._omnisharpManager.GetOmnisharpPath(this._options.path, this._options.useMono, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
             }
             catch (error) {
                 this.eventStream.post(new ObservableEvents.OmnisharpFailure(`Error occured in loading omnisharp from omnisharp.path\nCould not start the server due to ${error.toString()}`, error));
@@ -327,7 +327,7 @@ export class OmniSharpServer {
         this.eventStream.post(new ObservableEvents.OmnisharpInitialisation(new Date(), solutionPath));
         this._fireEvent(Events.BeforeServerStart, solutionPath);
 
-        return launchOmniSharp(cwd, args, launchPath).then(async value => {
+        return launchOmniSharp(cwd, args, launchInfo).then(async value => {
             this.eventStream.post(new ObservableEvents.OmnisharpLaunch(value.usingMono, value.command, value.process.pid));
 
             this._serverProcess = value.process;

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -15,7 +15,7 @@ import { ReadLine, createInterface } from 'readline';
 import { Request, RequestQueueCollection } from './requestQueue';
 import { DelayTracker } from './delayTracker';
 import { EventEmitter } from 'events';
-import { OmnisharpManager, OmniSharpLaunchInfo } from './OmnisharpManager';
+import { OmnisharpManager, LaunchInfo } from './OmnisharpManager';
 import { Options } from './options';
 import { PlatformInformation } from '../platform';
 import { launchOmniSharp } from './launcher';
@@ -312,11 +312,11 @@ export class OmniSharpServer {
             args.push('--debug');
         }
 
-        let launchInfo: OmniSharpLaunchInfo;
+        let launchInfo: LaunchInfo;
         if (this._options.path) {
             try {
                 let extensionPath = utils.getExtensionPath();
-                launchInfo = await this._omnisharpManager.GetOmnisharpPath(this._options.path, this._options.useMono, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
+                launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this._options.path, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
             }
             catch (error) {
                 this.eventStream.post(new ObservableEvents.OmnisharpFailure(`Error occured in loading omnisharp from omnisharp.path\nCould not start the server due to ${error.toString()}`, error));

--- a/test/featureTests/OmnisharpManager.test.ts
+++ b/test/featureTests/OmnisharpManager.test.ts
@@ -54,7 +54,7 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
 
     test('Returns default paths if no path is specified', async () => {
         let launchInfo = await manager.GetOmniSharpLaunchInfo(undefined, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/omnisharp/OmniSharp.exe'));
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/OmniSharp.exe'));
         expect(launchInfo.MonoLaunchPath).to.be.undefined;
     });
 

--- a/test/featureTests/OmnisharpManager.test.ts
+++ b/test/featureTests/OmnisharpManager.test.ts
@@ -23,7 +23,6 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
     const serverUrl = "https://roslynomnisharp.blob.core.windows.net";
     const installPath = ".omnisharp/experimental";
     const versionFilepathInServer = "releases/testVersionInfo.txt";
-    const useMono = false;
     const eventStream = new EventStream();
     const manager = GetTestOmnisharpManager(eventStream, platformInfo);
     let extensionPath: string;
@@ -39,58 +38,53 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
     });
 
     test('Throws error if the path is neither an absolute path nor a valid semver, nor the string "latest"', async () => {
-        expect(manager.GetOmnisharpPath("Some incorrect path", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
+        expect(manager.GetOmniSharpLaunchInfo("Some incorrect path", serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
     });
 
     test('Throws error when the specified path is null', async () => {
-        expect(manager.GetOmnisharpPath(null, useMono, serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
+        expect(manager.GetOmniSharpLaunchInfo(null, serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
     });
 
     test('Throws error when the specified path is empty', async () => {
-        expect(manager.GetOmnisharpPath("", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
+        expect(manager.GetOmniSharpLaunchInfo("", serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
     });
 
     test('Throws error when the specified path is an invalid semver', async () => {
-        expect(manager.GetOmnisharpPath("a.b.c", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
+        expect(manager.GetOmniSharpLaunchInfo("a.b.c", serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
     });
 
     test('Returns the same path if absolute path to an existing file is passed', async () => {
         tmpFile = tmp.fileSync();
-        let launchInfo = await manager.GetOmnisharpPath(tmpFile.name, useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        let launchInfo = await manager.GetOmniSharpLaunchInfo(tmpFile.name, serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(tmpFile.name);
     });
 
     test('Installs the latest version and returns the launch path based on the version and platform', async () => {
-        let launchInfo = await manager.GetOmnisharpPath("latest", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        let launchInfo = await manager.GetOmniSharpLaunchInfo("latest", serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
     });
 
     test('Installs the test version and returns the launch path based on the version and platform', async () => {
-        let launchInfo = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        let launchInfo = await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
     });
 
     test('Downloads package from given url and installs them at the specified path', async () => {
-        await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath); 
+        await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, installPath, extensionPath); 
         let exists = await util.fileExists(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/install_check_1.2.3.txt`));
         exists.should.equal(true);
     });
 
-    test('Downloads package and returns launch path based on platform - Not using mono on Linux ', async () => {
+    test('Downloads package and returns launch path based on platform - on Linux ', async () => {
         let manager = GetTestOmnisharpManager(eventStream, new PlatformInformation("linux", "x64"));
-        let launchInfo = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        let launchInfo = await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/run'));
-    });
-
-    test('Downloads package and returns launch path based on platform - Using mono on Linux ', async () => {
-        let manager = GetTestOmnisharpManager(eventStream, new PlatformInformation("linux", "x64"));
-        let launchInfo = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/omnisharp/OmniSharp.exe'));
+        launchInfo.MonoLaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/omnisharp/OmniSharp.exe'));
     });
 
     test('Downloads package and returns launch path based on install path ', async () => {
         let manager = GetTestOmnisharpManager(eventStream, platformInfo);
-        let launchInfo = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, "installHere", extensionPath);
+        let launchInfo = await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, "installHere", extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, 'installHere/1.2.3/OmniSharp.exe'));
     });
 

--- a/test/featureTests/OmnisharpManager.test.ts
+++ b/test/featureTests/OmnisharpManager.test.ts
@@ -56,18 +56,18 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
 
     test('Returns the same path if absolute path to an existing file is passed', async () => {
         tmpFile = tmp.fileSync();
-        let omnisharpPath = await manager.GetOmnisharpPath(tmpFile.name, useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        omnisharpPath.should.equal(tmpFile.name);
+        let launchInfo = await manager.GetOmnisharpPath(tmpFile.name, useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(tmpFile.name);
     });
 
     test('Installs the latest version and returns the launch path based on the version and platform', async () => {
-        let omnisharpPath = await manager.GetOmnisharpPath("latest", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        omnisharpPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
+        let launchInfo = await manager.GetOmnisharpPath("latest", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
     });
 
     test('Installs the test version and returns the launch path based on the version and platform', async () => {
-        let omnisharpPath = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        omnisharpPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
+        let launchInfo = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
     });
 
     test('Downloads package from given url and installs them at the specified path', async () => {
@@ -78,20 +78,20 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
 
     test('Downloads package and returns launch path based on platform - Not using mono on Linux ', async () => {
         let manager = GetTestOmnisharpManager(eventStream, new PlatformInformation("linux", "x64"));
-        let launchPath = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        launchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/run'));
+        let launchInfo = await manager.GetOmnisharpPath("1.2.3", useMono, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/run'));
     });
 
     test('Downloads package and returns launch path based on platform - Using mono on Linux ', async () => {
         let manager = GetTestOmnisharpManager(eventStream, new PlatformInformation("linux", "x64"));
-        let launchPath = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, installPath, extensionPath);
-        launchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/omnisharp/OmniSharp.exe'));
+        let launchInfo = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/experimental/1.2.3/omnisharp/OmniSharp.exe'));
     });
 
     test('Downloads package and returns launch path based on install path ', async () => {
         let manager = GetTestOmnisharpManager(eventStream, platformInfo);
-        let launchPath = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, "installHere", extensionPath);
-        launchPath.should.equal(path.resolve(extensionPath, 'installHere/1.2.3/OmniSharp.exe'));
+        let launchInfo = await manager.GetOmnisharpPath("1.2.3", true, serverUrl, versionFilepathInServer, "installHere", extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, 'installHere/1.2.3/OmniSharp.exe'));
     });
 
     teardown(async () => {

--- a/test/featureTests/OmnisharpManager.test.ts
+++ b/test/featureTests/OmnisharpManager.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as util from '../../src/common';
-import { should } from "chai";
+import { expect, should } from "chai";
 import { PlatformInformation } from "../../src/platform";
 import { rimraf } from 'async-file';
 import { OmnisharpManager } from '../../src/omnisharp/OmnisharpManager';
@@ -14,7 +14,6 @@ import { GetTestOmnisharpDownloader } from './testAssets/testAssets';
 
 const chai = require("chai");
 chai.use(require("chai-as-promised"));
-let expect = chai.expect;
 
 const tmp = require('tmp');
 
@@ -53,6 +52,19 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
         expect(manager.GetOmniSharpLaunchInfo("a.b.c", serverUrl, versionFilepathInServer, installPath, extensionPath)).to.be.rejectedWith(Error);
     });
 
+    test('Returns default paths if no path is specified', async () => {
+        let launchInfo = await manager.GetOmniSharpLaunchInfo(undefined, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/omnisharp/OmniSharp.exe'));
+        expect(launchInfo.MonoLaunchPath).to.be.undefined;
+    });
+
+    test('Returns default paths if no path is specified - Linux ', async () => {
+        let manager = GetTestOmnisharpManager(eventStream, new PlatformInformation("linux", "x64"));
+        let launchInfo = await manager.GetOmniSharpLaunchInfo(undefined, serverUrl, versionFilepathInServer, installPath, extensionPath);
+        launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/run'));
+        launchInfo.MonoLaunchPath.should.equal(path.resolve(extensionPath, '.omnisharp/omnisharp/OmniSharp.exe'));
+    });
+
     test('Returns the same path if absolute path to an existing file is passed', async () => {
         tmpFile = tmp.fileSync();
         let launchInfo = await manager.GetOmniSharpLaunchInfo(tmpFile.name, serverUrl, versionFilepathInServer, installPath, extensionPath);
@@ -62,11 +74,13 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
     test('Installs the latest version and returns the launch path based on the version and platform', async () => {
         let launchInfo = await manager.GetOmniSharpLaunchInfo("latest", serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
+        expect(launchInfo.MonoLaunchPath).to.be.undefined;
     });
 
     test('Installs the test version and returns the launch path based on the version and platform', async () => {
         let launchInfo = await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, installPath, extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, `.omnisharp/experimental/1.2.3/OmniSharp.exe`));
+        expect(launchInfo.MonoLaunchPath).to.be.undefined;
     });
 
     test('Downloads package from given url and installs them at the specified path', async () => {
@@ -86,6 +100,7 @@ suite('GetExperimentalOmnisharpPath : Returns Omnisharp experiment path dependin
         let manager = GetTestOmnisharpManager(eventStream, platformInfo);
         let launchInfo = await manager.GetOmniSharpLaunchInfo("1.2.3", serverUrl, versionFilepathInServer, "installHere", extensionPath);
         launchInfo.LaunchPath.should.equal(path.resolve(extensionPath, 'installHere/1.2.3/OmniSharp.exe'));
+        expect(launchInfo.MonoLaunchPath).to.be.undefined;
     });
 
     teardown(async () => {

--- a/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
@@ -135,8 +135,8 @@ suite("OmnisharpLoggerObserver", () => {
 
     suite('OmnisharpLaunch', () => {
         [
-            new OmnisharpLaunch(true, "someCommand", 4),
-            new OmnisharpLaunch(false, "someCommand", 4)
+            new OmnisharpLaunch("5.8.0", "someCommand", 4),
+            new OmnisharpLaunch(undefined, "someCommand", 4)
         ].forEach((event: OmnisharpLaunch) => {
 
             test(`Command and Pid are displayed`, () => {
@@ -147,8 +147,8 @@ suite("OmnisharpLoggerObserver", () => {
 
             test(`Message is displayed depending on usingMono value`, () => {
                 observer.post(event);
-                if (event.usingMono) {
-                    expect(logOutput).to.contain("OmniSharp server started with Mono");
+                if (event.monoVersion) {
+                    expect(logOutput).to.contain("OmniSharp server started with Mono 5.8.0");
                 }
                 else {
                     expect(logOutput).to.contain("OmniSharp server started");


### PR DESCRIPTION
While @rchande and I were investigating a different issue, we noticed that OmniSharp was always being launched with the run script when `"omnisharp.path"` is set to `"latest"`. Essentially, it would only try to launch OmniSharp on the globally-installed Mono if the user hasn't set `"omnisharp.path"` at all, which really isn't what we want.

Here are the desired behaviors for Linux/OSX:

1. If the user hasn't set `"omnisharp.path"` at all, launch the default OmniSharp. If a valid version of Mono is installed, launch with Mono; otherwise, use the run script.
2. If the user has set `"omnisharp.path"` to an absolute path, assume that path is OmniSharp and launch it. If the user also sets `"omnisharp.useMono"` to `true`, launch with Mono. If a valid version of Mono can't be found, throw an error.
3. If the user has set `"omnisharp.path"` to a version or `"latest"`, first, ensure the appropriate version of OmniSharp is downloaded. Then, if a valid version of Mono is installed, launch with Mono; otherwise, use the run script.

This change fixes `#3` above.

As part of this change, I've done a bit of refactoring to simplify things a bit. The OmniSharpManager has been changed to return two paths: the path to the run script, and the path to launch with Mono. In addition, the calculation of the path to the default OmniSharp has been pushed into the OmniSharpManager. The launcher code has also been simplified a bit. Finally, I changed the logging to only say "started with Mono" if OmniSharp was actually launched with Mono, and I added the version number of Mono.