### PR TITLE
debugger-launchjson.md: console related suggestions from recent issues

### DIFF
--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -43,6 +43,8 @@ The launch browser field can be optionally added if you need to launch with a we
 If there are web server dependencies in your project.json, the auto generated launch file will add launch 
 browser for you. It will open with the default program to handle URLs.
 
+Note that `launchBrowser` requires `"console": "internalConsole"`, as the browser launcher scrapes the standard output of the target process to know when the web server has initialized itself.
+
 ## Environment variables
 Environment variables may be passed to your program using this schema:
 
@@ -68,13 +70,14 @@ Example Properties/launchSettings.json file:
 ```
 
 ## Console (terminal) window
-By default, processes are launched with their console output (stdout/stderr) going to the VS Code Debugger Console. This is useful for executables that take their input from the network, files, etc. But this does NOT work for applications that want to read from the console (ex: `Console.ReadLine`). For these applications, use a setting such as the following:
 
-    "console": "integratedTerminal"
+The `"console"` setting controls what console (terminal) window the target app is launched into. It can be set to any of these values --
 
-When this is set to `integratedTerminal` the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneath the editor to interact with your application.
+`"internalConsole"` (default) : the target process's console output (stdout/stderr) goes to the VS Code Debug Console. This is useful for executables that take their input from the network, files, etc. But this does **NOT** work for applications that want to read from the console (ex: `Console.ReadLine`). 
 
-When this is set to `externalTerminal` the target process will run in a separate terminal.
+`"integratedTerminal"` : the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneath the editor to interact with your application. Alternatively add `"internalConsoleOptions": "neverOpen"` to make it so that the default foreground tab is the terminal tab.
+
+`"externalTerminal"`: the target process will run inside its own external terminal.
 
 ## Source File Map
 You can optionally configure a file by file mapping by providing map following this schema:


### PR DESCRIPTION
This rewrites the "console" documentation to hopefully be more clear. It also incorporates the suggestion to use `"internalConsoleOptions": "neverOpen"` with integratedTerminal that @BlinkSun made.

This also adds a note to the browser launch documentation that @achandlerwhite suggested.