### PR TITLE
Use the event stream for the ".NET Test Log"

### DIFF
--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 import AbstractProvider from './abstractProvider';
 import { DebuggerEventsProtocol } from '../coreclr-debug/debuggerEventsProtocol';
 import { OmniSharpServer } from '../omnisharp/server';
-import { TestExecutionCountReport, ReportDotnetTestResults, DotnetTestRunStart, DotnetTestMessage, DotnetTestRunFailure, DotnetTestsInClassRunStart, DebuggerWarning, DebugStart, DebugComplete } from '../omnisharp/loggingEvents';
+import { TestExecutionCountReport, ReportDotnetTestResults, DotnetTestRunStart, DotnetTestMessage, DotnetTestRunFailure, DotnetTestsInClassRunStart, DebuggerWarning, DebugStart, DebugComplete, DotnetTestDebugStart, DotnetTestsInClassDebugStart } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
 import LaunchConfiguration from './launchConfiguration';
 import Disposable from '../Disposable';
@@ -323,6 +323,8 @@ export default class TestManager extends AbstractProvider {
         // We support to styles of 'dotnet test' for debugging: The legacy 'project.json' testing, and the newer csproj support
         // using VS Test. These require a different level of communication.
 
+        this._eventStream.post(new DotnetTestDebugStart(testMethod));
+
         let { debugType, debugEventListener, targetFrameworkVersion } = await this._recordDebugAndGetDebugValues(fileName, testFrameworkName);
 
         return this._getLaunchConfiguration(debugType, fileName, testMethod, testFrameworkName, targetFrameworkVersion, debugEventListener)
@@ -339,6 +341,8 @@ export default class TestManager extends AbstractProvider {
     }
 
     private async _debugDotnetTestsInClass(methodsToRun: string[], fileName: string, testFrameworkName: string) {
+
+        this._eventStream.post(new DotnetTestsInClassDebugStart());
 
         let { debugType, debugEventListener, targetFrameworkVersion } = await this._recordDebugAndGetDebugValues(fileName, testFrameworkName);
 
@@ -433,7 +437,7 @@ class DebugEventListener {
                     event = DebuggerEventsProtocol.decodePacket(buffer);
                 }
                 catch (e) {
-                    this._eventStream.post(new DebuggerWarning("'Invalid' event received from debugger"));
+                    this._eventStream.post(new DebuggerWarning("Invalid event received from debugger"));
                     return;
                 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,8 @@ import { vscodeNetworkSettingsProvider, NetworkSettingsProvider } from './Networ
 import { ErrorMessageObserver } from './observers/ErrorMessageObserver';
 import OptionStream from './observables/OptionStream';
 import  OptionProvider from './observers/OptionProvider';
-import DotnetTestLogChannelObserver from './observers/DotnetTestLogChannelObserver';
+import DotnetTestChannelObserver from './observers/DotnetTestChannelObserver';
+import DotnetTestLoggerObserver from './observers/DotnetTestLoggerObserver';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -54,9 +55,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     eventStream.subscribe(dotnetChannelObserver.post);
     eventStream.subscribe(dotnetLoggerObserver.post);
 
-    let dotnetTestLogChannel = vscode.window.createOutputChannel(".NET Test Log");
-    let dotnetTestLogChannelObserver = new DotnetTestLogChannelObserver(dotnetTestLogChannel);
-    eventStream.subscribe(dotnetTestLogChannelObserver.post);
+    let dotnetTestChannel = vscode.window.createOutputChannel(".NET Test Log");
+    let dotnetTestChannelObserver = new DotnetTestChannelObserver(dotnetTestChannel);
+    let dotnetTestLoggerObserver = new DotnetTestLoggerObserver(dotnetTestChannel);
+    eventStream.subscribe(dotnetTestChannelObserver.post);
+    eventStream.subscribe(dotnetTestLoggerObserver.post);
     
     let csharpChannel = vscode.window.createOutputChannel('C#');
     let csharpchannelObserver = new CsharpChannelObserver(csharpChannel);

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { vscodeNetworkSettingsProvider, NetworkSettingsProvider } from './Networ
 import { ErrorMessageObserver } from './observers/ErrorMessageObserver';
 import OptionStream from './observables/OptionStream';
 import  OptionProvider from './observers/OptionProvider';
+import DotnetTestLogChannelObserver from './observers/DotnetTestLogChannelObserver';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -53,6 +54,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     eventStream.subscribe(dotnetChannelObserver.post);
     eventStream.subscribe(dotnetLoggerObserver.post);
 
+    let dotnetTestLogChannel = vscode.window.createOutputChannel(".NET Test Log");
+    let dotnetTestLogChannelObserver = new DotnetTestLogChannelObserver(dotnetTestLogChannel);
+    eventStream.subscribe(dotnetTestLogChannelObserver.post);
+    
     let csharpChannel = vscode.window.createOutputChannel('C#');
     let csharpchannelObserver = new CsharpChannelObserver(csharpChannel);
     let csharpLogObserver = new CsharpLoggerObserver(csharpChannel);

--- a/src/observers/DotnetTestChannelObserver.ts
+++ b/src/observers/DotnetTestChannelObserver.ts
@@ -4,14 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure, DotnetTestsInClassRunStart } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure, DotnetTestsInClassRunStart, DotnetTestDebugStart } from "../omnisharp/loggingEvents";
 
 export default class DotnetTestChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
             case DotnetTestRunStart.name:
             case DotnetTestRunFailure.name:   
-            case DotnetTestsInClassRunStart.name:    
+            case DotnetTestsInClassRunStart.name: 
+            case DotnetTestDebugStart.name:    
                 this.showChannel();
                 break;
         }

