### PR TITLE
Use the latest omnisharp for integration tests

### DIFF
--- a/test/integrationTests/testAssets/singleCsproj/.vscode/settings.json
+++ b/test/integrationTests/testAssets/singleCsproj/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "omnisharp.path": "1.32.2-beta.21"
+    "omnisharp.path": "latest"
 }

--- a/test/integrationTests/testAssets/slnWithCsproj/.vscode/settings.json
+++ b/test/integrationTests/testAssets/slnWithCsproj/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "omnisharp.defaultLaunchSolution": "b_SecondInOrder_SlnFile.sln",
-    "omnisharp.path": "1.32.2-beta.21",
+    "omnisharp.path": "latest",
 }


### PR DESCRIPTION
The bug where OmniSharp was crashing on Travis should be fixed as of https://github.com/OmniSharp/omnisharp-roslyn/issues/1256.