### PR TITLE
Clear the OmniSharp channel before restarting the server

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -14,7 +14,7 @@ import * as vscode from 'vscode';
 import { DotNetAttachItemsProviderFactory, AttachPicker, RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
 import { getAdapterExecutionCommand } from '../coreclr-debug/activate';
-import { CommandShowOutput, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
+import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
 import { PlatformInformation } from '../platform';
 import CompositeDisposable from '../CompositeDisposable';
@@ -23,7 +23,7 @@ import OptionProvider from '../observers/OptionProvider';
 export default function registerCommands(server: OmniSharpServer, platformInfo: PlatformInformation, eventStream: EventStream, optionProvider: OptionProvider): CompositeDisposable {
     let d1 = vscode.commands.registerCommand('o.restart', () => restartOmniSharp(server));
     let d2 = vscode.commands.registerCommand('o.pickProjectAndStart', async () => pickProjectAndStart(server, optionProvider));
-    let d3 = vscode.commands.registerCommand('o.showOutput', () => eventStream.post(new CommandShowOutput()));
+    let d3 = vscode.commands.registerCommand('o.showOutput', () => eventStream.post(new ShowOmniSharpChannel()));
     let d4 = vscode.commands.registerCommand('dotnet.restore', fileName => {
         if (fileName) {
             dotnetRestoreForProject(server, fileName, eventStream);

--- a/src/observers/OmnisharpChannelObserver.ts
+++ b/src/observers/OmnisharpChannelObserver.ts
@@ -4,17 +4,20 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, CommandShowOutput, OmnisharpFailure } from '../omnisharp/loggingEvents';
+import { BaseEvent, ShowOmniSharpChannel, OmnisharpFailure, OmnisharpRestart } from '../omnisharp/loggingEvents';
 
 export class OmnisharpChannelObserver extends BaseChannelObserver {
 
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
-            case CommandShowOutput.name:
+            case ShowOmniSharpChannel.name:
                 this.showChannel();
                 break;
             case OmnisharpFailure.name:
                 this.showChannel();
+                break;
+            case OmnisharpRestart.name:
+                this.clearChannel();
                 break;
         }
     }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -135,7 +135,7 @@ export class OmnisharpServerVerboseMessage extends EventWithMessage { }
 
 export class ProjectModified implements BaseEvent { }
 export class ActivationFailure implements BaseEvent { }
-export class CommandShowOutput implements BaseEvent { }
+export class ShowOmniSharpChannel implements BaseEvent { }
 export class DebuggerNotInstalledFailure implements BaseEvent { }
 export class CommandDotNetRestoreStart implements BaseEvent { }
 export class InstallationSuccess implements BaseEvent { }
@@ -147,3 +147,4 @@ export class ActiveTextEditorChanged implements BaseEvent { }
 export class OmnisharpServerOnStop implements BaseEvent { }
 export class OmnisharpServerOnStart implements BaseEvent { }
 export class LatestBuildDownloadStart implements BaseEvent { }
+export class OmnisharpRestart implements BaseEvent { }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -321,7 +321,6 @@ export class OmniSharpServer {
 
         try {
             let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo, options);
-            this.eventStream.post(new ObservableEvents.ShowOmniSharpChannel());
             this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid));
 
             this._serverProcess = launchResult.process;

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -321,6 +321,7 @@ export class OmniSharpServer {
 
         try {
             let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo, options);
+            this.eventStream.post(new ObservableEvents.ShowOmniSharpChannel());
             this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid));
 
             this._serverProcess = launchResult.process;
@@ -416,6 +417,7 @@ export class OmniSharpServer {
     public async restart(launchTarget: LaunchTarget = this._launchTarget): Promise<void> {
         if (launchTarget) {
             await this.stop();
+            this.eventStream.post(new ObservableEvents.OmnisharpRestart());
             const options = this.optionProvider.GetLatestOptions();
             await this._start(launchTarget, options);
         }

--- a/test/unitTests/logging/OmnisharpChannelObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpChannelObserver.test.ts
@@ -2,22 +2,45 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { should, expect } from 'chai';
+import { expect } from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
 import { OmnisharpChannelObserver } from '../../../src/observers/OmnisharpChannelObserver';
-import { OmnisharpFailure } from '../../../src/omnisharp/loggingEvents';
+import { OmnisharpFailure, ShowOmniSharpChannel, BaseEvent, OmnisharpRestart } from '../../../src/omnisharp/loggingEvents';
 
 suite("OmnisharpChannelObserver", () => {
-    suiteSetup(() => should());
-    test(`OmnisharpFailure: Shows the channel`, () => {
-        let event = new OmnisharpFailure("errorMessage", new Error("error"));
-        let hasShown = false;
-        let observer = new OmnisharpChannelObserver({
-            ...getNullChannel(),
-            show: () => { hasShown = true; }
-        });
 
-        observer.post(event);
-        expect(hasShown).to.be.true;
+    let hasShown: boolean;
+    let hasCleared: boolean;
+    let observer: OmnisharpChannelObserver;
+
+    setup(() => {
+        hasShown = false;
+        hasCleared = false;
+        observer = new OmnisharpChannelObserver({
+            ...getNullChannel(),
+            show: () => { hasShown = true; },
+            clear: () => { hasCleared = true; }
+        });
+    });
+
+    [
+        new OmnisharpFailure("errorMessage", new Error("error")),
+        new ShowOmniSharpChannel()
+    ].forEach((event: BaseEvent) => {
+        test(`${event.constructor.name}: Channel is shown`, () => {
+            expect(hasShown).to.be.false;
+            observer.post(event);
+            expect(hasShown).to.be.true;
+        });
+    });
+
+    [
+        new OmnisharpRestart()
+    ].forEach((event: BaseEvent) => {
+        test(`${event.constructor.name}: Channel is cleared`, () => {
+            expect(hasCleared).to.be.false;
+            observer.post(event);
+            expect(hasCleared).to.be.true;
+        });
     });
 });


### PR DESCRIPTION
Clear the `Omnisharp log` channel when we restart the server to avoid having to navigate through logs from the previous start.

A relevant unit test also added to the OmnisharpChannelObserver