### PR TITLE
Set QuickPick windows to not lose focus

### DIFF
--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -27,6 +27,7 @@ export class AttachPicker {
         return this.attachItemsProvider.getAttachItems()
             .then(processEntries => {
                 let attachPickOptions: vscode.QuickPickOptions = {
+                    ignoreFocusOut: true,
                     matchOnDescription: true,
                     matchOnDetail: true,
                     placeHolder: "Select the process to attach to"
@@ -223,6 +224,7 @@ export class RemoteAttachPicker {
                 .then(async pipeCmd => RemoteAttachPicker.getRemoteOSAndProcesses(pipeCmd, pipeTransport.pipeCwd, platformInfo))
                 .then(processes => {
                     let attachPickOptions: vscode.QuickPickOptions = {
+                        ignoreFocusOut: true,
                         matchOnDescription: true,
                         matchOnDetail: true,
                         placeHolder: "Select the process to attach to"


### PR DESCRIPTION
Enabling ignoreFocusOut allows the QuickPick window to not disappear
when clicking on other windows or when other windows have focus.

An example of us losing focus before a user has selected a process is 
when a compound is used for launch, we lose focus
and then close the quick pick window as resolved with undefined process.

One catch is that now users have to hit esc to dismiss the process
picker window instead of clicking away.

Addressees: #2443 