### PR TITLE
Adding folders with Miscellaneous Cs files as Launch Targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * Added support for tracking opening, closing and changing of virtual documents that don't exist on disk. (PR: [#2436](https://github.com/OmniSharp/omnisharp-vscode/pull/2436)) _(Contributed by [@NTaylorMullen](https://github.com/NTaylorMullen))_
 
+* Enabled IDE features for .cs files that are not part of a project. (PR: [#2471](https://github.com/OmniSharp/omnisharp-vscode/pull/2471), [omnisharp-roslyn#1252](https://github.com/OmniSharp/omnisharp-roslyn/pull/1252))
+
 #### Misc
 
 * Added a prompt to "Restart OmniSharp" when there is a change in omnisharp "path", "useGlobalMono" or "waitForDebugger" settings.(PR: [#2316](https://github.com/OmniSharp/omnisharp-vscode/pull/2316))

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -16,8 +16,7 @@ export enum LaunchTargetKind {
     ProjectJson,
     Folder,
     Csx,
-    Cake,
-    MiscellaneousCS
+    Cake
 }
 
 /**
@@ -180,11 +179,11 @@ function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[] {
 
         if (hasCs && !hasSlnFile && !hasCsProjFiles && !hasProjectJson && !hasProjectJsonAtRoot) {
             targets.push({
-                label: "Miscellaneous",
-                description: path.basename(folderPath),
+                label: path.basename(folderPath),
+                description: '',
                 target: folderPath,
                 directory: folderPath,
-                kind: LaunchTargetKind.MiscellaneousCS
+                kind: LaunchTargetKind.Folder
             });
         }
     });


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/47

With the effort to support Miscellaneous files in O#(https://github.com/OmniSharp/omnisharp-roslyn/pull/1252), modifying the LaunchTargets to add a folder with Misc files, if it found a cs file with no sln or csproj files