### PR TITLE
Remove the retain vsix option and check for absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,23 @@
 * Adds support for [Source Link](https://aka.ms/SourceLinkSpec), Symbol Servers and other more advanced symbol options ([#373](https://github.com/OmniSharp/omnisharp-vscode/issues/373))
 * Adds launch.json option to suppress Just-In-Time compiler optimizations.
 * Due to the previous two items and work from the .NET Team, it is now possible to easily debug into ASP.NET itself in projects running against .NET Core 2.1 preview 1. Support for debugging into all the managed code in .NET Core will come in future .NET Core 2.1 builds. Instructions are in the [wiki](https://github.com/OmniSharp/omnisharp-vscode/wiki/Debugging-into-the-.NET-Framework-itself).
+* Adds a Code Lens indicator for runnning and debugging all tests in a class. ([#420](https://github.com/OmniSharp/omnisharp-vscode/issues/420), PR: [#1961](https://github.com/OmniSharp/omnisharp-vscode/pull/1961); PR: [omnisharp-roslyn#1089](https://github.com/OmniSharp/omnisharp-roslyn/pull/1089))
 
 #### Specify OmniSharp Version
 Enables the use of pre-release builds of Omnisharp. Downloading a pre-release build of Omnisharp allows the C# extension for VS Code to use features that have been merged into the "master" branch of omnisharp-roslyn(https://github.com/OmniSharp/omnisharp-roslyn) but that have not been officially released
 * Adds support to use the "omnisharp.path" option to download a specific copy of OmniSharp. The possible values for this option are:
-  * Some absolute path - Use a local copy of OmniSharp. The value must point to a directory which contains OmniSharp, typically a user's build output directory for the OmniSharp-Roslyn project. Example: C:\omnisharp-roslyn\artifacts\publish\OmniSharp.Stdio\win7-x64\OmniSharp.exe.
-  * "latest" - Use the latest CI build
-  * `version` - Use a specific version of OmniSharp. Example: `1.29.2-beta.60`
+  * `<Path to the omnisharp executable>` - Use a local copy of OmniSharp. The value must point to a directory which contains OmniSharp, typically a user's build output directory for the OmniSharp-Roslyn project. Example: C:\omnisharp-roslyn\artifacts\publish\OmniSharp.Stdio\win7-x64\OmniSharp.exe.
+  * `latest` - Use the latest CI build
+  * `<version>` - Use a specific version of OmniSharp. Example: `1.29.2-beta.60`
+
+#### Editor
+
+* Splits the OmniSharp status bar item into two parts, both of which appear on the left and have specific responsibilities. ([#2146](https://github.com/OmniSharp/omnisharp-vscode/issues/2146), PR: [@2133](https://github.com/OmniSharp/omnisharp-vscode/pull/2133))
+  * OmniSharp server status bar item - Shows the various stages that the OmniSharp server initialization might be in (eg: Downloading, Installing, etc). The flame icon is green when the server is initialized and running properly, or red if there is an error.
+  * Project Information status bar item - 
+    * Displays the name of the selected project regardless of the currently active document.  
+    * If a project is already selected, it displays the name of the selected project. Clicking on it displays a menu to switch to other projects in the workspace. 
+    * If there are multiple possible launch targets, it displays 'Select Project'. Clicking on it displays a menu to select one.
 
 ## 1.14.0 (February 14, 2018)
 

--- a/tasks/commandLineArguments.ts
+++ b/tasks/commandLineArguments.ts
@@ -8,12 +8,9 @@
 import * as minimist from 'minimist';
 import * as path from 'path';
 
-let argv = minimist(process.argv.slice(2), { 
-    boolean: ['retainVsix']
-});
+let argv = minimist(process.argv.slice(2));
 
 export const commandLineOptions ={
-    retainVsix: !!argv['retainVsix'],
     outputFolder:  makePathAbsolute(argv['o']),
     codeExtensionPath: makePathAbsolute(argv['codeExtensionPath'])
 };
@@ -21,10 +18,6 @@ export const commandLineOptions ={
 function makePathAbsolute(originalPath: string) {
     if (!originalPath || originalPath == '') {
         return undefined;
-    }
-
-    if (path.isAbsolute(originalPath)) {
-        return originalPath;        
     }
 
     return path.resolve(originalPath);

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -14,7 +14,6 @@ import * as path from 'path';
 import * as util from '../src/common';
 import spawnNode from '../tasks/spawnNode';
 import { codeExtensionPath, offlineVscodeignorePath, vscodeignorePath, vscePath, packedVsixOutputRoot } from '../tasks/projectPaths';
-import { commandLineOptions } from '../tasks/commandLineArguments';
 import { CsharpLoggerObserver } from '../src/observers/CsharpLoggerObserver';
 import { EventStream } from '../src/EventStream';
 import { getPackageJSON } from '../tasks/packageJson';
@@ -38,16 +37,8 @@ gulp.task('vsix:offline:package', async () => {
 });
 
 async function doPackageOffline() {
+    cleanSync(true);
     util.setExtensionPath(codeExtensionPath);
-
-    if (commandLineOptions.retainVsix) {
-        //if user doesnot want to clean up the existing vsix packages
-        cleanSync(false);
-    }
-    else {
-        cleanSync(true);
-    }
-
     const packageJSON = getPackageJSON();
     const name = packageJSON.name;
     const version = packageJSON.version;
@@ -80,9 +71,7 @@ async function doOfflinePackage(platformInfo: PlatformInformation, packageName: 
     }
 
     cleanSync(false);
-
     const packageFileName = `${packageName}-${platformInfo.platform}-${platformInfo.architecture}.vsix`;
-
     await install(platformInfo, packageJSON);
     await doPackageSync(packageFileName, outputFolder);
 }

--- a/test/releaseTests/offlinePackage.test.ts
+++ b/test/releaseTests/offlinePackage.test.ts
@@ -22,7 +22,6 @@ suite("Offline packaging of VSIX", function () {
         let args: string[] = [];
         args.push(path.join("node_modules", "gulp", "bin", "gulp.js"));
         args.push("package:offline");
-        args.push("--retainVsix");// do not delete the existing vsix in the repo
         args.push(`-o`);
         args.push(tmpDir.name);
         invokeNode(args);

--- a/test/releaseTests/offlinePackage.test.ts
+++ b/test/releaseTests/offlinePackage.test.ts
@@ -8,17 +8,16 @@ import * as glob from 'glob-promise';
 import * as path from 'path';
 import { invokeNode } from './testAssets/testAssets';
 import { PlatformInformation } from '../../src/platform';
-import { rimraf } from 'async-file';
-import * as tmp from 'tmp';
+import { TmpAsset, CreateTmpDir } from '../../src/CreateTmpAsset';
 
 suite("Offline packaging of VSIX", function () {
     let vsixFiles: string[];
     this.timeout(1000000);
-    let tmpDir: tmp.SynchrounousResult = null;
+    let tmpDir: TmpAsset;
 
-    suiteSetup(() => {
+    suiteSetup(async () => {
         chai.should();
-        tmpDir = tmp.dirSync();
+        tmpDir = await CreateTmpDir(true);
         let args: string[] = [];
         args.push(path.join("node_modules", "gulp", "bin", "gulp.js"));
         args.push("package:offline");
@@ -45,9 +44,7 @@ suite("Offline packaging of VSIX", function () {
 
     suiteTeardown(async () => {
         if (tmpDir) {
-            await rimraf(tmpDir.name);
+            tmpDir.dispose();
         }
-
-        tmpDir = null;
     });
 });


### PR DESCRIPTION
path.resolve will return the path if it is already absolute so that check is not required.

Also retainVSix option was added to ease testing in the root folder, however since we are using the tmpdirectory, this can be removed.