--- a/src/observers/DotnetTestChannelObserver.ts
+++ b/src/observers/DotnetTestChannelObserver.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure, DotnetTestsInClassRunStart, DotnetTestDebugStart } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure, DotnetTestsInClassRunStart, DotnetTestDebugStart, DotnetTestsInClassDebugStart } from "../omnisharp/loggingEvents";
 
 export default class DotnetTestChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
@@ -13,6 +13,7 @@ export default class DotnetTestChannelObserver extends BaseChannelObserver {
             case DotnetTestRunFailure.name:   
             case DotnetTestsInClassRunStart.name: 
             case DotnetTestDebugStart.name:    
+            case DotnetTestsInClassDebugStart.name:    
                 this.showChannel();
                 break;
         }

--- a/src/observers/DotnetTestChannelObserver.ts
+++ b/src/observers/DotnetTestChannelObserver.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure, DotnetTestsInClassRunStart } from "../omnisharp/loggingEvents";
 
 export default class DotnetTestChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
             case DotnetTestRunStart.name:
-            case DotnetTestRunFailure.name:    
+            case DotnetTestRunFailure.name:   
+            case DotnetTestsInClassRunStart.name:    
                 this.showChannel();
                 break;
         }

--- a/src/observers/DotnetTestChannelObserver.ts
+++ b/src/observers/DotnetTestChannelObserver.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestRunFailure } from "../omnisharp/loggingEvents";
 
-export default class DotnetTestLogChannelObserver extends BaseChannelObserver {
+export default class DotnetTestChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
-            
+            case DotnetTestRunStart.name:
+            case DotnetTestRunFailure.name:    
+                this.showChannel();
+                break;
         }
     }
 }

--- a/src/observers/DotnetTestLogChannelObserver.ts
+++ b/src/observers/DotnetTestLogChannelObserver.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseChannelObserver } from "./BaseChannelObserver";
+import { BaseEvent } from "../omnisharp/loggingEvents";
+
+export default class DotnetTestLogChannelObserver extends BaseChannelObserver {
+    public post = (event: BaseEvent) => {
+        switch (event.constructor.name) {
+            
+        }
+    }
+}

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseEvent, DotnetTestRunStart, DotnetTestMessage, ReportDotnetTestResults, DotnetTestDebugStart } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestMessage, ReportDotnetTestResults, DotnetTestDebugStart, DebuggerWarning, DebugStart, DebugComplete } from "../omnisharp/loggingEvents";
 import { BaseLoggerObserver } from "./BaseLoggerObserver";
 import * as protocol from '../omnisharp/protocol';
 
