### PR TITLE
Removing a possible race condition between the downloader and installer - To remove the `Immediate Zip File error` 

### DIFF
--- a/src/omnisharp/OmnisharpDownloader.ts
+++ b/src/omnisharp/OmnisharpDownloader.ts
@@ -49,7 +49,7 @@ export class OmnisharpDownloader {
         try {
             this.eventStream.post(new LatestBuildDownloadStart());
             tmpFile = await CreateTmpFile();
-            await DownloadFile(tmpFile.fd, description, this.eventStream, this.networkSettingsProvider, url);
+            await DownloadFile(tmpFile.name, description, this.eventStream, this.networkSettingsProvider, url);
             return fs.readFileSync(tmpFile.name, 'utf8');
         }
         catch (error) {

--- a/src/packageManager/FileDownloader.ts
+++ b/src/packageManager/FileDownloader.ts
@@ -13,11 +13,11 @@ import { parse as parseUrl } from 'url';
 import { getProxyAgent } from './proxy';
 import { NetworkSettingsProvider } from '../NetworkSettings';
 
-export async function DownloadFile(destinationFileDescriptor: number, description: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider, url: string, fallbackUrl?: string){
+export async function DownloadFile(destinationPath: string,  description: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider, url: string, fallbackUrl?: string){
     eventStream.post(new DownloadStart(description));
     
     try {
-        await downloadFile(destinationFileDescriptor, description, url, eventStream, networkSettingsProvider);
+        await downloadFile(destinationPath, description, url, eventStream, networkSettingsProvider);
         eventStream.post(new DownloadSuccess(` Done!`));
     }
     catch (primaryUrlError) {
@@ -27,7 +27,7 @@ export async function DownloadFile(destinationFileDescriptor: number, descriptio
         if (fallbackUrl) {
             eventStream.post(new DownloadFallBack(fallbackUrl));
             try {
-                await downloadFile(destinationFileDescriptor, description, fallbackUrl, eventStream, networkSettingsProvider);
+                await downloadFile(destinationPath, description, fallbackUrl, eventStream, networkSettingsProvider);
                 eventStream.post(new DownloadSuccess(' Done!'));
             }
             catch (fallbackUrlError) {
@@ -40,7 +40,7 @@ export async function DownloadFile(destinationFileDescriptor: number, descriptio
     }
 }
 
-async function downloadFile(fd: number, description: string, urlString: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider): Promise<void> {
+async function downloadFile(destinationPath: string, description: string, urlString: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider): Promise<void> {
     const url = parseUrl(urlString);
     const networkSettings = networkSettingsProvider();
     const proxy = networkSettings.proxy;
@@ -54,14 +54,10 @@ async function downloadFile(fd: number, description: string, urlString: string, 
     };
 
     return new Promise<void>((resolve, reject) => {
-        if (fd == 0) {
-            reject(new NestedError("Temporary package file unavailable"));
-        }
-
         let request = https.request(options, response => {
             if (response.statusCode === 301 || response.statusCode === 302) {
                 // Redirect - download from new location
-                return resolve(downloadFile(fd, description, response.headers.location, eventStream, networkSettingsProvider));
+                return resolve(downloadFile(destinationPath, description, response.headers.location, eventStream, networkSettingsProvider));
             }
 
             else if (response.statusCode != 200) {
@@ -74,7 +70,7 @@ async function downloadFile(fd: number, description: string, urlString: string, 
             let packageSize = parseInt(response.headers['content-length'], 10);
             let downloadedBytes = 0;
             let downloadPercentage = 0;
-            let tmpFile = fs.createWriteStream(null, { fd });
+            let tmpFile = fs.createWriteStream(destinationPath);
 
             eventStream.post(new DownloadSizeObtained(packageSize));
 
@@ -89,7 +85,6 @@ async function downloadFile(fd: number, description: string, urlString: string, 
                 }
             });
 
-            response.on('end', () => {
             tmpFile.on('error', err => {
                 reject(new NestedError(`Writestream error: ${err.message || 'NONE'}`, err)); 
             });
@@ -99,13 +94,11 @@ async function downloadFile(fd: number, description: string, urlString: string, 
             });
 
             response.on('error', err => {
-                reject(new NestedError(`Reponse error: ${err.message || 'NONE'}`, err));
                 tmpFile.end(); //close the writable stream if there is an error in the response
                 reject(new NestedError(`Response error: ${err.message || 'NONE'}`, err));
             });
 
             // Begin piping data from the response to the package file
-            response.pipe(tmpFile, { end: false });
             response.pipe(tmpFile);
         });
 

--- a/src/packageManager/PackageManager.ts
+++ b/src/packageManager/PackageManager.ts
@@ -23,7 +23,7 @@ export async function DownloadAndInstallPackages(packages: Package[], provider: 
         for (let pkg of filteredPackages) {
             try {
                 tmpFile = await CreateTmpFile();
-                await DownloadFile(tmpFile.fd, pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
+                await DownloadFile(tmpFile.name, pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
                 await InstallZip(tmpFile.name, pkg.description, pkg.installPath, pkg.binaries, eventStream);
             }
             catch (error) {

--- a/src/packageManager/PackageManager.ts
+++ b/src/packageManager/PackageManager.ts
@@ -24,7 +24,7 @@ export async function DownloadAndInstallPackages(packages: Package[], provider: 
             try {
                 tmpFile = await CreateTmpFile();
                 await DownloadFile(tmpFile.fd, pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
-                await InstallZip(tmpFile.fd, pkg.description, pkg.installPath, pkg.binaries, eventStream);
+                await InstallZip(tmpFile.name, pkg.description, pkg.installPath, pkg.binaries, eventStream);
             }
             catch (error) {
                 if (error instanceof NestedError) {

--- a/src/packageManager/ZipInstaller.ts
+++ b/src/packageManager/ZipInstaller.ts
@@ -21,7 +21,7 @@ export async function InstallZip(sourcePath: string, description: string, destin
 
         yauzl.open(sourcePath, { lazyEntries: true }, (err, zipFile) => {
             if (err) {
-                return reject(new NestedError(`Immediate zip file error: ${err}`));
+                return reject(new NestedError(`Immediate zip file error:  ${err.message || 'NONE'}`));
             }
 
             zipFile.readEntry();

--- a/test/unitTests/Packages/FileDownloader.test.ts
+++ b/test/unitTests/Packages/FileDownloader.test.ts
@@ -92,7 +92,7 @@ suite("FileDownloader", () => {
         ].forEach((elem) => {
             suite(elem.description, () => {
                 test('File is downloaded', async () => {
-                    await DownloadFile(tmpFile.fd, fileDescription, eventStream, networkSettingsProvider, getURL(elem.urlPath), getURL(elem.fallBackUrlPath));
+                    await DownloadFile(tmpFile.name, fileDescription, eventStream, networkSettingsProvider, getURL(elem.urlPath), getURL(elem.fallBackUrlPath));
                     const stats = await fs.stat(tmpFile.name);
                     expect(stats.size).to.not.equal(0);
                     let text = await fs.readFile(tmpFile.name, 'utf8');
@@ -100,7 +100,7 @@ suite("FileDownloader", () => {
                 });
 
                 test('Events are created in the correct order', async () => {
-                    await DownloadFile(tmpFile.fd, fileDescription, eventStream, networkSettingsProvider,  getURL(elem.urlPath), getURL(elem.fallBackUrlPath));
+                    await DownloadFile(tmpFile.name, fileDescription, eventStream, networkSettingsProvider,  getURL(elem.urlPath), getURL(elem.fallBackUrlPath));
                     expect(eventBus).to.be.deep.equal(elem.getEventSequence());
                 });
             });
@@ -109,7 +109,7 @@ suite("FileDownloader", () => {
 
     suite('If the response status Code is 301, redirect occurs and the download succeeds', () => {
         test('File is downloaded from the redirect url', async () => {
-            await DownloadFile(tmpFile.fd, fileDescription, eventStream, networkSettingsProvider, getURL(redirectUrlPath));
+            await DownloadFile(tmpFile.name, fileDescription, eventStream, networkSettingsProvider, getURL(redirectUrlPath));
             const stats = await fs.stat(tmpFile.name);
             expect(stats.size).to.not.equal(0);
             let text = await fs.readFile(tmpFile.name, "utf8");
@@ -119,7 +119,7 @@ suite("FileDownloader", () => {
 
     suite('If the response status code is not 301, 302 or 200 then the download fails', () => {
         test('Error is thrown', async () => {
-            expect(DownloadFile(tmpFile.fd, fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath))).be.rejected;
+            expect(DownloadFile(tmpFile.name, fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath))).be.rejected;
         });
 
         test('Download Start and Download Failure events are created', async () => {
@@ -128,17 +128,12 @@ suite("FileDownloader", () => {
                 new DownloadFailure("failed (error code '404')")
             ];
             try {
-                await DownloadFile(tmpFile.fd, fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath));
+                await DownloadFile(tmpFile.name, fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath));
             }
             catch (error) {
                 expect(eventBus).to.be.deep.equal(eventsSequence);
             }
         });
-    });
-
-    test('Error is thrown on invalid input file', async () => {
-        //fd=0 means there is no file
-        expect(DownloadFile(0, fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath))).to.be.rejected;
     });
 
     teardown(async () => {


### PR DESCRIPTION
In the downloader we were piping the response to the output stream with `end: false` due to which we were not getting the writestream `finish` event which indicates when the response was completely written to the filestream. This led to the `Immediate Zip FIle Error` when using the Download and Install Pipeline as we didnt wait for the data to be completely put into the filestream and trying to unzip it created that error.

So in this PR, I have removed {end: false} condition and am resolving the promise of the dowloader when the filestream finish event is seen, so that there is no race condition.
Also instead of using open file descriptors, modified the code to use the file paths so there is no problem, even if the file doesnot have an open fd.
