### PR TITLE
Using a test event bus and disposing the subscription to the event stream

### DIFF
--- a/src/EventStream.ts
+++ b/src/EventStream.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Subject } from "rxjs/Subject";
 import { BaseEvent } from "./omnisharp/loggingEvents";
+import { Subscription } from "rxjs/Subscription";
 
 export class EventStream {
     private sink: Subject<BaseEvent>;
@@ -16,7 +17,7 @@ export class EventStream {
         this.sink.next(event);
     }
 
-    public subscribe(eventHandler: (event: BaseEvent) => void) {
-        this.sink.subscribe(eventHandler);
+    public subscribe(eventHandler: (event: BaseEvent) => void): Subscription {
+        return this.sink.subscribe(eventHandler);
     }
 }

--- a/test/unitTests/testAssets/TestEventBus.ts
+++ b/test/unitTests/testAssets/TestEventBus.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { EventStream } from "../../../src/EventStream";
+import { BaseEvent } from "../../../src/omnisharp/loggingEvents";
+import Disposable, { IDisposable } from "../../../src/Disposable";
+
+export default class TestEventBus {
+    private eventBus: Array<BaseEvent>;
+    private disposable: IDisposable;
+
+    constructor(eventStream: EventStream){
+        this.eventBus = [];
+        this.disposable = new Disposable(eventStream.subscribe(event => this.eventBus.push(event)));
+    }
+
+    public getEvents(): Array<BaseEvent>{
+        return this.eventBus;
+    }
+
+    public dispose(){
+        this.disposable.dispose();
+    }
+}


### PR DESCRIPTION
Using a test event bus class in the unit tests that is used to subscribe to the event stream and checking whether the expected events are produced.