### PR TITLE
Check for run script instead of mono run time

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
         "./mono.osx",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/mono.osx",
+      "installTestPath": "./.omnisharp/run",
       "platformId": "osx"
     },
     {
@@ -201,7 +201,7 @@
         "./mono.linux-x86",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/mono.linux-x86",
+      "installTestPath": "./.omnisharp/run",
       "platformId": "linux-x86"
     },
     {
@@ -219,7 +219,7 @@
         "./mono.linux-x86_64",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/mono.linux-x86_64",
+      "installTestPath": "./.omnisharp/run",
       "platformId": "linux-x64"
     },
     {


### PR DESCRIPTION
Since the path to the mono runtime binary has changed, we must check for the presence of the run script to determine whether the package exists or not.