### PR TITLE
Add url in the download failure

### DIFF
--- a/src/packageManager/FileDownloader.ts
+++ b/src/packageManager/FileDownloader.ts
@@ -12,7 +12,7 @@ import { parse as parseUrl } from 'url';
 import { getProxyAgent } from './proxy';
 import { NetworkSettingsProvider } from '../NetworkSettings';
 
-export async function DownloadFile(description: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider, url: string, fallbackUrl?: string) {
+export async function DownloadFile(description: string, eventStream: EventStream, networkSettingsProvider: NetworkSettingsProvider, url: string, fallbackUrl?: string): Promise<Buffer> {
     eventStream.post(new DownloadStart(description));
 
     try {
@@ -65,7 +65,7 @@ async function downloadFile(description: string, urlString: string, eventStream:
 
             else if (response.statusCode != 200) {
                 // Download failed - print error message
-                eventStream.post(new DownloadFailure(`failed (error code '${response.statusCode}')`));
+                eventStream.post(new DownloadFailure(`Failed to download from ${url}. Error code '${response.statusCode}')`));
                 return reject(new NestedError(response.statusCode.toString()));
             }
 
@@ -93,7 +93,7 @@ async function downloadFile(description: string, urlString: string, eventStream:
             });
 
             response.on('error', err => {
-                reject(new NestedError(`Failed to download from ${urlString}. Error Message: ${err.message} || 'NONE'}`, err)); 
+                reject(new NestedError(`Failed to download from ${urlString}. Error Message: ${err.message} || 'NONE'}`, err));
             });
         });
 

--- a/src/packageManager/FileDownloader.ts
+++ b/src/packageManager/FileDownloader.ts
@@ -65,7 +65,7 @@ async function downloadFile(description: string, urlString: string, eventStream:
 
             else if (response.statusCode != 200) {
                 // Download failed - print error message
-                eventStream.post(new DownloadFailure(`Failed to download from ${url}. Error code '${response.statusCode}')`));
+                eventStream.post(new DownloadFailure(`Failed to download from ${urlString}. Error code '${response.statusCode}')`));
                 return reject(new NestedError(response.statusCode.toString()));
             }
 

--- a/test/unitTests/Packages/FileDownloader.test.ts
+++ b/test/unitTests/Packages/FileDownloader.test.ts
@@ -34,7 +34,7 @@ suite("FileDownloader", () => {
     const getFallBackURLEvents = () => {
         return [
             new DownloadStart(fileDescription),
-            new DownloadFailure("failed (error code '404')"),
+            new DownloadFailure(`Failed to download from ${server.baseUrl}${errorUrlPath}. Error code '404')`),
             new DownloadFallBack(`${server.baseUrl}${correctUrlPath}`),
             new DownloadSizeObtained(12),
             new DownloadProgress(100, fileDescription),
@@ -99,7 +99,7 @@ suite("FileDownloader", () => {
         test('Download Start and Download Failure events are created', async () => {
             let eventsSequence = [
                 new DownloadStart(fileDescription),
-                new DownloadFailure("failed (error code '404')")
+                new DownloadFailure(`Failed to download from ${server.baseUrl}${errorUrlPath}. Error code '404')`)
             ];
             try {
                 await DownloadFile(fileDescription, eventStream, networkSettingsProvider, getURL(errorUrlPath));


### PR DESCRIPTION
Related issue: #2519 

When the download fails from a url, we should display the url for them so that they can go ahead and download the packages manually.