### PR TITLE
Add vitual documents with a definite scheme

### DIFF
--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -50,7 +50,7 @@ function trackFutureVirtualDocuments(server: OmniSharpServer, eventStream: Event
 }
 
 function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): boolean {
-    if (document.uri.scheme === 'file' || document.languageId !== 'csharp' || document.uri.scheme !== "virtualCSharp") {
+    if (document.uri.scheme !== "virtualCSharp" || document.languageId !== 'csharp') {
         // We're only interested in non-physical CSharp documents.
         return true;
     }

--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -50,7 +50,7 @@ function trackFutureVirtualDocuments(server: OmniSharpServer, eventStream: Event
 }
 
 function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): boolean {
-    if (document.uri.scheme === 'file' || document.languageId !== 'csharp') {
+    if (document.uri.scheme === 'file' || document.languageId !== 'csharp' || document.uri.scheme !== "virtualCSharp") {
         // We're only interested in non-physical CSharp documents.
         return true;
     }

--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -50,7 +50,7 @@ function trackFutureVirtualDocuments(server: OmniSharpServer, eventStream: Event
 }
 
 function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): boolean {
-    if (document.uri.scheme !== "virtualCSharp" || document.languageId !== 'csharp') {
+    if (document.uri.scheme.startsWith("virtualCSharp-") || document.languageId !== 'csharp') {
         // We're only interested in non-physical CSharp documents.
         return true;
     }

--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -50,7 +50,7 @@ function trackFutureVirtualDocuments(server: OmniSharpServer, eventStream: Event
 }
 
 function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): boolean {
-    if (document.uri.scheme.startsWith("virtualCSharp-") || document.languageId !== 'csharp') {
+    if (!document.uri.scheme.startsWith("virtualCSharp-") || document.languageId !== 'csharp') {
         // We're only interested in non-physical CSharp documents.
         return true;
     }

--- a/src/features/virtualDocumentTracker.ts
+++ b/src/features/virtualDocumentTracker.ts
@@ -50,7 +50,7 @@ function trackFutureVirtualDocuments(server: OmniSharpServer, eventStream: Event
 }
 
 function shouldIgnoreDocument(document: TextDocument, server: OmniSharpServer): boolean {
-    if (!document.uri.scheme.startsWith("virtualCSharp-") || document.languageId !== 'csharp') {
+    if (document.uri.scheme === "virtualCSharp-" || !document.uri.scheme.startsWith("virtualCSharp-") ||  document.languageId !== 'csharp') {
         // We're only interested in non-physical CSharp documents.
         return true;
     }

--- a/test/integrationTests/virtualDocumentTracker.integration.test.ts
+++ b/test/integrationTests/virtualDocumentTracker.integration.test.ts
@@ -15,7 +15,7 @@ chai.use(require('chai-arrays'));
 chai.use(require('chai-fs'));
 
 suite(`Virtual Document Tracking ${testAssetWorkspace.description}`, function () {
-    let virtualScheme: string = "virtual";
+    let virtualScheme: string = "virtualCSharp";
     let virtualDocumentRegistration: IDisposable;
 
     suiteSetup(async function () {

--- a/test/integrationTests/virtualDocumentTracker.integration.test.ts
+++ b/test/integrationTests/virtualDocumentTracker.integration.test.ts
@@ -15,7 +15,7 @@ chai.use(require('chai-arrays'));
 chai.use(require('chai-fs'));
 
 suite(`Virtual Document Tracking ${testAssetWorkspace.description}`, function () {
-    let virtualScheme: string = "virtualCSharp";
+    let virtualScheme: string = "virtualCSharp-test";
     let virtualDocumentRegistration: IDisposable;
 
     suiteSetup(async function () {


### PR DESCRIPTION
Fixes: #2538 

When git diff is opened we add a virtual document with the same path as the original document and when the diff is closed we are sending omnisharp a delete event from the virtualDocumentTracker that deletes the file from the workspace.

Hence to avoid virtual documents from various extensions interfering with omnisharp, the virtual document tracker will only track virtual documents that obey a specific scheme.

cc @NTaylorMullen 