@@ -23,7 +23,20 @@ export default class DotnetTestLoggerObserver extends BaseLoggerObserver {
             case DotnetTestDebugStart.name:
                 this.handleDotnetTestDebugStart(<DotnetTestDebugStart>event);
                 break;
+            case DebuggerWarning.name:
+                this.handleDebuggerWarning(<DebuggerWarning>event);
+                break;
+            case DebugStart.name:
+                this.handleDebugStart(<DebugStart>event);
+                break;
+            case DebugComplete.name:
+                this.logger.appendLine("Debugging complete.\n");
+                break;
         }
+    }
+
+    private handleDebuggerWarning(event: DebuggerWarning) {
+        this.logger.appendLine(`Warning: ${event.message}`);
     }
 
     private handleDotnetTestDebugStart(event: DotnetTestDebugStart) {
@@ -34,6 +47,10 @@ export default class DotnetTestLoggerObserver extends BaseLoggerObserver {
     private handleDotnetTestRunStart(event: DotnetTestRunStart): any {
         this.logger.appendLine(`Running test ${event.testMethod}...`);
         this.logger.appendLine('');
+    }
+
+    private handleDebugStart(event: DebugStart) {
+        this.logger.appendLine(`Started debugging process #${event.targetProcessId}.`);
     }
 
     private handleReportDotnetTestResults(event: ReportDotnetTestResults) {

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseEvent, DotnetTestRunStart, DotnetTestRunMessage } from "../omnisharp/loggingEvents";
+import { BaseLoggerObserver } from "./BaseLoggerObserver";
+
+export default class DotnetTestLoggerObserver extends BaseLoggerObserver {
+    
+    public post = (event: BaseEvent) => {
+        switch (event.constructor.name) {
+            case DotnetTestRunStart.name:
+                this.handleDotnetTestRunStart(<DotnetTestRunStart>event);
+                break;
+            case DotnetTestRunMessage.name:
+                this.logger.appendLine((<DotnetTestRunMessage>event).message);
+                break;
+        }
+    }
+
+    handleDotnetTestRunStart(event: DotnetTestRunStart): any {
+        this.logger.appendLine(`Running test ${event.testMethod}...`);
+        this.logger.appendLine('');
+    }
+}

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -3,31 +3,39 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseEvent, DotnetTestRunStart, DotnetTestRunMessage, ReportDotnetTestResults } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotnetTestRunStart, DotnetTestMessage, ReportDotnetTestResults, DotnetTestDebugStart } from "../omnisharp/loggingEvents";
 import { BaseLoggerObserver } from "./BaseLoggerObserver";
 import * as protocol from '../omnisharp/protocol';
 
 export default class DotnetTestLoggerObserver extends BaseLoggerObserver {
-    
+
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
             case DotnetTestRunStart.name:
                 this.handleDotnetTestRunStart(<DotnetTestRunStart>event);
                 break;
-            case DotnetTestRunMessage.name:
-                this.logger.appendLine((<DotnetTestRunMessage>event).message);
+            case DotnetTestMessage.name:
+                this.logger.appendLine((<DotnetTestMessage>event).message);
                 break;
             case ReportDotnetTestResults.name:
                 this.handleReportDotnetTestResults(<ReportDotnetTestResults>event);
                 break;
+            case DotnetTestDebugStart.name:
+                this.handleDotnetTestDebugStart(<DotnetTestDebugStart>event);
+                break;
         }
