### PR TITLE
Display prompt [Information Message]  to restart the server when the omnisharp configuration changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import OptionStream from './observables/OptionStream';
 import  OptionProvider from './observers/OptionProvider';
 import DotNetTestChannelObserver from './observers/DotnetTestChannelObserver';
 import DotNetTestLoggerObserver from './observers/DotnetTestLoggerObserver';
+import { ShowOmniSharpConfigHasChanged } from './observers/OptionChangeObserver';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -120,6 +121,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     }));
 
     context.subscriptions.push(optionStream);
+    context.subscriptions.push(ShowOmniSharpConfigHasChanged(optionStream, vscode));
 
     let coreClrDebugPromise = Promise.resolve();
     if (runtimeDependenciesExist) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,11 +30,11 @@ import { ProjectStatusBarObserver } from './observers/ProjectStatusBarObserver';
 import CSharpExtensionExports from './CSharpExtensionExports';
 import { vscodeNetworkSettingsProvider, NetworkSettingsProvider } from './NetworkSettings';
 import { ErrorMessageObserver } from './observers/ErrorMessageObserver';
-import OptionStream from './observables/OptionStream';
+import { createOptionStream } from './observables/OptionStream';
 import  OptionProvider from './observers/OptionProvider';
 import DotNetTestChannelObserver from './observers/DotnetTestChannelObserver';
 import DotNetTestLoggerObserver from './observers/DotnetTestLoggerObserver';
-import { ShowOmniSharpConfigHasChanged } from './observers/OptionChangeObserver';
+import { ShowOmniSharpConfigChangePrompt } from './observers/OptionChangeObserver';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     util.setExtensionPath(extension.extensionPath);
 
     const eventStream = new EventStream();
-    const optionStream = new OptionStream(vscode);
+    const optionStream = createOptionStream(vscode);
     let optionProvider = new OptionProvider(optionStream);
 
     let dotnetChannel = vscode.window.createOutputChannel('.NET');
@@ -120,8 +120,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
         eventStream.post(new ActiveTextEditorChanged());
     }));
 
-    context.subscriptions.push(optionStream);
-    context.subscriptions.push(ShowOmniSharpConfigHasChanged(optionStream, vscode));
+    context.subscriptions.push(optionProvider);
+    context.subscriptions.push(ShowOmniSharpConfigChangePrompt(optionStream, vscode));
 
     let coreClrDebugPromise = Promise.resolve();
     if (runtimeDependenciesExist) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,11 +30,11 @@ import { ProjectStatusBarObserver } from './observers/ProjectStatusBarObserver';
 import CSharpExtensionExports from './CSharpExtensionExports';
 import { vscodeNetworkSettingsProvider, NetworkSettingsProvider } from './NetworkSettings';
 import { ErrorMessageObserver } from './observers/ErrorMessageObserver';
-import { createOptionStream } from './observables/OptionStream';
 import  OptionProvider from './observers/OptionProvider';
 import DotNetTestChannelObserver from './observers/DotnetTestChannelObserver';
 import DotNetTestLoggerObserver from './observers/DotnetTestLoggerObserver';
 import { ShowOmniSharpConfigChangePrompt } from './observers/OptionChangeObserver';
+import createOptionStream from './observables/CreateOptionStream';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 

--- a/src/observables/CreateOptionStream.ts
+++ b/src/observables/CreateOptionStream.ts
@@ -10,7 +10,7 @@ import 'rxjs/add/operator/publishBehavior';
 import { Observable } from "rxjs/Observable";
 import { Observer } from "rxjs/Observer";
 
