### PR TITLE
Initial Razor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out
 .omnisharp-*/
 .debugger
 .vscode-test
+.razor
 
 install.*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "csharp",
-  "version": "1.17.0-beta1",
+  "version": "1.17.0-beta3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2508,6 +2508,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
       "requires": {
         "pend": "1.2.0"
       }
@@ -4250,7 +4251,7 @@
         "through2": "2.0.3",
         "vinyl": "2.1.0",
         "vinyl-fs": "2.4.4",
-        "yauzl": "2.9.1",
+        "yauzl": "2.10.0",
         "yazl": "2.4.3"
       },
       "dependencies": {
@@ -5663,6 +5664,14 @@
         "regex-not": "1.0.2",
         "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
+      }
+    },
+    "microsoft.aspnetcore.razor.vscode": {
+      "version": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/84c3319bc81e794e873cb931084cb6c8/microsoft.aspnetcore.razor.vscode-1.0.0-alpha1-20181003.5.tgz",
+      "integrity": "sha512-WPwQlsWfFZBpycbBMnzx3Aa8hPYOARFgzE2uwk2rNHfi1FI7Ff1WMigslAS3OEnqrZgN2X0n9jJRjSZL3ylirg==",
+      "requires": {
+        "vscode-html-languageservice": "2.1.9",
+        "vscode-languageclient": "5.1.0"
       }
     },
     "mime": {
@@ -11620,7 +11629,7 @@
         "tmp": "0.0.29",
         "url-join": "1.1.0",
         "vso-node-api": "6.1.2-preview",
-        "yauzl": "2.9.1",
+        "yauzl": "2.10.0",
         "yazl": "2.4.3"
       },
       "dependencies": {
@@ -11699,10 +11708,60 @@
         "applicationinsights": "1.0.1"
       }
     },
+    "vscode-html-languageservice": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.9.tgz",
+      "integrity": "sha512-zHb6zqt55THIkHjywsjBqGwBr9vCOmBDh6mGyyawGi/8XH2Y6yIAH7KXTxN4Ov9A2M0CT2mwSA3tl+IKtIJtjg==",
+      "requires": {
+        "vscode-languageserver-types": "3.13.0",
+        "vscode-nls": "4.0.0",
+        "vscode-uri": "1.0.6"
+      },
+      "dependencies": {
+        "vscode-nls": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.0.0.tgz",
+          "integrity": "sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw=="
+        }
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+    },
+    "vscode-languageclient": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.0.tgz",
+      "integrity": "sha512-Z95Kps8UqD4o17HE3uCkZuvenOsxHVH46dKmaGVpGixEFZigPaVuVxLM/JWeIY9aRenoC0ZD9CK1O7L4jpffKg==",
+      "requires": {
+        "semver": "5.5.0",
+        "vscode-languageserver-protocol": "3.13.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
+      "integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+      "requires": {
+        "vscode-jsonrpc": "4.0.0",
+        "vscode-languageserver-types": "3.13.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
+      "integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+    },
     "vscode-nls": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz",
       "integrity": "sha1-gIUiOAhEuK0VNJmvXDsDkhrqAto="
+    },
+    "vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     },
     "vso-node-api": {
       "version": "6.1.2-preview",
@@ -11862,12 +11921,22 @@
       }
     },
     "yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
         "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "1.1.0"
+      },
+      "dependencies": {
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "requires": {
+            "pend": "1.2.0"
+          }
+        }
       }
     },
     "yazl": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "1.0.0",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/84c3319bc81e794e873cb931084cb6c8/microsoft.aspnetcore.razor.vscode-1.0.0-alpha1-20181003.5.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "0.0.4",
     "open": "*",
@@ -84,7 +85,7 @@
     "tmp": "0.0.33",
     "vscode-debugprotocol": "1.6.1",
     "vscode-extension-telemetry": "0.0.15",