+    }
+
+    private handleDotnetTestDebugStart(event: DotnetTestDebugStart) {
+        this.logger.appendLine(`Debugging method ${event.testMethod}...`);
+        this.logger.appendLine('');
     }
 
     private handleDotnetTestRunStart(event: DotnetTestRunStart): any {
         this.logger.appendLine(`Running test ${event.testMethod}...`);
         this.logger.appendLine('');
     }
-    
+
     private handleReportDotnetTestResults(event: ReportDotnetTestResults) {
         const results = event.results;
         const totalTests = results.length;

--- a/src/observers/ErrorMessageObserver.ts
+++ b/src/observers/ErrorMessageObserver.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
-import { BaseEvent, ZipError, DotnetTestRunFailure } from "../omnisharp/loggingEvents";
+import { BaseEvent, ZipError, DotnetTestRunFailure, DebuggerStartFailure } from "../omnisharp/loggingEvents";
 import { vscode } from "../vscodeAdapter";
 import showErrorMessage from "./utils/ShowErrorMessage";
 
@@ -21,6 +20,9 @@ export class ErrorMessageObserver {
             case DotnetTestRunFailure.name:
                 this.handleDotnetTestRunFailure(<DotnetTestRunFailure>event);
                 break;
+            case DebuggerStartFailure.name:
+                this.handleDebuggerStartFailure(<DebuggerStartFailure>event);
+                break;
         }
     }
 
@@ -30,5 +32,9 @@ export class ErrorMessageObserver {
 
     private handleDotnetTestRunFailure(event: DotnetTestRunFailure) {
         showErrorMessage(this.vscode,`Failed to run test because ${event.message}.`);
+    }
+
+    private handleDebuggerStartFailure(event: DebuggerStartFailure) {
+        showErrorMessage(this.vscode, `Failed to start debugger: ${event.message}`);
     }
 }

--- a/src/observers/ErrorMessageObserver.ts
+++ b/src/observers/ErrorMessageObserver.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { BaseEvent, ZipError } from "../omnisharp/loggingEvents";
+import { BaseEvent, ZipError, DotnetTestRunFailure } from "../omnisharp/loggingEvents";
 import { vscode } from "../vscodeAdapter";
 import showErrorMessage from "./utils/ShowErrorMessage";
 
@@ -18,10 +18,17 @@ export class ErrorMessageObserver {
             case ZipError.name:
                 this.handleZipError(<ZipError>event);
                 break;
+            case DotnetTestRunFailure.name:
+                this.handleDotnetTestRunFailure(<DotnetTestRunFailure>event);
+                break;
         }
     }
 
     private handleZipError(event: ZipError) {
         showErrorMessage(this.vscode, event.message);
+    }
+
+    private handleDotnetTestRunFailure(event: DotnetTestRunFailure) {
+        showErrorMessage(this.vscode,`Failed to run test because ${event.message}.`);
     }
 }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -122,6 +122,14 @@ export class ZipError implements BaseEvent {
     constructor(public message: string) { }
 }
 
+export class ReportDotnetTestResults implements BaseEvent {
+    constructor(results: protocol.V2.DotNetTestResult[]) { }
+}
+
+export class DotnetTestRunStart implements BaseEvent {
+    constructor(public testMethod: string) { }
+}
+
 export class DebuggerPrerequisiteFailure extends EventWithMessage { }
 export class DebuggerPrerequisiteWarning extends EventWithMessage { }
 export class CommandDotNetRestoreProgress extends EventWithMessage { }
@@ -132,6 +140,8 @@ export class DownloadFailure extends EventWithMessage { }
 export class OmnisharpServerOnStdErr extends EventWithMessage { }
 export class OmnisharpServerMessage extends EventWithMessage { }
 export class OmnisharpServerVerboseMessage extends EventWithMessage { }
