### PR TITLE
Add option to run with a custom mono installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -535,6 +535,14 @@
           ],
           "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 5.8.1 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 5.8.1 or greater is available on the PATH."
         },
+        "omnisharp.monoPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Specifies the path to a mono installation to use when \"useGlobalMono\" is set to \"always\" or \"auto\", instead of the default system one."
+        },
         "omnisharp.waitForDebugger": {
           "type": "boolean",
           "default": false,

--- a/src/observers/OmnisharpLoggerObserver.ts
+++ b/src/observers/OmnisharpLoggerObserver.ts
@@ -54,12 +54,14 @@ export class OmnisharpLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpLaunch(event: OmnisharpLaunch) {
+        this.logger.append(`OmniSharp server started`);
         if (event.monoVersion) {
-            this.logger.appendLine(`OmniSharp server started with Mono ${event.monoVersion}`);
+            this.logger.append(` with Mono ${event.monoVersion}`);
+            if (event.monoPath !== undefined) {
+                this.logger.append(` (${event.monoPath})`);
+            }
         }
-        else {
-            this.logger.appendLine(`OmniSharp server started`);
-        }
+        this.logger.appendLine('.');
 
         this.logger.increaseIndent();
         this.logger.appendLine(`Path: ${event.command}`);

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -199,6 +199,7 @@ export interface LaunchResult {
     process: ChildProcess;
     command: string;
     monoVersion?: string;
+    monoPath?: string;
 }
 
 export async function launchOmniSharp(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation, options: Options): Promise<LaunchResult> {
@@ -250,12 +251,12 @@ async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platf
 
         const launchPath = launchInfo.MonoLaunchPath || launchInfo.LaunchPath;
 
-        return launchNixMono(launchPath, monoVersion, cwd, args, childEnv);
+        return launchNixMono(launchPath, monoVersion, options.monoPath, cwd, args, childEnv);
     }
 
     // If we can launch on the global Mono, do so; otherwise, launch directly;
     if (options.useGlobalMono === "auto" && isValidMonoAvailable && launchInfo.MonoLaunchPath) {
-        return launchNixMono(launchInfo.MonoLaunchPath, monoVersion, cwd, args, childEnv);
+        return launchNixMono(launchInfo.MonoLaunchPath, monoVersion, options.monoPath, cwd, args, childEnv);
     }
     else {
         return launchNix(launchInfo.LaunchPath, cwd, args);
@@ -312,7 +313,7 @@ function launchNix(launchPath: string, cwd: string, args: string[]): LaunchResul
     };
 }
 
-function launchNixMono(launchPath: string, monoVersion: string, cwd: string, args: string[], environment: NodeJS.ProcessEnv): LaunchResult {
+function launchNixMono(launchPath: string, monoVersion: string, monoPath: string, cwd: string, args: string[], environment: NodeJS.ProcessEnv): LaunchResult {
     let argsCopy = args.slice(0); // create copy of details args
     argsCopy.unshift(launchPath);
     argsCopy.unshift("--assembly-loader=strict");
@@ -327,6 +328,7 @@ function launchNixMono(launchPath: string, monoVersion: string, cwd: string, arg
         process,
         command: launchPath,
         monoVersion,
+        monoPath,
     };
 }
 

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -27,7 +27,7 @@ export class OmnisharpInitialisation implements BaseEvent {
 }
 
 export class OmnisharpLaunch implements BaseEvent {
-    constructor(public monoVersion: string, public command: string, public pid: number) { }
+    constructor(public monoVersion: string, public command: string, public pid: number, public monoPath?: string) { }
 }
 
 export class PackageInstallation implements BaseEvent {

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -27,7 +27,7 @@ export class OmnisharpInitialisation implements BaseEvent {
 }
 
 export class OmnisharpLaunch implements BaseEvent {
-    constructor(public monoVersion: string, public command: string, public pid: number, public monoPath?: string) { }
+    constructor(public monoVersion: string, public monoPath: string, public command: string, public pid: number) { }
 }
 
 export class PackageInstallation implements BaseEvent {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -20,8 +20,9 @@ export class Options {
         public showTestsCodeLens: boolean,
         public disableCodeActions: boolean,
         public disableMSBuildDiagnosticWarning: boolean,
-        public defaultLaunchSolution?: string) { }
-        
+        public defaultLaunchSolution?: string,
+        public monoPath?: string) { }
+
 
     public static Read(vscode: vscode): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -36,6 +37,7 @@ export class Options {
 
         const path = Options.readPathOption(csharpConfig, omnisharpConfig);
         const useGlobalMono = Options.readUseGlobalMonoOption(omnisharpConfig, csharpConfig);
+        const monoPath = omnisharpConfig.get<string>('monoPath', undefined);
 
         const waitForDebugger = omnisharpConfig.get<boolean>('waitForDebugger', false);
 
@@ -75,7 +77,9 @@ export class Options {
             showTestsCodeLens,
             disableCodeActions,
             disableMSBuildDiagnosticWarning,
-            defaultLaunchSolution);
+            defaultLaunchSolution,
+            monoPath,
+        );
     }
 
     private static readPathOption(csharpConfig: WorkspaceConfiguration, omnisharpConfig: WorkspaceConfiguration): string | null {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -37,7 +37,7 @@ export class Options {
 
         const path = Options.readPathOption(csharpConfig, omnisharpConfig);
         const useGlobalMono = Options.readUseGlobalMonoOption(omnisharpConfig, csharpConfig);
-        const monoPath = omnisharpConfig.get<string>('monoPath', undefined);
+        const monoPath = omnisharpConfig.get<string>('monoPath', undefined) || undefined;
 
         const waitForDebugger = omnisharpConfig.get<boolean>('waitForDebugger', false);
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -321,7 +321,7 @@ export class OmniSharpServer {
 
         try {
             let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo, options);
-            this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid));
+            this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid, options.monoPath));
 
             this._serverProcess = launchResult.process;
             this._delayTrackers = {};

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -321,7 +321,7 @@ export class OmniSharpServer {
 
         try {
             let launchResult = await launchOmniSharp(cwd, args, launchInfo, this.platformInfo, options);
-            this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.command, launchResult.process.pid, options.monoPath));
+            this.eventStream.post(new ObservableEvents.OmnisharpLaunch(launchResult.monoVersion, launchResult.monoPath, launchResult.command, launchResult.process.pid));
 
             this._serverProcess = launchResult.process;
             this._delayTrackers = {};

--- a/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
@@ -135,10 +135,10 @@ suite("OmnisharpLoggerObserver", () => {
 
     suite('OmnisharpLaunch', () => {
         [
-            { 'event': new OmnisharpLaunch("5.12.0",  "someCommand", 4),                 'expected': "OmniSharp server started with Mono 5.12.0." },
-            { 'event': new OmnisharpLaunch(undefined, "someCommand", 4),                 'expected': "OmniSharp server started." },
-            { 'event': new OmnisharpLaunch("5.12.0",  "someCommand", 4, 'path to mono'), 'expected': "OmniSharp server started with Mono 5.12.0 (path to mono)." },
-            { 'event': new OmnisharpLaunch(undefined, "someCommand", 4, 'path to mono'), 'expected': "OmniSharp server started." },
+            { 'event': new OmnisharpLaunch("5.8.0", undefined, "someCommand", 4), 'expected': "OmniSharp server started with Mono 5.8.0." },
+            { 'event': new OmnisharpLaunch(undefined, undefined, "someCommand", 4), 'expected': "OmniSharp server started." },
+            { 'event': new OmnisharpLaunch("5.8.0", "path to mono", "someCommand", 4), 'expected': "OmniSharp server started with Mono 5.8.0 (path to mono)." },
+            { 'event': new OmnisharpLaunch(undefined, "path to mono", "someCommand", 4), 'expected': "OmniSharp server started." },
         ].forEach((data: { event: OmnisharpLaunch, expected: string }) => {
             const event = data.event;
 

--- a/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpLoggerObserver.test.ts
@@ -135,9 +135,12 @@ suite("OmnisharpLoggerObserver", () => {
 
     suite('OmnisharpLaunch', () => {
         [
-            new OmnisharpLaunch("5.8.0", "someCommand", 4),
-            new OmnisharpLaunch(undefined, "someCommand", 4)
-        ].forEach((event: OmnisharpLaunch) => {
+            { 'event': new OmnisharpLaunch("5.12.0",  "someCommand", 4),                 'expected': "OmniSharp server started with Mono 5.12.0." },
+            { 'event': new OmnisharpLaunch(undefined, "someCommand", 4),                 'expected': "OmniSharp server started." },
+            { 'event': new OmnisharpLaunch("5.12.0",  "someCommand", 4, 'path to mono'), 'expected': "OmniSharp server started with Mono 5.12.0 (path to mono)." },
+            { 'event': new OmnisharpLaunch(undefined, "someCommand", 4, 'path to mono'), 'expected': "OmniSharp server started." },
+        ].forEach((data: { event: OmnisharpLaunch, expected: string }) => {
+            const event = data.event;
 
             test(`Command and Pid are displayed`, () => {
                 observer.post(event);
@@ -145,14 +148,9 @@ suite("OmnisharpLoggerObserver", () => {
                 expect(logOutput).to.contain(event.pid);
             });
 
-            test(`Message is displayed depending on usingMono value`, () => {
+            test(`Message is displayed depending on monoVersion and monoPath value`, () => {
                 observer.post(event);
-                if (event.monoVersion) {
-                    expect(logOutput).to.contain("OmniSharp server started with Mono 5.8.0");
-                }
-                else {
-                    expect(logOutput).to.contain("OmniSharp server started");
-                }
+                expect(logOutput).to.contain(data.expected);
             });
         });
     });

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -16,6 +16,7 @@ suite("Options tests", () => {
         const options = Options.Read(vscode);
         expect(options.path).to.be.null;
         options.useGlobalMono.should.equal("auto");
+        expect(options.monoPath).to.be.undefined;
         options.waitForDebugger.should.equal(false);
         options.loggingLevel.should.equal("information");
         options.autoStart.should.equal(true);


### PR DESCRIPTION
👋 

When `useGlobalMono` is set to `always` or `auto`, the launcher uses whatever mono it finds in the path, which may or may not be a usable mono version for omnisharp. The user may have a suitable mono installation for omnisharp somewhere else, but not set as the default system one, or they may want to have omnisharp launched with a specific mono for omnisharp for debugging purposes. In my case, I have:

```
drwxr-xr-x  4.2.2.30
drwxr-xr-x  4.6.2.16
drwxr-xr-x  4.8.1.0
drwxr-xr-x  5.12.0.226_1
drwxr-xr-x  5.14.0.169_1
drwxr-xr-x  5.4.1.6
drwxr-xr-x  5.8.1.0_1
```

and I switch between them often, depending on what I need to do. Having vscode tied to whatever happens to be currently set on my system is really brittle, and if I need to have vscode use a particular mono version because of some mono bug, it's hard.

This PR adds a `monoPath` configuration option, and changes the launcher so that the environment variables PATH and MONO_GAC_PREFIX are changed to include the `monoPath` value, if set, when launching mono. If the `monoPath` option isn't set, it behaves as normal (also if `useGlobalMono` is set to `never`). I figured maybe this is useful for other people out there too 😃 