-    "yauzl": "2.9.1"
+    "yauzl": "2.10.0"
   },
   "devDependencies": {
     "@types/archiver": "2.1.1",
@@ -268,6 +269,56 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui"
+    },
+    {
+      "description": "Razor Language Server (Windows / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/f14ac3d133fbd3ec940741c7e5ea270a/razorlanguageserver-win-x64-1.0.0-alpha1-20181003.5.zip",
+      "installPath": ".razor",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "x86_64"
+      ]
+    },
+    {
+      "description": "Razor Language Server (Windows / x86)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/2650922e18baf2470fa1e7eb3b7fcd6a/razorlanguageserver-win-x86-1.0.0-alpha1-20181003.5.zip",
+      "installPath": ".razor",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "x86"
+      ]
+    },
+    {
+      "description": "Razor Language Server (Linux / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/90ec9047fa008298d85e3abc15866818/razorlanguageserver-linux-x64-1.0.0-alpha1-20181003.5.zip",
+      "installPath": ".razor",
+      "platforms": [
+        "linux"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "description": "Razor Language Server (macOS / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/273c49f3-fc9b-4140-bc65-b47b9ac61267/ef4d3d9d01cd5cffd41095de48e466a8/razorlanguageserver-osx-x64-1.0.0-alpha1-20181003.5.zip",
+      "installPath": ".razor",
+      "platforms": [
+        "darwin"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
     }
   ],
   "engines": {
@@ -276,6 +327,7 @@
   "activationEvents": [
     "onDebug",
     "onLanguage:csharp",
+    "onLanguage:aspnetcorerazor",
     "onCommand:o.restart",
     "onCommand:o.pickProjectAndStart",
     "onCommand:o.showOutput",
@@ -602,6 +654,39 @@
           "type": "boolean",
           "default": false,
           "description": "Specifies whether notifications should be shown if OmniSharp encounters warnings or errors loading a project. Note that these warnings/errors are always emitted to the OmniSharp log"
+        },
+        "razor.disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to disable Razor language features."
+        },
+        "razor.languageServer.directory": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Overrides the path to the Razor Language Server directory."
+        },
+        "razor.languageServer.debug": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to wait for debug attach when launching the language server."
+        },
+        "razor.languageServer.trace": {
+          "type": "string",
+          "default": "Off",
+          "enum": [
+            "Off",
+            "Messages",
+            "Verbose"
+          ],
+          "enumDescriptions": [
+            "Does not log messages from Razor Language Server",
+            "Logs only some messages from Razor Language Server",
+            "Logs all messages from Razor Language Server"
+          ],
+          "description": "Specifies whether to output all messages [Verbose], some messages [Messages] or not at all [Off]."
         }
       }
     },
@@ -660,6 +745,16 @@
         "command": "csharp.reportIssue",
         "title": "Start authoring a new issue on GitHub",
         "category": "CSharp"
+      },
+      {
+        "command": "extension.showRazorCSharpWindow",
+        "title": "Show Razor CSharp",
+        "category": "Razor"
+      },
+      {
+        "command": "extension.showRazorHtmlWindow",
+        "title": "Show Razor Html",
+        "category": "Razor"
       }
     ],
     "keybindings": [
@@ -682,7 +777,8 @@
         "enableBreakpointsFor": {
           "languageIds": [
             "csharp",
-            "razor"
+            "razor",
+            "aspnetcorerazor"
           ]
         },
         "variables": {
@@ -1749,7 +1845,8 @@
         "enableBreakpointsFor": {
           "languageIds": [
             "csharp",
-            "razor"
+            "razor",
+            "aspnetcorerazor"
           ]
         },
         "variables": {
@@ -2712,6 +2809,37 @@
           }
         }
       }
-    ]
+    ],
+    "languages": [
+      {
+        "id": "aspnetcorerazor",
+        "extensions": [
+          ".cshtml"
+        ],
+        "mimetypes": [
+          "text/x-cshtml"
+        ],
+        "configuration": "./src/razor/language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "aspnetcorerazor",
+        "scopeName": "text.aspnetcorerazor",
+        "path": "./src/razor/syntaxes/aspnetcorerazor.tmLanguage.json"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "extension.showRazorCSharpWindow",
+          "when": "resourceLangId == aspnetcorerazor"
+        },
+        {
+          "command": "extension.showRazorHtmlWindow",
+          "when": "resourceLangId == aspnetcorerazor"
+        }
+      ]
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { ShowOmniSharpConfigChangePrompt } from './observers/OptionChangeObserve
 import createOptionStream from './observables/CreateOptionStream';
 import { CSharpExtensionId } from './constants/CSharpExtensionId';
 import { OpenURLObserver } from './observers/OpenURLObserver';
