### PR TITLE
Increase minimum required mono to 5.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
   * As an alternative, consider installing the [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools) extension by @tintoy.
 
+## 1.15.1 (May 11, 1018)
+
+* The minimum Mono version required to run OmniSharp on has been increased to 5.8.1.
+
 ## 1.15.0 (May 10, 2018)
 
 #### Debugger

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/package.json
+++ b/package.json
@@ -530,11 +530,11 @@
             "never"
           ],
           "enumDescriptions": [
-            "Automatically launch OmniSharp with \"mono\" if version 5.2.0 or greater is available on the PATH.",
-            "Always launch OmniSharp with \"mono\". If version 5.2.0 or greater is not available on the PATH, an error will be printed.",
+            "Automatically launch OmniSharp with \"mono\" if version 5.8.1 or greater is available on the PATH.",
+            "Always launch OmniSharp with \"mono\". If version 5.8.1 or greater is not available on the PATH, an error will be printed.",
             "Never launch OmniSharp on a globally-installed Mono."
           ],
-          "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 5.2.0 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 5.2.0 or greater is available on the PATH."
+          "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 5.8.1 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 5.8.1 or greater is available on the PATH."
         },
         "omnisharp.waitForDebugger": {
           "type": "boolean",

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -237,12 +237,12 @@ async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platf
     }
 
     let monoVersion = await getMonoVersion();
-    let isValidMonoAvailable = await satisfies(monoVersion, '>=5.2.0');
+    let isValidMonoAvailable = await satisfies(monoVersion, '>=5.8.1');
 
     // If the user specifically said that they wanted to launch on Mono, respect their wishes.
     if (options.useGlobalMono === "always") {
         if (!isValidMonoAvailable) {
-            throw new Error('Cannot start OmniSharp because Mono version >=5.2.0 is required.');
+            throw new Error('Cannot start OmniSharp because Mono version >=5.8.1 is required.');
         }
 
         const launchPath = launchInfo.MonoLaunchPath || launchInfo.LaunchPath;


### PR DESCRIPTION
Fixes #2281

The latest version of Roslyn used in OmniSharp crashes on Mono runtimes earlier that 5.8.1. So, we need to increase the minimum required version.