### PR TITLE
Support `envFile` option in launch.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -822,6 +822,11 @@
                 "description": "Environment variables passed to the program.",
                 "default": {}
               },
+              "envFile": {
+                "type": "string",
+                "description": "Environment variables passed to the program by a file.",
+                "default": "${workspaceFolder}/.env"
+              },
               "console": {
                 "type": "string",
                 "enum": [
@@ -1883,6 +1888,11 @@
                 },
                 "description": "Environment variables passed to the program.",
                 "default": {}
+              },
+              "envFile": {
+                "type": "string",
+                "description": "Environment variables passed to the program by a file.",
+                "default": "${workspaceFolder}/.env"
               },
               "console": {
                 "type": "string",

--- a/src/coreclr-debug/ParsedEnvironmentFile.ts
+++ b/src/coreclr-debug/ParsedEnvironmentFile.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs-extra';
+
+export class ParsedEnvironmentFile
+{
+    public Env: { [key: string]: any };
+    public Warning: string | null;
+
+    private constructor(env: { [key: string]: any }, warning: string | null)
+    {
+        this.Env = env;
+        this.Warning = warning;
+    }
+
+    public static CreateFromFile(envFile: string, initialEnv: { [key: string]: any } | undefined): ParsedEnvironmentFile {
+        let content: string = fs.readFileSync(envFile, "utf8");
+        return this.CreateFromContent(content, envFile, initialEnv);
+    }
+
+    public static CreateFromContent(content: string, envFile: string, initialEnv: { [key: string]: any } | undefined): ParsedEnvironmentFile {
+
+        // Remove UTF-8 BOM if present
+        if(content.charAt(0) === '\uFEFF') {
+            content = content.substr(1);
+        }
+
+        let parseErrors: string[] = [];
+        let env: { [key: string]: any } = initialEnv;
+        if (!env) {
+            env = {};
+        }
+
+        content.split("\n").forEach(line => {
+            // Split the line between key and value
+            const r: RegExpMatchArray = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+
+            if (r !== null) {
+                const key: string = r[1];
+                let value: string = r[2] || "";
+                if ((value.length > 0) && (value.charAt(0) === '"') && (value.charAt(value.length - 1) === '"')) {
+                    value = value.replace(/\\n/gm, "\n");
+                }
+
+                value = value.replace(/(^['"]|['"]$)/g, "");
+
+                env[key] = value;
+            }
+            else {
+                // Blank lines and lines starting with # are no parse errors
+                const comments: RegExp = new RegExp(/^\s*(#|$)/);
+                if (!comments.test(line)) {
+                    parseErrors.push(line);
+                }
+            }
+        });
+
+        // show error message if single lines cannot get parsed
+        let warning: string = null;
+        if(parseErrors.length !== 0) {
+            warning = "Ignoring non-parseable lines in envFile " + envFile + ": ";
+            parseErrors.forEach(function (value, idx, array) {
+                warning += "\"" + value + "\"" + ((idx !== array.length - 1) ? ", " : ".");
+            });
+        }
+
+        return new ParsedEnvironmentFile(env, warning);
+    }
+}

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -317,6 +317,11 @@
           "description": "Environment variables passed to the program.",
           "default": {}
         },
+        "envFile": {
+          "type": "string",
+          "description": "Environment variables passed to the program by a file.",
+          "default": "${workspaceFolder}/.env"
+        },
         "console": {
           "type": "string",
           "enum": [ "internalConsole", "integratedTerminal", "externalTerminal" ],

--- a/test/unitTests/ParsedEnvironmentFile.test.ts
+++ b/test/unitTests/ParsedEnvironmentFile.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ParsedEnvironmentFile } from '../../src/coreclr-debug/ParsedEnvironmentFile';
+import { should, expect } from 'chai';
+
+suite("ParsedEnvironmentFile", () => {
+    suiteSetup(() => should());
+
+    test("Add single variable", () => {
+        const content = `MyName=VALUE`;
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName"].should.equal("VALUE");
+    });
+
+    test("Handle quoted values", () => {
+        const content = `MyName="VALUE"`;
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName"].should.equal("VALUE");
+    });
+
+    test("Handle BOM", () => {
+        const content = "\uFEFFMyName=VALUE";
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName"].should.equal("VALUE");
+    });
+
+    test("Add multiple variables", () => {
+        const content = `
+MyName1=Value1
+MyName2=Value2
+
+`;
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName1"].should.equal("Value1");
+        result.Env["MyName2"].should.equal("Value2");
+    });
+
+    test("Update variable", () => {
+        const content = `
+MyName1=Value1
+MyName2=Value2
+
+`;
+        const initialEnv : { [key: string]: any } = {
+            "MyName1": "Value7",
+            "ThisShouldNotChange": "StillHere"
+        };
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", initialEnv);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName1"].should.equal("Value1");
+        result.Env["MyName2"].should.equal("Value2");
+        result.Env["ThisShouldNotChange"].should.equal("StillHere");
+    });
+
+    test("Handle comments", () => {
+        const content = `# This is an environment file    
+MyName1=Value1
+# This is a comment in the middle of the file
+MyName2=Value2
+`;
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        expect(result.Warning).to.be.null;
+        result.Env["MyName1"].should.equal("Value1");
+        result.Env["MyName2"].should.equal("Value2");
+    });
+    
+    test("Handle invalid lines", () => {
+        const content = `
+This_Line_Is_Wrong
+MyName1=Value1
+MyName2=Value2
+
+`;
+        const fakeConfig : { [key: string]: any } = {};
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+
+        result.Warning.should.startWith("Ignoring non-parseable lines in envFile TestEnvFileName");
+        result.Env["MyName1"].should.equal("Value1");
+        result.Env["MyName2"].should.equal("Value2");
+    });
+});


### PR DESCRIPTION
Adds a new option for launch.json - envFile: it will read environment variables from the given UTF8 file. This way environment variables can be passed to the debugger and launch.json stays clean of sensitive data (like passwords).

This resolves #1944 