+import { activateRazorExtension } from './razor/razor';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -132,6 +133,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     if (runtimeDependenciesExist) {
         // activate coreclr-debug
         coreClrDebugPromise = coreclrdebug.activate(extension, context, platformInfo, eventStream);
+    }
+
+    if (!optionProvider.GetLatestOptions().razorDisabled) {
+        await activateRazorExtension(context, extension.extensionPath, eventStream);
     }
 
     return {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -23,7 +23,8 @@ export class Options {
         public minFindSymbolsFilterLength: number,
         public maxFindSymbolsItems: number,
         public defaultLaunchSolution?: string,
-        public monoPath?: string) { }
+        public monoPath?: string,
+        public razorDisabled?: boolean) { }
 
 
     public static Read(vscode: vscode): Options {
@@ -36,6 +37,7 @@ export class Options {
 
         const omnisharpConfig = vscode.workspace.getConfiguration('omnisharp');
         const csharpConfig = vscode.workspace.getConfiguration('csharp');
+        const razorConfig = vscode.workspace.getConfiguration('razor');
 
         const path = Options.readPathOption(csharpConfig, omnisharpConfig);
         const useGlobalMono = Options.readUseGlobalMonoOption(omnisharpConfig, csharpConfig);
@@ -68,6 +70,8 @@ export class Options {
         const minFindSymbolsFilterLength = omnisharpConfig.get<number>('minFindSymbolsFilterLength', 0);
         const maxFindSymbolsItems = omnisharpConfig.get<number>('maxFindSymbolsItems', 1000);   // The limit is applied only when this setting is set to a number greater than zero
 
+        const razorDisabled = !!razorConfig && razorConfig.get<boolean>('disabled', false);
+
         return new Options(
             path, 
             useGlobalMono, 
@@ -86,6 +90,7 @@ export class Options {
             maxFindSymbolsItems,
             defaultLaunchSolution,
             monoPath,
+            razorDisabled
         );
     }
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from 'fs';
 import * as path from 'path';
 import * as protocol from './protocol';
 import * as utils from '../common';
@@ -93,7 +94,7 @@ export class OmniSharpServer {
     private updateProjectDebouncer = new Subject<ObservableEvents.ProjectModified>();
     private firstUpdateProject: boolean;
 
-    constructor(private vscode: vscode, networkSettingsProvider: NetworkSettingsProvider, private packageJSON: any, private platformInfo: PlatformInformation, private eventStream: EventStream, private optionProvider: OptionProvider, extensionPath: string, private monoResolver: IMonoResolver) {
+    constructor(private vscode: vscode, networkSettingsProvider: NetworkSettingsProvider, private packageJSON: any, private platformInfo: PlatformInformation, private eventStream: EventStream, private optionProvider: OptionProvider, private extensionPath: string, private monoResolver: IMonoResolver) {
         this._requestQueue = new RequestQueueCollection(this.eventStream, 8, request => this._makeRequest(request));
         let downloader = new OmnisharpDownloader(networkSettingsProvider, this.eventStream, this.packageJSON, platformInfo, extensionPath);
         this._omnisharpManager = new OmnisharpManager(downloader, platformInfo);
@@ -304,14 +305,25 @@ export class OmniSharpServer {
             '--loglevel', options.loggingLevel
         ];
 
+        if (!options.razorDisabled) {
+            // Razor support only exists for certain platforms, so only load the plugin if present
+            const razorPluginPath = path.join(
+                this.extensionPath,
+                '.razor',
+                'OmniSharpPlugin',
+                'Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll');
+            if (fs.existsSync(razorPluginPath)) {
+                args.push('--plugin', razorPluginPath);
+            }
+        }
+
         if (options.waitForDebugger === true) {
             args.push('--debug');
         }
 
         let launchInfo: LaunchInfo;
         try {
-            let extensionPath = utils.getExtensionPath();
-            launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this.packageJSON.defaults.omniSharp, options.path, serverUrl, latestVersionFileServerPath, installPath, extensionPath);
+            launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this.packageJSON.defaults.omniSharp, options.path, serverUrl, latestVersionFileServerPath, installPath, this.extensionPath);
         }
         catch (error) {
             this.eventStream.post(new ObservableEvents.OmnisharpFailure(`Error occured in loading omnisharp from omnisharp.path\nCould not start the server due to ${error.toString()}`, error));

--- a/src/razor/language-configuration.json
+++ b/src/razor/language-configuration.json
@@ -1,0 +1,23 @@
+{
+	"comments": {
+		"blockComment": [ "<!--", "-->" ]
+	},
+	"brackets": [
+		["<!--", "-->"],
+		["<", ">"],
+		["{", "}"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" }
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "<", "close": ">" }
+	]
+}

--- a/src/razor/razor.ts
+++ b/src/razor/razor.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as Razor from 'microsoft.aspnetcore.razor.vscode';
+import { EventStream } from '../EventStream';
+
+export async function activateRazorExtension(context: vscode.ExtensionContext, extensionPath: string, eventStream: EventStream) {
+    const razorConfig = vscode.workspace.getConfiguration('razor');
+    const configuredLanguageServerDir = razorConfig.get<string>('languageServer.directory', null);
+    const languageServerDir = configuredLanguageServerDir || path.join(extensionPath, '.razor');
+
+    if (fs.existsSync(languageServerDir)) {
+        await Razor.activate(context, languageServerDir, eventStream);
+    } else if (configuredLanguageServerDir) {
+        // It's only an error if the nonexistent dir was explicitly configured
+        // If it's the default dir, this is expected for unsupported platforms
+        vscode.window.showErrorMessage(
+            `Cannot load Razor language server because the configured directory was not found: '${languageServerDir}'`);
+    }
+}

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -1,0 +1,9 @@
+{
+	"name": "ASP.NET Core Razor",
+	"scopeName": "text.aspnetcorerazor",
+	"patterns": [
+		{
+			"include": "text.html.cshtml"
+		}
+	]
+}


### PR DESCRIPTION
This is identical to the earlier PR (#2554) that was merged then reverted, except that in `package.json`, the dependency URLs have been updated to ones we are ready to be used for the initial preview.