-export function createOptionStream(vscode: vscode): Observable<Options> {
+export default function createOptionStream(vscode: vscode): Observable<Options> {
     return Observable.create((observer: Observer<Options>) => {
         let disposable = vscode.workspace.onDidChangeConfiguration(e => {
             //if the omnisharp or csharp configuration are affected only then read the options

--- a/src/observers/OptionChangeObserver.ts
+++ b/src/observers/OptionChangeObserver.ts
@@ -1,0 +1,32 @@
+/*--------------------------------------------------------------------------------------------- 
+ *  Copyright (c) Microsoft Corporation. All rights reserved. 
+ *  Licensed under the MIT License. See License.txt in the project root for license information. 
+ *--------------------------------------------------------------------------------------------*/
+
+import OptionStream from "../observables/OptionStream";
+import { vscode } from "../vscodeAdapter";
+import { Options } from "../omnisharp/options";
+import ShowInformationMessage from "./utils/ShowInformationMessage";
+
+export function ShowOmniSharpConfigHasChanged(optionStream: OptionStream, vscode: vscode) {
+    let options: Options;
+    return optionStream.subscribe(newOptions => {
+        if (options && hasChanged(options, newOptions)) {
+            let message = "OmniSharp configuration has changed. Would you like to relaunch the OmniSharp server with your changes?";
+            ShowInformationMessage(vscode, message, { title: "Restart Now", command: 'o.restart' });
+        }
+
+        options = newOptions;
+    });
+}
+
+function hasChanged(oldOptions: Options, newOptions: Options): boolean {
+    if (oldOptions.path != newOptions.path ||
+        oldOptions.useGlobalMono != newOptions.useGlobalMono ||
+        oldOptions.waitForDebugger != newOptions.waitForDebugger) {
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/observers/OptionChangeObserver.ts
+++ b/src/observers/OptionChangeObserver.ts
@@ -24,19 +24,14 @@ export function ShowOmniSharpConfigChangePrompt(optionObservable: Observable<Opt
     let subscription = ConfigChangeObservable(optionObservable)
         .subscribe(_ => {
             let message = "OmniSharp configuration has changed. Would you like to relaunch the OmniSharp server with your changes?";
-            ShowInformationMessage(vscode, message, { title: "Restart Now", command: 'o.restart' });
+            ShowInformationMessage(vscode, message, { title: "Restart OmniSharp", command: 'o.restart' });
         });
 
     return new Disposable(subscription);
 }
 
 function hasChanged(oldOptions: Options, newOptions: Options): boolean {
-    if (oldOptions.path != newOptions.path ||
+    return (oldOptions.path != newOptions.path ||
         oldOptions.useGlobalMono != newOptions.useGlobalMono ||
-        oldOptions.waitForDebugger != newOptions.waitForDebugger) {
-
-        return true;
-    }
-
-    return false;
+        oldOptions.waitForDebugger != newOptions.waitForDebugger);
 }

--- a/src/observers/OptionChangeObserver.ts
+++ b/src/observers/OptionChangeObserver.ts
@@ -20,7 +20,7 @@ function ConfigChangeObservable(optionObservable: Observable<Options>): Observab
     });
 }
 
-export function ShowOmniSharpConfigChangePrompt(optionObservable: Observable<Options>, vscode: vscode) {
+export function ShowOmniSharpConfigChangePrompt(optionObservable: Observable<Options>, vscode: vscode): Disposable {
     let subscription = ConfigChangeObservable(optionObservable)
         .subscribe(_ => {
             let message = "OmniSharp configuration has changed. Would you like to relaunch the OmniSharp server with your changes?";

--- a/src/observers/OptionProvider.ts
+++ b/src/observers/OptionProvider.ts
@@ -4,19 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Options } from "../omnisharp/options";
-import OptionStream from "../observables/OptionStream";
+import { Subscription } from "rxjs/Subscription";
+import { Observable } from "rxjs/Observable";
 
 export default class OptionProvider {
     private options: Options;
+    private subscription: Subscription;
 
-    constructor(optionStream: OptionStream) {
-        optionStream.subscribe(options => this.options = options);
+    constructor(optionObservable: Observable<Options>) {
+        this.subscription = optionObservable.subscribe(options => this.options = options);
     }
 
     public GetLatestOptions(): Options {
         if (!this.options) {
             throw new Error("Error reading OmniSharp options");
         }
+
         return this.options;
+    }
+
+    public dispose = () => {
+        this.subscription.unsubscribe();
     }
 }

--- a/test/unitTests/OptionObserver/OptionChangeObserver.test.ts
+++ b/test/unitTests/OptionObserver/OptionChangeObserver.test.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { use as chaiUse, expect, should } from 'chai';
+import { updateConfig, getVSCodeWithConfig } from '../testAssets/Fakes';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromPromise';
+import 'rxjs/add/operator/timeout';
+import { vscode, ConfigurationChangeEvent } from '../../../src/vscodeAdapter';
+import OptionStream from '../../../src/observables/OptionStream';
+import Disposable from '../../../src/Disposable';
+import { ShowOmniSharpConfigHasChanged } from '../../../src/observers/OptionChangeObserver';
+import { GetConfigChangeEvent } from '../testAssets/GetConfigChangeEvent';
+
+chaiUse(require('chai-as-promised'));
+chaiUse(require('chai-string'));
+
+suite("OmniSharpConfigChangeObserver", () => {
+    suiteSetup(() => should());
+
+    let doClickOk: () => void;
+    let doClickCancel: () => void;
+    let signalCommandDone: () => void;
+    let commandDone: Promise<void>;
+    let vscode: vscode;
+    let infoMessage: string;
+    let invokedCommand: string;
+    let listenerFunction: Array<(e: ConfigurationChangeEvent) => any>;
+
+    setup(() => {
+        listenerFunction = new Array<(e: ConfigurationChangeEvent) => any>();
+        vscode = getVSCodeWithConfig();
+        vscode.window.showInformationMessage = async <T>(message: string, ...items: T[]) => {
+            infoMessage = message;
+            return new Promise<T>(resolve => {
+                doClickCancel = () => {
+                    resolve(undefined);
+                };
+
+                doClickOk = () => {
+                    resolve(...items);
+                };
+            });
+        };
+
+        vscode.commands.executeCommand = (command: string, ...rest: any[]) => {
+            invokedCommand = command;
+            signalCommandDone();
+            return undefined;
+        };
+
+        vscode.workspace.onDidChangeConfiguration = (listener: (e: ConfigurationChangeEvent) => any, thisArgs?: any, disposables?: Disposable[]) => {
+            listenerFunction.push(listener);
+            return new Disposable(() => { });
+        };
+
+        let optionStream = new OptionStream(vscode);
+        ShowOmniSharpConfigHasChanged(optionStream, vscode);
+        commandDone = new Promise<void>(resolve => {
+            signalCommandDone = () => { resolve(); };
+        });
+    });
+
+    suite('When there is a change in OmniSharp Config', () => {
+        test('The information message is shown when the config changes', async () => {
+            let changingConfig = "omnisharp";
+            updateConfig(vscode, changingConfig, 'path', "somePath");
+            listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+            expect(infoMessage).to.be.equal("OmniSharp configuration has changed. Would you like to relaunch the OmniSharp server with your changes?");
+        });
+
+        test('Given an information message if the user clicks cancel, the command is not executed', async () => {
+            let changingConfig = "omnisharp";
+            updateConfig(vscode, changingConfig, 'path', "somePath");
+            listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+            doClickCancel();
+            await expect(Observable.fromPromise(commandDone).timeout(1).toPromise()).to.be.rejected;
+            expect(invokedCommand).to.be.undefined;
+        });
+
+        test('Given an information message if the user clicks Restore, the command is executed', async () => {
+            let changingConfig = "omnisharp";
+            updateConfig(vscode, changingConfig, 'path', "somePath");
+            listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+            doClickOk();
+            await commandDone;
+            expect(invokedCommand).to.be.equal("o.restart");
+        });
+    });
+
+    teardown(() => {
+        infoMessage = undefined;
+        invokedCommand = undefined;
+        doClickCancel = undefined;
+        doClickOk = undefined;
+        signalCommandDone = undefined;
+        commandDone = undefined;
+    });
+});

--- a/test/unitTests/OptionObserver/OptionChangeObserver.test.ts
+++ b/test/unitTests/OptionObserver/OptionChangeObserver.test.ts
@@ -37,7 +37,7 @@ suite("OmniSharpConfigChangeObserver", () => {
             signalCommandDone = () => { resolve(); };
         });
     });
-
+    
     [
         { config: "omnisharp", section: "path", value: "somePath" },
         { config: "omnisharp", section: "waitForDebugger", value: true },
@@ -68,25 +68,27 @@ suite("OmniSharpConfigChangeObserver", () => {
                 expect(invokedCommand).to.be.equal("o.restart");
             });
         });
-    });
-
-    [
-        { config: "csharp", section: 'disableCodeActions', value: true },
-        { config: "csharp", section: 'testsCodeLens.enabled', value: false },
-        { config: "omnisharp", section: 'referencesCodeLens.enabled', value: false },
-        { config: "csharp", section: 'format.enable', value: false },
-        { config: "omnisharp", section: 'useEditorFormattingSettings', value: false },
-        { config: "omnisharp", section: 'maxProjectResults', value: 1000 },
-        { config: "omnisharp", section: 'projectLoadTimeout', value: 1000 },
-        { config: "omnisharp", section: 'autoStart', value: false },
-        { config: "omnisharp", section: 'loggingLevel', value: 'verbose' }
-    ].forEach(elem => {
-        test(`The information message is not shown when ${elem.config} ${elem.section} changes`, async () => {
-            expect(infoMessage).to.be.undefined;
-            expect(invokedCommand).to.be.undefined;
-            updateConfig(vscode, elem.config, elem.section, elem.value);
-            optionObservable.next(Options.Read(vscode));
-            expect(infoMessage).to.be.undefined;
+        });
+    
+    suite('Information Message is not shown on change in',() => {
+        [
+            { config: "csharp", section: 'disableCodeActions', value: true },
+            { config: "csharp", section: 'testsCodeLens.enabled', value: false },
+            { config: "omnisharp", section: 'referencesCodeLens.enabled', value: false },
+            { config: "csharp", section: 'format.enable', value: false },
+            { config: "omnisharp", section: 'useEditorFormattingSettings', value: false },
+            { config: "omnisharp", section: 'maxProjectResults', value: 1000 },
+            { config: "omnisharp", section: 'projectLoadTimeout', value: 1000 },
+            { config: "omnisharp", section: 'autoStart', value: false },
+            { config: "omnisharp", section: 'loggingLevel', value: 'verbose' }
+        ].forEach(elem => {
+            test(`${elem.config} ${elem.section}`, async () => {
+                expect(infoMessage).to.be.undefined;
+                expect(invokedCommand).to.be.undefined;
+                updateConfig(vscode, elem.config, elem.section, elem.value);
+                optionObservable.next(Options.Read(vscode));
+                expect(infoMessage).to.be.undefined;
+            });
         });
     });
 

--- a/test/unitTests/OptionObserver/OptionProvider.test.ts
+++ b/test/unitTests/OptionObserver/OptionProvider.test.ts
@@ -9,6 +9,7 @@ import OptionStream from "../../../src/observables/OptionStream";
 import { vscode, ConfigurationChangeEvent } from "../../../src/vscodeAdapter";
 import Disposable from "../../../src/Disposable";
 import OptionProvider from '../../../src/observers/OptionProvider';
+import { GetConfigChangeEvent } from '../testAssets/GetConfigChangeEvent';
 
 suite('OptionProvider', () => {
     suiteSetup(() => should());
@@ -44,7 +45,7 @@ suite('OptionProvider', () => {
     test("Gives the latest options if there are changes in omnisharp config", () => {
         let changingConfig = "omnisharp";
         updateConfig(vscode, changingConfig, 'path', "somePath");
-        listenerFunction.forEach(listener => listener(getConfigChangeEvent(changingConfig)));
+        listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
         let options = optionProvider.GetLatestOptions();
         expect(options.path).to.be.equal("somePath");
     });
@@ -52,7 +53,7 @@ suite('OptionProvider', () => {
     test("Gives the latest options if there are changes in csharp config", () => {
         let changingConfig = 'csharp';
         updateConfig(vscode, changingConfig, 'disableCodeActions', true);
-        listenerFunction.forEach(listener => listener(getConfigChangeEvent(changingConfig)));
+        listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
         let options = optionProvider.GetLatestOptions();
         expect(options.disableCodeActions).to.be.equal(true);
     });
@@ -66,10 +67,4 @@ function getVSCode(listenerFunction: Array<(e: ConfigurationChangeEvent) => any>
     };
 
     return vscode;
-}
-
-function getConfigChangeEvent(changingConfig: string): ConfigurationChangeEvent {
-    return {
-        affectsConfiguration: (section: string) => section == changingConfig
-    };
 }

--- a/test/unitTests/OptionObserver/OptionProvider.test.ts
+++ b/test/unitTests/OptionObserver/OptionProvider.test.ts
@@ -5,66 +5,35 @@
 
 import { should, expect } from 'chai';
 import { getVSCodeWithConfig, updateConfig } from "../testAssets/Fakes";
-import OptionStream from "../../../src/observables/OptionStream";
-import { vscode, ConfigurationChangeEvent } from "../../../src/vscodeAdapter";
-import Disposable from "../../../src/Disposable";
+import { vscode } from "../../../src/vscodeAdapter";
 import OptionProvider from '../../../src/observers/OptionProvider';
-import { GetConfigChangeEvent } from '../testAssets/GetConfigChangeEvent';
+import { Subject } from 'rxjs/Subject';
+import { Options } from '../../../src/omnisharp/options';
 
 suite('OptionProvider', () => {
     suiteSetup(() => should());
 
     let vscode: vscode;
-    let listenerFunction: Array<(e: ConfigurationChangeEvent) => any>;
     let optionProvider: OptionProvider;
+    let optionObservable: Subject<Options>;
     
     setup(() => {
-        listenerFunction = new Array<(e: ConfigurationChangeEvent) => any>();
-        vscode = getVSCode(listenerFunction);
-        let optionStream = new OptionStream(vscode);
-        optionProvider = new OptionProvider(optionStream);
+        vscode = getVSCodeWithConfig();
+        optionObservable = new Subject<Options>();
+        optionProvider = new OptionProvider(optionObservable);
     });
 
-    test("Gives the default options if there is no change", () => {
-        let options = optionProvider.GetLatestOptions();
-        expect(options.path).to.be.null;
-        options.useGlobalMono.should.equal("auto");
-        options.waitForDebugger.should.equal(false);
-        options.loggingLevel.should.equal("information");
-        options.autoStart.should.equal(true);
-        options.projectLoadTimeout.should.equal(60);
-        options.maxProjectResults.should.equal(250);
-        options.useEditorFormattingSettings.should.equal(true);
-        options.useFormatting.should.equal(true);
-        options.showReferencesCodeLens.should.equal(true);
-        options.showTestsCodeLens.should.equal(true);
-        options.disableCodeActions.should.equal(false);
-        options.disableCodeActions.should.equal(false);
+    test("Throws exception when no options are pushed", () => {
+        expect(optionProvider.GetLatestOptions).to.throw();
     });
 
-    test("Gives the latest options if there are changes in omnisharp config", () => {
+    test("Gives the latest options when options are changed", () => {
         let changingConfig = "omnisharp";
         updateConfig(vscode, changingConfig, 'path', "somePath");
-        listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+        optionObservable.next(Options.Read(vscode));
+        updateConfig(vscode, changingConfig, 'path', "anotherPath");
+        optionObservable.next(Options.Read(vscode));
         let options = optionProvider.GetLatestOptions();
-        expect(options.path).to.be.equal("somePath");
-    });
-
-    test("Gives the latest options if there are changes in csharp config", () => {
-        let changingConfig = 'csharp';
-        updateConfig(vscode, changingConfig, 'disableCodeActions', true);
-        listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
-        let options = optionProvider.GetLatestOptions();
-        expect(options.disableCodeActions).to.be.equal(true);
+        expect(options.path).to.be.equal("anotherPath");
     });
 });
-
-function getVSCode(listenerFunction: Array<(e: ConfigurationChangeEvent) => any>): vscode {
-    let vscode = getVSCodeWithConfig();
-    vscode.workspace.onDidChangeConfiguration = (listener: (e: ConfigurationChangeEvent) => any, thisArgs?: any, disposables?: Disposable[]) => {
-        listenerFunction.push(listener);
-        return new Disposable(() => { });
-    };
-
-    return vscode;
-}

--- a/test/unitTests/logging/InformationMessageObserver.test.ts
+++ b/test/unitTests/logging/InformationMessageObserver.test.ts
@@ -19,9 +19,7 @@ suite("InformationMessageObserver", () => {
     let doClickOk: () => void;
     let doClickCancel: () => void;
     let signalCommandDone: () => void;
-    let commandDone = new Promise<void>(resolve => {
-        signalCommandDone = () => { resolve(); };
-    });
+    let commandDone: Promise<void>;
     let vscode = getVsCode();
     let infoMessage: string;
     let relativePath: string;
@@ -29,9 +27,6 @@ suite("InformationMessageObserver", () => {
     let observer: InformationMessageObserver = new InformationMessageObserver(vscode);
 
     setup(() => {
-        infoMessage = undefined;
-        relativePath = undefined;
-        invokedCommand = undefined;
         commandDone = new Promise<void>(resolve => {
             signalCommandDone = () => { resolve(); };
         });
@@ -80,6 +75,15 @@ suite("InformationMessageObserver", () => {
                 });
             });
         });
+        });
+    
+    teardown(() => {
+        commandDone = undefined; 
+        infoMessage = undefined;
+        relativePath = undefined;
+        invokedCommand = undefined;
+        doClickCancel = undefined;
+        doClickOk = undefined;
     });
 
     function getVsCode() {

--- a/test/unitTests/optionStream.test.ts
+++ b/test/unitTests/optionStream.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { should, expect } from 'chai';
+import { ConfigurationChangeEvent, vscode } from "../../src/vscodeAdapter";
+import { getVSCodeWithConfig, updateConfig } from "./testAssets/Fakes";
+import Disposable from "../../src/Disposable";
+import { Observable } from "rxjs/Observable";
+import { Options } from "../../src/omnisharp/options";
+import { GetConfigChangeEvent } from './testAssets/GetConfigChangeEvent';
+import { Subscription } from 'rxjs/Subscription';
+import createOptionStream from '../../src/observables/CreateOptionStream';
+
+suite('OptionStream', () => {
+    suiteSetup(() => should());
+
+    let listenerFunction: Array<(e: ConfigurationChangeEvent) => any>;
+    let vscode: vscode;
+    let optionStream: Observable<Options>;
+    let disposeCalled: boolean;
+
+    setup(() => {
+        listenerFunction = new Array<(e: ConfigurationChangeEvent) => any>();
+        vscode = getVSCode(listenerFunction);
+        optionStream = createOptionStream(vscode);
+        disposeCalled = false;
+    });
+
+    suite('Returns the recent options to the subscriber', () => {
+        let subscription: Subscription;
+        let options: Options;
+
+        setup(() => {
+            subscription = optionStream.subscribe(newOptions => options = newOptions);
+        });
+
+        test('Returns the default options if there is no change', () => {
+            expect(options.path).to.be.null;
+            options.useGlobalMono.should.equal("auto");
+            options.waitForDebugger.should.equal(false);
+            options.loggingLevel.should.equal("information");
+            options.autoStart.should.equal(true);
+            options.projectLoadTimeout.should.equal(60);
+            options.maxProjectResults.should.equal(250);
+            options.useEditorFormattingSettings.should.equal(true);
+            options.useFormatting.should.equal(true);
+            options.showReferencesCodeLens.should.equal(true);
+            options.showTestsCodeLens.should.equal(true);
+            options.disableCodeActions.should.equal(false);
+        });
+
+        test('Gives the changed option when the omnisharp config changes', () => {
+            expect(options.path).to.be.null;
+            let changingConfig = "omnisharp";
+            updateConfig(vscode, changingConfig, 'path', "somePath");
+            listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+            options.path.should.equal("somePath");
+        });
+
+        test('Gives the changed option when the csharp config changes', () => {
+            options.disableCodeActions.should.equal(false);
+            let changingConfig = "csharp";
+            updateConfig(vscode, changingConfig, 'disableCodeActions', true);
+            listenerFunction.forEach(listener => listener(GetConfigChangeEvent(changingConfig)));
+            options.disableCodeActions.should.equal(true);
+        });
+
+        teardown(() => {
+            options = undefined;
+            listenerFunction = undefined;
+            subscription.unsubscribe();
+            subscription = undefined;
+        });
+    });
+
+    test('Dispose is called when the last subscriber unsubscribes', () => {
+        disposeCalled.should.equal(false);
+        let subscription1 = optionStream.subscribe(_ => { });
+        let subscription2 = optionStream.subscribe(_ => { });
+        let subscription3 = optionStream.subscribe(_ => { });
+        subscription1.unsubscribe();
+        disposeCalled.should.equal(false);
+        subscription2.unsubscribe();
+        disposeCalled.should.equal(false);
+        subscription3.unsubscribe();
+        disposeCalled.should.equal(true);
+    });
+
+    function getVSCode(listenerFunction: Array<(e: ConfigurationChangeEvent) => any>): vscode {
+        let vscode = getVSCodeWithConfig();
+        vscode.workspace.onDidChangeConfiguration = (listener: (e: ConfigurationChangeEvent) => any, thisArgs?: any, disposables?: Disposable[]) => {
+            listenerFunction.push(listener);
+            return new Disposable(() => disposeCalled = true);
+        };
+
+        return vscode;
+    }
+});

--- a/test/unitTests/testAssets/GetConfigChangeEvent.ts
+++ b/test/unitTests/testAssets/GetConfigChangeEvent.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConfigurationChangeEvent } from "../../../src/vscodeAdapter";
+ 
+export function GetConfigChangeEvent(changingConfig: string): ConfigurationChangeEvent {
+    return {
+        affectsConfiguration: (section: string) => section == changingConfig
+    };
+}


### PR DESCRIPTION
Added an option change observer that subscribes to an Observable<Options> and shows the information message when there is a change in the configuration the server cares about and then restarts the server when "Restart" is clicked. Added unit tests for each of the components involved.