### PR TITLE
Use the fsPath instead of path in the virtual document tracker

### DIFF
--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -63,7 +63,7 @@ function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): 
 }
 
 async function openVirtualDocument(document: TextDocument, server: OmniSharpServer, eventStream: EventStream) {
-    let req = { FileName: document.uri.path, changeType: FileChangeType.Create };
+    let req = { FileName: document.uri.fsPath, changeType: FileChangeType.Create };
     try {
         await serverUtils.filesChanged(server, [req]);
         await serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName });
@@ -74,7 +74,7 @@ async function openVirtualDocument(document: TextDocument, server: OmniSharpServ
 }
 
 async function closeVirtualDocument(document: TextDocument, server: OmniSharpServer, eventStream: EventStream) {
-    let req = { FileName: document.uri.path, changeType: FileChangeType.Delete };
+    let req = { FileName: document.uri.fsPath, changeType: FileChangeType.Delete };
     try {
         await serverUtils.filesChanged(server, [req]);
     }

--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -63,7 +63,13 @@ function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): 
 }
 
 async function openVirtualDocument(document: TextDocument, server: OmniSharpServer, eventStream: EventStream) {
-    let req = { FileName: document.uri.fsPath, changeType: FileChangeType.Create };
+    let path = document.uri.fsPath;
+
+    if (!path) {
+        path = document.uri.path;
+    }
+    
+    let req = { FileName: path, changeType: FileChangeType.Create };
     try {
         await serverUtils.filesChanged(server, [req]);
         await serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName });
@@ -74,7 +80,13 @@ async function openVirtualDocument(document: TextDocument, server: OmniSharpServ
 }
 
 async function closeVirtualDocument(document: TextDocument, server: OmniSharpServer, eventStream: EventStream) {
-    let req = { FileName: document.uri.fsPath, changeType: FileChangeType.Delete };
+    let path = document.uri.fsPath;
+
+    if (!path) {
+        path = document.uri.path;
+    }
+    
+    let req = { FileName: path, changeType: FileChangeType.Delete };
     try {
         await serverUtils.filesChanged(server, [req]);
     }


### PR DESCRIPTION
The virtual document tracker was sending a file change request with "path" instead of fsPath. The path was not a valid file system path and was causing omnisharp to crash when a deleted file was being opened in the git side-bar( https://github.com/OmniSharp/omnisharp-roslyn/pull/1252#issuecomment-413059744).