### PR TITLE
Add/update 'omnisharp.useGlobalMono' option

### DIFF
--- a/package.json
+++ b/package.json
@@ -521,10 +521,20 @@
           "default": null,
           "description": "Specifies the path to OmniSharp. This can be the absolute path to an OmniSharp executable, a specific version number, or \"latest\". If a version number or \"latest\" is specified, the appropriate version of OmniSharp will be downloaded on your behalf."
         },
-        "omnisharp.useMono": {
-          "type": "boolean",
-          "default": false,
-          "description": "Launch OmniSharp with Mono."
+        "omnisharp.useGlobalMono": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "always",
+            "never"
+          ],
+          "enumDescriptions": [
+            "Automatically launch OmniSharp with \"mono\" if version 5.2.0 or greater is available on the PATH.",
+            "Always launch OmniSharp with \"mono\". If version 5.2.0 or greater is not available on the PATH, an error will be printed.",
+            "Never launch OmniSHarp on a globally-installed Mono."
+          ],
+          "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 5.2.0 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 5.2.0 or greater is available on the PATH."
         },
         "omnisharp.waitForDebugger": {
           "type": "boolean",

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -32,7 +32,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
     }
 
     private _resetCachedOptions(): void {
-        this._options = Options.Read();
+        this._options = Options.Read(vscode);
     }
 
     public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.Command[]> {

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -39,7 +39,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
     }
 
     private _resetCachedOptions(): void {
-        this._options = Options.Read();
+        this._options = Options.Read(vscode);
     }
 
     private static filteredSymbolNames: { [name: string]: boolean } = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     eventStream.subscribe(omnisharpLogObserver.post);
     eventStream.subscribe(omnisharpChannelObserver.post);
 
-    let warningMessageObserver = new WarningMessageObserver(vscode, () => Options.Read().disableMSBuildDiagnosticWarning || false);
+    let warningMessageObserver = new WarningMessageObserver(vscode, () => Options.Read(vscode).disableMSBuildDiagnosticWarning || false);
     eventStream.subscribe(warningMessageObserver.post);
 
     let informationMessageObserver = new InformationMessageObserver(vscode);

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -43,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext, eventStream: Ev
         scheme: 'file' // only files from disk
     };
 
-    const options = Options.Read();
+    const options = Options.Read(vscode);
     const server = new OmniSharpServer(vscode, provider, eventStream, packageJSON, platformInfo);
     omnisharp = server;
     const advisor = new Advisor(server); // create before server is started

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -242,16 +242,18 @@ async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platf
     let isValidMonoAvailable = await satisfies(monoVersion, '>=5.2.0');
 
     // If the user specifically said that they wanted to launch on Mono, respect their wishes.