+export class DotnetTestRunMessage extends EventWithMessage { }
+export class DotnetTestRunFailure extends EventWithMessage { }
 
 export class ProjectModified implements BaseEvent { }
 export class ActivationFailure implements BaseEvent { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -168,4 +168,5 @@ export class OmnisharpServerOnStart implements BaseEvent { }
 export class LatestBuildDownloadStart implements BaseEvent { }
 export class OmnisharpRestart implements BaseEvent { }
 export class DotnetTestsInClassRunStart implements BaseEvent { }
+export class DotnetTestsInClassDebugStart implements BaseEvent { }
 export class DebugComplete implements BaseEvent { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -151,6 +151,7 @@ export class OmnisharpServerVerboseMessage extends EventWithMessage { }
 export class DotnetTestMessage extends EventWithMessage { }
 export class DotnetTestRunFailure extends EventWithMessage { }
 export class DebuggerWarning extends EventWithMessage { }
+export class DebuggerStartFailure extends EventWithMessage { }
 
 export class ProjectModified implements BaseEvent { }
 export class ActivationFailure implements BaseEvent { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -123,7 +123,7 @@ export class ZipError implements BaseEvent {
 }
 
 export class ReportDotnetTestResults implements BaseEvent {
-    constructor(results: protocol.V2.DotNetTestResult[]) { }
+    constructor(public results: protocol.V2.DotNetTestResult[]) { }
 }
 
 export class DotnetTestRunStart implements BaseEvent {
@@ -158,3 +158,4 @@ export class OmnisharpServerOnStop implements BaseEvent { }
 export class OmnisharpServerOnStart implements BaseEvent { }
 export class LatestBuildDownloadStart implements BaseEvent { }
 export class OmnisharpRestart implements BaseEvent { }
+export class DotnetTestsInClassRunStart implements BaseEvent { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -130,6 +130,10 @@ export class DotnetTestRunStart implements BaseEvent {
     constructor(public testMethod: string) { }
 }
 
+export class DotnetTestDebugStart implements BaseEvent {
+    constructor(public testMethod: string) { }
+}
+
 export class DebuggerPrerequisiteFailure extends EventWithMessage { }
 export class DebuggerPrerequisiteWarning extends EventWithMessage { }
 export class CommandDotNetRestoreProgress extends EventWithMessage { }
@@ -140,7 +144,7 @@ export class DownloadFailure extends EventWithMessage { }
 export class OmnisharpServerOnStdErr extends EventWithMessage { }
 export class OmnisharpServerMessage extends EventWithMessage { }
 export class OmnisharpServerVerboseMessage extends EventWithMessage { }
-export class DotnetTestRunMessage extends EventWithMessage { }
+export class DotnetTestMessage extends EventWithMessage { }
 export class DotnetTestRunFailure extends EventWithMessage { }
 
 export class ProjectModified implements BaseEvent { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -134,6 +134,10 @@ export class DotnetTestDebugStart implements BaseEvent {
     constructor(public testMethod: string) { }
 }
 
+export class DebugStart implements BaseEvent {
+    constructor(public targetProcessId: number) { }
+}
+
 export class DebuggerPrerequisiteFailure extends EventWithMessage { }
 export class DebuggerPrerequisiteWarning extends EventWithMessage { }
 export class CommandDotNetRestoreProgress extends EventWithMessage { }
@@ -146,6 +150,7 @@ export class OmnisharpServerMessage extends EventWithMessage { }
 export class OmnisharpServerVerboseMessage extends EventWithMessage { }
 export class DotnetTestMessage extends EventWithMessage { }
 export class DotnetTestRunFailure extends EventWithMessage { }
+export class DebuggerWarning extends EventWithMessage { }
 
 export class ProjectModified implements BaseEvent { }
 export class ActivationFailure implements BaseEvent { }
@@ -163,3 +168,4 @@ export class OmnisharpServerOnStart implements BaseEvent { }
 export class LatestBuildDownloadStart implements BaseEvent { }
 export class OmnisharpRestart implements BaseEvent { }
 export class DotnetTestsInClassRunStart implements BaseEvent { }
+export class DebugComplete implements BaseEvent { }


### PR DESCRIPTION
Removes the logging responsibilty of the ".NET Test Log" into a dotnet test log channel and logger observer using the event stream.