### PR TITLE
If the config looks functional return it, otherwise force VSCode to open config file

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -140,9 +140,9 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
             config = this.parseEnvFile(config.envFile.replace(/\${workspaceFolder}/g, folder.uri.path), config);
         }
 
-        // vsdbg will error check the debug configuration fields      
-        return config;
-    }   
+        // If the config looks functional return it, otherwise force VSCode to open a configuration file https://github.com/Microsoft/vscode/issues/54213
+        return config && config.type ? config : null;
+    }
 
     private static async showFileWarningAsync(message: string, fileName: string) {
         const openItem: MessageItem = { title: 'Open envFile' };


### PR DESCRIPTION
Hi VSCode dev here,

VSCode changed the functionality when to automatically open a launch.json file.
Previosuly if the return configuraiton would not have a `.type` field we would automatically open it, however we decided that the extensions must explictly request this by returning `null`. More details about the change and the motivation behind it can be found here
https://github.com/Microsoft/vscode/issues/54213

It would be great if we could merge this as soon as possible since it creates a regression, more details about it here https://github.com/Microsoft/vscode/issues/59487

fyi @gregg-miskelly @DustinCampbell @akshita31 
sorry for pinging everyone