### PR TITLE
Improve logging of tests

### DIFF
--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -40,12 +40,12 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleDotnetTestDebugStart(event: DotNetTestDebugStart) {
-        this.logger.appendLine(`Debugging method ${event.testMethod}...`);
+        this.logger.appendLine(`----- Debugging test method ${event.testMethod} -----`);
         this.logger.appendLine('');
     }
 
     private handleDotnetTestRunStart(event: DotNetTestRunStart): any {
-        this.logger.appendLine(`Running test ${event.testMethod}...`);
+        this.logger.appendLine(`----- Running test method "${event.testMethod}" -----`);
         this.logger.appendLine('');
     }
 
@@ -54,12 +54,14 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleReportDotnetTestResults(event: ReportDotNetTestResults) {
+        this.logger.appendLine("----- Test Execution Summary -----");
+        this.logger.appendLine('');
         const results = event.results;
         const totalTests = results.length;
 
         let totalPassed = 0, totalFailed = 0, totalSkipped = 0;
         for (let result of results) {
-            this.logger.appendLine(`${result.MethodName}: ${result.Outcome}`);
+            this.logTestResult(result);
             switch (result.Outcome) {
                 case protocol.V2.TestOutcomes.Failed:
                     totalFailed += 1;
@@ -73,8 +75,22 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
             }
         }
 
-        this.logger.appendLine('');
         this.logger.appendLine(`Total tests: ${totalTests}. Passed: ${totalPassed}. Failed: ${totalFailed}. Skipped: ${totalSkipped}`);
         this.logger.appendLine('');
     }
+
+    private logTestResult(result: protocol.V2.DotNetTestResult) {
+        this.logger.appendLine(`${result.MethodName}: ${processOutcome(result.Outcome)}`);
+        this.logger.increaseIndent();
+        this.logger.appendLine(`Outcome: ${processOutcome(result.Outcome)}`);
+        if (result.ErrorMessage) {
+            this.logger.appendLine(`Error Message: ${result.ErrorMessage}`);
+        }
+        this.logger.appendLine();
+        this.logger.decreaseIndent();
+    }
+}
+
+function processOutcome(input: string) {
+    return input.charAt(0).toUpperCase() + input.slice(1);
 }

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -85,7 +85,13 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
         this.logger.appendLine(`Outcome: ${processOutcome(result.Outcome)}`);
         if (result.ErrorMessage) {
             this.logger.appendLine(`Error Message: ${result.ErrorMessage}`);
+            
         }
+
+        if (result.ErrorStackTrace) {
+            this.logger.appendLine(`Error StackTrace: ${result.ErrorStackTrace}`);
+        }
+
         this.logger.appendLine();
         this.logger.decreaseIndent();
     }

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -80,7 +80,7 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 
     private logTestResult(result: protocol.V2.DotNetTestResult) {
-        this.logger.appendLine(`${result.MethodName}: ${processOutcome(result.Outcome)}`);
+        this.logger.appendLine(`${result.MethodName}:`);
         this.logger.increaseIndent();
         this.logger.appendLine(`Outcome: ${processOutcome(result.Outcome)}`);
         if (result.ErrorMessage) {
@@ -91,6 +91,6 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 }
 
-function processOutcome(input: string) {
+export function processOutcome(input: string) {
     return input.charAt(0).toUpperCase() + input.slice(1);
 }

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -89,7 +89,7 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
         }
 
         if (result.ErrorStackTrace) {
-            this.logger.appendLine(`Error StackTrace: ${result.ErrorStackTrace}`);
+            this.logger.appendLine(`Stack Trace: ${result.ErrorStackTrace}`);
         }
 
         this.logger.appendLine();

--- a/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
+++ b/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
@@ -79,8 +79,8 @@ suite(`${DotNetTestLoggerObserver.name}`, () => {
 
         test('Displays the error message and error stack trace if any is present', () => {
             observer.post(event);
-            expect(appendedMessage).to.contain("foo:\n    Outcome: Failed\n    Error Message: assertion failed\n    Error StackTrace: stacktrace1");
-            expect(appendedMessage).to.contain("failinator:\n    Outcome: Failed\n    Error Message: error occured\n    Error StackTrace: stacktrace2");
+            expect(appendedMessage).to.contain("foo:\n    Outcome: Failed\n    Error Message: assertion failed\n    Stack Trace: stacktrace1");
+            expect(appendedMessage).to.contain("failinator:\n    Outcome: Failed\n    Error Message: error occured\n    Stack Trace: stacktrace2");
         });
     });
 });