-    if (options.useMono) {
+    if (options.useGlobalMono === "always") {
         if (!isValidMonoAvailable) {
             throw new Error('Cannot start OmniSharp because Mono version >=5.2.0 is required.');
         }
 
-        return launchNixMono(launchInfo.LaunchPath, monoVersion, cwd, args);
+        const launchPath = launchInfo.MonoLaunchPath || launchInfo.LaunchPath;
+
+        return launchNixMono(launchPath, monoVersion, cwd, args);
     }
 
     // If we can launch on the global Mono, do so; otherwise, launch directly;
-    if (isValidMonoAvailable && launchInfo.MonoLaunchPath) {
+    if (options.useGlobalMono === "auto" && isValidMonoAvailable && launchInfo.MonoLaunchPath) {
         return launchNixMono(launchInfo.MonoLaunchPath, monoVersion, cwd, args);
     }
     else {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -41,7 +41,7 @@ export function findLaunchTargets(): Thenable<LaunchTarget[]> {
         return Promise.resolve([]);
     }
 
-    const options = Options.Read();
+    const options = Options.Read(vscode);
 
     return vscode.workspace.findFiles(
             /*include*/ '{**/*.sln,**/*.csproj,**/project.json,**/*.csx,**/*.cake}',
@@ -204,9 +204,9 @@ export interface LaunchResult {
     monoVersion?: string;
 }
 
-export async function launchOmniSharp(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation): Promise<LaunchResult> {
+export async function launchOmniSharp(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation, options: Options): Promise<LaunchResult> {
     return new Promise<LaunchResult>((resolve, reject) => {
-        launch(cwd, args, launchInfo, platformInfo)
+        launch(cwd, args, launchInfo, platformInfo, options)
             .then(result => {
                 // async error - when target not not ENEOT
                 result.process.on('error', err => {
@@ -222,9 +222,7 @@ export async function launchOmniSharp(cwd: string, args: string[], launchInfo: L
     });
 }
 
-async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation): Promise<LaunchResult> {
-    const options = Options.Read();
-
+async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation, options: Options): Promise<LaunchResult> {
     if (options.useEditorFormattingSettings) {
         let globalConfig = vscode.workspace.getConfiguration();
         let csharpConfig = vscode.workspace.getConfiguration('[csharp]');

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import { vscode, WorkspaceConfiguration } from '../vscodeAdapter';
 
 export class Options {
     constructor(
@@ -21,7 +21,7 @@ export class Options {
         public disableCodeActions: boolean,
         public disableMSBuildDiagnosticWarning: boolean) { }
 
-    public static Read(): Options {
+    public static Read(vscode: vscode): Options {
         // Extra effort is taken below to ensure that legacy versions of options
         // are supported below. In particular, these are:
         //
@@ -74,7 +74,7 @@ export class Options {
             disableMSBuildDiagnosticWarning);
     }
 
-    private static readPathOption(csharpConfig: vscode.WorkspaceConfiguration, omnisharpConfig: vscode.WorkspaceConfiguration): string | null {
+    private static readPathOption(csharpConfig: WorkspaceConfiguration, omnisharpConfig: WorkspaceConfiguration): string | null {
         if (omnisharpConfig.has('path')) {
             // If 'omnisharp.path' setting was found, use it.
             return omnisharpConfig.get<string>('path');
@@ -89,7 +89,7 @@ export class Options {
         }
     }
 
-    private static readUseGlobalMonoOption(omnisharpConfig: vscode.WorkspaceConfiguration, csharpConfig: vscode.WorkspaceConfiguration): string {
+    private static readUseGlobalMonoOption(omnisharpConfig: WorkspaceConfiguration, csharpConfig: WorkspaceConfiguration): string {
         function toUseGlobalMonoValue(value: boolean): string {
             // True means 'always' and false means 'auto'.
             return value ? "always" : "auto";

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -81,7 +81,7 @@ export class Options {
         }
         else if (csharpConfig.has('omnisharp')) {
             // BACKCOMPAT: If 'csharp.omnisharp' setting was found, use it.
-            return csharpConfig.get<string>('path');
+            return csharpConfig.get<string>('omnisharp');
         }
         else {
             // Otherwise, null.

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -38,8 +38,8 @@ export class Options {
         const waitForDebugger = omnisharpConfig.get<boolean>('waitForDebugger', false);
 
         // support the legacy "verbose" level as "debug"
-        let loggingLevel = omnisharpConfig.get<string>('loggingLevel');
-        if (loggingLevel.toLowerCase() === 'verbose') {
+        let loggingLevel = omnisharpConfig.get<string>('loggingLevel', 'information');
+        if (loggingLevel && loggingLevel.toLowerCase() === 'verbose') {
             loggingLevel = 'debug';
         }
 
@@ -56,7 +56,7 @@ export class Options {
 
         const disableCodeActions = csharpConfig.get<boolean>('disableCodeActions', false);
 
-        const disableMSBuildDiagnosticWarning = omnisharpConfig.get<boolean>('disableMSBuildDiagnosticWarning');
+        const disableMSBuildDiagnosticWarning = omnisharpConfig.get<boolean>('disableMSBuildDiagnosticWarning', false);
 
         return new Options(
             path, 
@@ -97,7 +97,7 @@ export class Options {
 
         if (omnisharpConfig.has('useGlobalMono')) {
             // If 'omnisharp.useGlobalMono' setting was found, just use it.
-            return omnisharpConfig.get<string>('useGlobalMono');
+            return omnisharpConfig.get<string>('useGlobalMono', "auto");
         }
         else if (omnisharpConfig.has('useMono')) {
             // BACKCOMPAT: If 'omnisharp.useMono' setting was found, true maps to "always" and false maps to "auto"

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -85,7 +85,6 @@ export class OmniSharpServer {
     private _launchTarget: LaunchTarget;
     private _requestQueue: RequestQueueCollection;
     private _serverProcess: ChildProcess;
-    private _options: Options;
 
     private _omnisharpManager: OmnisharpManager;
     private updateProjectDebouncer = new Subject<ObservableEvents.ProjectModified>();
@@ -237,7 +236,7 @@ export class OmniSharpServer {
 
     // --- start, stop, and connect
 
-    private async _start(launchTarget: LaunchTarget): Promise<void> {
+    private async _start(launchTarget: LaunchTarget, options: Options): Promise<void> {
 
         let disposables = new CompositeDisposable();
 
@@ -292,7 +291,6 @@ export class OmniSharpServer {
 
         const solutionPath = launchTarget.target;
         const cwd = path.dirname(solutionPath);
-        this._options = Options.Read();
 
         let args = [
             '-s', solutionPath,
@@ -300,17 +298,17 @@ export class OmniSharpServer {
             '--stdio',
             'DotNet:enablePackageRestore=false',
             '--encoding', 'utf-8',
-            '--loglevel', this._options.loggingLevel
+            '--loglevel', options.loggingLevel
         ];
 
-        if (this._options.waitForDebugger === true) {
+        if (options.waitForDebugger === true) {
             args.push('--debug');
         }
 
         let launchInfo: LaunchInfo;
         try {
             let extensionPath = utils.getExtensionPath();
-            launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this.packageJSON.defaults.omniSharp, this._options.path, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
+            launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this.packageJSON.defaults.omniSharp, options.path, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
         }
         catch (error) {
             this.eventStream.post(new ObservableEvents.OmnisharpFailure(`Error occured in loading omnisharp from omnisharp.path\nCould not start the server due to ${error.toString()}`, error));
@@ -321,7 +319,7 @@ export class OmniSharpServer {
         this._fireEvent(Events.BeforeServerStart, solutionPath);
 
         try {
-            let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo);
+            let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo, options);
             this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid));
 
             this._serverProcess = launchResult.process;
@@ -329,7 +327,7 @@ export class OmniSharpServer {
             this._setState(ServerState.Started);
             this._fireEvent(Events.ServerStart, solutionPath);
 
-            await this._doConnect();
+            await this._doConnect(options);
 
             this._telemetryIntervalId = setInterval(() => this._reportTelemetry(), TelemetryReportingDelay);
             this._requestQueue.drain();
@@ -417,7 +415,10 @@ export class OmniSharpServer {
     public async restart(launchTarget: LaunchTarget = this._launchTarget): Promise<void> {
         if (launchTarget) {
             await this.stop();
-            await this._start(launchTarget);
+
+            const options = Options.Read(this.vscode);
+
+            await this._start(launchTarget, options);
         }
     }
 
@@ -503,7 +504,7 @@ export class OmniSharpServer {
         });
     }
 
-    private async _doConnect(): Promise<void> {
+    private async _doConnect(options: Options): Promise<void> {
 
         this._serverProcess.stderr.on('data', (data: any) => {
             this._fireEvent('stderr', String(data));
@@ -519,7 +520,7 @@ export class OmniSharpServer {
             let listener: Disposable;
 
             // Convert the timeout from the seconds to milliseconds, which is required by setTimeout().
-            const timeoutDuration = this._options.projectLoadTimeout * 1000;
+            const timeoutDuration = options.projectLoadTimeout * 1000;
 
             // timeout logic
             const handle = setTimeout(() => {

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { should, expect } from 'chai';
+import { Options } from '../../src/omnisharp/options';
+import { getFakeVsCode, getWorkspaceConfiguration } from './testAssets/Fakes';
+
+function getVSCode() {
+    const vscode = getFakeVsCode();
+
+    const omnisharpConfig = getWorkspaceConfiguration();
+    const csharpConfig = getWorkspaceConfiguration();
+
+    vscode.workspace.getConfiguration = (section?, resource?) =>
+    {
+        if (section === 'omnisharp')
+        {
+            return omnisharpConfig;
+        }
+
+        if (section === 'csharp')
+        {
+            return csharpConfig;
+        }
+
+        return undefined;
+    };
+
+    return vscode;
+}
+
+suite("Options tests", () => {
+    suiteSetup(() => should());
+
+    test('Construct options and verify defaults', () =>
+    {
+        const vscode = getVSCode();
+        const options = Options.Read(vscode);
+
+        expect(options.path).to.be.null;
+        options.useGlobalMono.should.equal("auto");
+        options.waitForDebugger.should.equal(false);
+        options.loggingLevel.should.equal("information");
+        options.autoStart.should.equal(true);
+        options.projectLoadTimeout.should.equal(60);
+        options.maxProjectResults.should.equal(250);
+        options.useEditorFormattingSettings.should.equal(true);
+        options.useFormatting.should.equal(true);
+        options.showReferencesCodeLens.should.equal(true);
+        options.showTestsCodeLens.should.equal(true);
+        options.disableCodeActions.should.equal(false);
+        options.disableCodeActions.should.equal(false);
+    });
+});

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -6,23 +6,24 @@
 import { should, expect } from 'chai';
 import { Options } from '../../src/omnisharp/options';
 import { getFakeVsCode, getWorkspaceConfiguration } from './testAssets/Fakes';
+import { WorkspaceConfiguration } from '../../src/vscodeAdapter';
 
-function getVSCode() {
+function getVSCode(omnisharpConfig?: WorkspaceConfiguration, csharpConfig?: WorkspaceConfiguration) {
     const vscode = getFakeVsCode();
 
-    const omnisharpConfig = getWorkspaceConfiguration();
-    const csharpConfig = getWorkspaceConfiguration();
+    const _omnisharpConfig = omnisharpConfig || getWorkspaceConfiguration();
+    const _csharpConfig = csharpConfig || getWorkspaceConfiguration();
 
     vscode.workspace.getConfiguration = (section?, resource?) =>
     {
         if (section === 'omnisharp')
         {
-            return omnisharpConfig;
+            return _omnisharpConfig;
         }
 
         if (section === 'csharp')
         {
-            return csharpConfig;
+            return _csharpConfig;
         }
 
         return undefined;
@@ -34,7 +35,7 @@ function getVSCode() {
 suite("Options tests", () => {
     suiteSetup(() => should());
 
-    test('Construct options and verify defaults', () =>
+    test('Verify defaults', () =>
     {
         const vscode = getVSCode();
         const options = Options.Read(vscode);
@@ -52,5 +53,84 @@ suite("Options tests", () => {
         options.showTestsCodeLens.should.equal(true);
         options.disableCodeActions.should.equal(false);
         options.disableCodeActions.should.equal(false);
+    });
+
+    test('BACK-COMPAT: "omnisharp.loggingLevel": "verbose" == "omnisharp.loggingLevel": "debug"', () =>
+    {
+        const omnisharpConfig = getWorkspaceConfiguration();
+        omnisharpConfig.update('loggingLevel', "verbose");
+        const vscode = getVSCode(omnisharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.loggingLevel.should.equal("debug");
+    });
+
+    test('BACK-COMPAT: "omnisharp.useMono": true == "omnisharp.useGlobalMono": "always"', () =>
+    {
+        const omnisharpConfig = getWorkspaceConfiguration();
+        omnisharpConfig.update('useMono', true);
+        const vscode = getVSCode(omnisharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.useGlobalMono.should.equal("always");
+    });
+
+    test('BACK-COMPAT: "omnisharp.useMono": false == "omnisharp.useGlobalMono": "auto"', () =>
+    {
+        const omnisharpConfig = getWorkspaceConfiguration();
+        omnisharpConfig.update('useMono', false);
+        const vscode = getVSCode(omnisharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.useGlobalMono.should.equal("auto");
+    });
+
+    test('BACK-COMPAT: "csharp.omnisharpUsesMono": true == "omnisharp.useGlobalMono": "always"', () =>
+    {
+        const csharpConfig = getWorkspaceConfiguration();
+        csharpConfig.update('omnisharpUsesMono', true);
+        const vscode = getVSCode(undefined, csharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.useGlobalMono.should.equal("always");
+    });
+
+    test('BACK-COMPAT: "csharp.omnisharpUsesMono": false == "omnisharp.useGlobalMono": "auto"', () =>
+    {
+        const csharpConfig = getWorkspaceConfiguration();
+        csharpConfig.update('omnisharpUsesMono', false);
+        const vscode = getVSCode(undefined, csharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.useGlobalMono.should.equal("auto");
+    });
+
+    test('BACK-COMPAT: "csharp.omnisharp" is used if it is set and "omnisharp.path" is not', () =>
+    {
+        const csharpConfig = getWorkspaceConfiguration();
+        csharpConfig.update('omnisharp', 'OldPath');
+        const vscode = getVSCode(undefined, csharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.path.should.equal("OldPath");
+    });
+
+    test('BACK-COMPAT: "csharp.omnisharp" is not used if "omnisharp.path" is set', () =>
+    {
+        const omnisharpConfig = getWorkspaceConfiguration();
+        omnisharpConfig.update('path', 'NewPath');
+        const csharpConfig = getWorkspaceConfiguration();
+        csharpConfig.update('omnisharp', 'OldPath');
+        const vscode = getVSCode(omnisharpConfig, csharpConfig);
+
+        const options = Options.Read(vscode);
+
+        options.path.should.equal("NewPath");
     });
 });

--- a/test/unitTests/testAssets/Fakes.ts
+++ b/test/unitTests/testAssets/Fakes.ts
@@ -32,8 +32,8 @@ export const getNullTelemetryReporter = (): ITelemetryReporter => {
 };
 
 export const getNullWorkspaceConfiguration = (): vscode.WorkspaceConfiguration => {
-    let workspace: vscode.WorkspaceConfiguration = {
-        get: <T>(section: string): T| undefined => {
+    let configuration: vscode.WorkspaceConfiguration = {
+        get: <T>(section: string): T | undefined => {
             return undefined;
         },
         has: (section: string) => { return undefined; },
@@ -42,9 +42,33 @@ export const getNullWorkspaceConfiguration = (): vscode.WorkspaceConfiguration =
                 key: undefined
             };
         },
-        update: async () => { return Promise.resolve(); },
+        update: async () => { return Promise.resolve(); }
     };
-    return workspace;
+
+    return configuration;
+};
+
+export const getWorkspaceConfiguration = (): vscode.WorkspaceConfiguration => {
+    let values: { [key: string]: any } = {};
+    
+    let configuration: vscode.WorkspaceConfiguration = {
+        get<T>(section: string, defaultValue?: T): T | undefined {
+            let result = <T>values[section];
+            return result === undefined && defaultValue !== undefined
+                ? defaultValue
+                : result;
+        },
+        has: (section: string) => {
+            return values[section] !== undefined;
+        },
+        inspect: () => { throw new Error("Not Implemented"); },
+        update: async (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean) => {
+            values[section] = value;
+            return Promise.resolve();
+        }
+    };
+
+    return configuration;
 };
 
 export function getOmnisharpMSBuildProjectDiagnosticsEvent(fileName: string, warnings: MSBuildDiagnosticsMessage[], errors: MSBuildDiagnosticsMessage[]): OmnisharpServerMsBuildProjectDiagnostics {


### PR DESCRIPTION
This change updates the name of the 'omnisharp.useMono' option to 'omnisharp.useGlobalMono', and makes it a tri-state value rather than a boolean. It now has three possible values:

* "auto": Launch OmniSharp on the globally-installed Mono if it's available.
* "always": Always try to launch OmniSharp on the globally-installed Mono and error if it's not available.
* "never": Never launch OmniSharp on the globall-installed Mono.