### PR TITLE
Fix 'envFile' launch.json option on Windows

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -137,7 +137,7 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
 
         // read from envFile and set config.env
         if (config.envFile) {
-            config = this.parseEnvFile(config.envFile.replace(/\${workspaceFolder}/g, folder.uri.path), config);
+            config = this.parseEnvFile(config.envFile.replace(/\${workspaceFolder}/g, folder.uri.fsPath), config);
         }
 
         // vsdbg will error check the debug configuration fields      


### PR DESCRIPTION
The 'workspaceFolder' subsitution logic was wrong for 'envFile', which broke the feature on Windows. This fixes it.

This fixes https://github.com/OmniSharp/omnisharp-vscode/issues/2512