--- a/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
+++ b/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from 'chai';
+import * as chai from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
 import { EventWithMessage, DotNetTestDebugWarning, DotNetTestDebugStart, BaseEvent, DotNetTestRunStart, DotNetTestDebugProcessStart, DotNetTestMessage, DotNetTestDebugComplete, ReportDotNetTestResults } from '../../../src/omnisharp/loggingEvents';
 import DotNetTestLoggerObserver from '../../../src/observers/DotnetTestLoggerObserver';
 import * as protocol from '../../../src/omnisharp/protocol';
+
+const expect = chai.expect;
+chai.use(require('chai-string'));
 
 suite(`${DotNetTestLoggerObserver.name}`, () => {
     let appendedMessage: string;
@@ -65,16 +68,19 @@ suite(`${DotNetTestLoggerObserver.name}`, () => {
         test(`Displays the outcome of each test`, () => {
             observer.post(event);
             event.results.forEach(result => {
-                expect(appendedMessage).to.contain(`${result.MethodName}: ${result.Outcome}`);
+                expect(appendedMessage).to.containIgnoreCase(`${result.MethodName}:\n    Outcome: ${result.Outcome}`);
             });
         });
 
         test(`Displays the total outcome`, () => {
             observer.post(event);
-            expect(appendedMessage).to.contain(`Total tests: ${event.results.length}. Passed: 1. Failed: 2. Skipped: 1`);
-            event.results.forEach(result => {
-                expect(appendedMessage).to.contain(`${result.MethodName}: ${result.Outcome}`);
-            });
+            expect(appendedMessage).to.contain(`Total tests: 4. Passed: 1. Failed: 2. Skipped: 1`);
+        });
+
+        test('Displays the error message if any is present', () => {
+            observer.post(event);
+            expect(appendedMessage).to.contain("foo:\n    Outcome: Failed\n    Error Message: assertion failed");
+            expect(appendedMessage).to.contain("failinator:\n    Outcome: Failed\n    Error Message: error occured");
         });
     });
 });

--- a/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
+++ b/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
@@ -59,8 +59,8 @@ suite(`${DotNetTestLoggerObserver.name}`, () => {
     suite(`${ReportDotNetTestResults.name}`, () => {
         let event = new ReportDotNetTestResults(
             [
-                getDotNetTestResults("foo", "failed", "assertion failed", ""),
-                getDotNetTestResults("failinator", "failed", "error occured", ""),
+                getDotNetTestResults("foo", "failed", "assertion failed", "stacktrace1"),
+                getDotNetTestResults("failinator", "failed", "error occured", "stacktrace2"),
                 getDotNetTestResults("bar", "skipped", "", ""),
                 getDotNetTestResults("passinator", "passed", "", ""),
             ]);
@@ -77,10 +77,10 @@ suite(`${DotNetTestLoggerObserver.name}`, () => {
             expect(appendedMessage).to.contain(`Total tests: 4. Passed: 1. Failed: 2. Skipped: 1`);
         });
 
-        test('Displays the error message if any is present', () => {
+        test('Displays the error message and error stack trace if any is present', () => {
             observer.post(event);
-            expect(appendedMessage).to.contain("foo:\n    Outcome: Failed\n    Error Message: assertion failed");
-            expect(appendedMessage).to.contain("failinator:\n    Outcome: Failed\n    Error Message: error occured");
+            expect(appendedMessage).to.contain("foo:\n    Outcome: Failed\n    Error Message: assertion failed\n    Error StackTrace: stacktrace1");
+            expect(appendedMessage).to.contain("failinator:\n    Outcome: Failed\n    Error Message: error occured\n    Error StackTrace: stacktrace2");
         });
     });
 });


### PR DESCRIPTION
Fixes: #2268 

After this fix, the output appears as : 
----- Running test method "BankTests.UnitTest1.Debit_WithValidAmount_UpdatesBalance" -----

` Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Bank -> c:\Users\Bank\Bank\bin\Debug\Bank.dll
  BankTests -> c:\Users\Bank\BankTests\bin\Debug\netcoreapp2.0\BankTests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.19


----- Test Execution Summary -----

BankTests.UnitTest1.Debit_WithValidAmount_UpdatesBalance: Failed
    Outcome: Failed
    Error Message: Assert.AreEqual failed. Expected a difference no greater than <0.001> between expected value <7.7> and actual value <7.44>. Account not debited correctly
    
Total tests: 1. Passed: 0. Failed: 1. Skipped: 0 `
