### PR TITLE
Update Razor configurations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -655,6 +655,19 @@
           "default": false,
           "description": "Specifies whether notifications should be shown if OmniSharp encounters warnings or errors loading a project. Note that these warnings/errors are always emitted to the OmniSharp log"
         },
+        "razor.plugin.path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Overrides the path to the Razor plugin dll."
+        },
+        "razor.devmode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Forces the omnisharp-vscode extension to run in a mode that enables local Razor.VSCode deving."
+        },
         "razor.disabled": {
           "type": "boolean",
           "default": false,
@@ -673,7 +686,7 @@
           "default": false,
           "description": "Specifies whether to wait for debug attach when launching the language server."
         },
-        "razor.languageServer.trace": {
+        "razor.trace": {
           "type": "string",
           "default": "Off",
           "enum": [
@@ -682,9 +695,9 @@
             "Verbose"
           ],
           "enumDescriptions": [
-            "Does not log messages from Razor Language Server",
-            "Logs only some messages from Razor Language Server",
-            "Logs all messages from Razor Language Server"
+            "Does not log messages from the Razor extension",
+            "Logs only some messages from the Razor extension",
+            "Logs all messages from the Razor extension"
           ],
           "description": "Specifies whether to output all messages [Verbose], some messages [Messages] or not at all [Off]."
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import createOptionStream from './observables/CreateOptionStream';
 import { CSharpExtensionId } from './constants/CSharpExtensionId';
 import { OpenURLObserver } from './observers/OpenURLObserver';
 import { activateRazorExtension } from './razor/razor';
+import { RazorLoggerObserver } from './observers/RazorLoggerObserver';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -136,7 +137,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     }
 
     if (!optionProvider.GetLatestOptions().razorDisabled) {
-        await activateRazorExtension(context, extension.extensionPath, eventStream);
+        const razorObserver = new RazorLoggerObserver(omnisharpChannel);
+        eventStream.subscribe(razorObserver.post);
+
+        if (!optionProvider.GetLatestOptions().razorDevMode) {
+            await activateRazorExtension(context, extension.extensionPath, eventStream);
+        }
     }
 
     return {

--- a/src/observers/RazorLoggerObserver.ts
+++ b/src/observers/RazorLoggerObserver.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BaseLoggerObserver } from "./BaseLoggerObserver";
+import { RazorPluginPathSpecified, BaseEvent, RazorPluginPathDoesNotExist, RazorDevModeActive } from "../omnisharp/loggingEvents";
+
+export class RazorLoggerObserver extends BaseLoggerObserver {
+    public post = (event: BaseEvent) => {
+        switch (event.constructor.name) {
+            case RazorPluginPathSpecified.name:
+                this.handleRazorPluginPathSpecifiedMessage(<RazorPluginPathSpecified>event);
+                break;
+            case RazorPluginPathDoesNotExist.name:
+                this.handleRazorPluginPathDoesNotExistMessage(<RazorPluginPathDoesNotExist>event);
+                break;
+            case RazorDevModeActive.name:
+                this.handleRazorDevMode();
+                break;
+        }
+    }
+
+    private handleRazorPluginPathSpecifiedMessage(event: RazorPluginPathSpecified) {
+        this.logger.appendLine('Razor Plugin Path Specified');
+        this.logger.increaseIndent();
+        this.logger.appendLine(`Path: ${event.path}`);
+        this.logger.decreaseIndent();
+        this.logger.appendLine();
+    }
+
+    private handleRazorPluginPathDoesNotExistMessage(event: RazorPluginPathSpecified) {
+        this.logger.appendLine(`[error]: Razor plugin path was specified as '${event.path}' but does not exist on disk.`);
+    }
+
+    private handleRazorDevMode() {
+        this.logger.appendLine('Razor dev mode active. Suppressing built-in OmniSharp Razor support.');
+        this.logger.appendLine();
+    }
+}

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -28,7 +28,7 @@ import WorkspaceSymbolProvider from '../features/workspaceSymbolProvider';
 import forwardChanges from '../features/changeForwarding';
 import registerCommands from '../features/commands';
 import { PlatformInformation } from '../platform';
-import { ProjectJsonDeprecatedWarning, OmnisharpStart } from './loggingEvents';
+import { ProjectJsonDeprecatedWarning, OmnisharpStart, RazorDevModeActive } from './loggingEvents';
 import { EventStream } from '../EventStream';
 import { NetworkSettingsProvider } from '../NetworkSettings';
 import CompositeDisposable from '../CompositeDisposable';
@@ -152,8 +152,14 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
             });
     }));
 
-    // read and store last solution or folder path
-    disposables.add(server.onBeforeServerStart(path => context.workspaceState.update('lastSolutionPathOrFolder', path)));
+    disposables.add(server.onBeforeServerStart(path => {
+        if (options.razorDevMode) {
+            eventStream.post(new RazorDevModeActive());
+        }
+
+        // read and store last solution or folder path
+        context.workspaceState.update('lastSolutionPathOrFolder', path);
+    }));
 
     if (options.autoStart) {
         server.autoStart(context.workspaceState.get<string>('lastSolutionPathOrFolder'));

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -158,6 +158,14 @@ export class OpenURL {
     constructor(public url: string) { }
 }
 
+export class RazorPluginPathSpecified implements BaseEvent {
+    constructor(public path: string) {}
+}
+
+export class RazorPluginPathDoesNotExist implements BaseEvent {
+    constructor(public path: string) {}
+}
+
 export class DebuggerPrerequisiteFailure extends EventWithMessage { }
 export class DebuggerPrerequisiteWarning extends EventWithMessage { }
 export class CommandDotNetRestoreProgress extends EventWithMessage { }
@@ -173,6 +181,7 @@ export class DotNetTestRunFailure extends EventWithMessage { }
 export class DotNetTestDebugWarning extends EventWithMessage { }
 export class DotNetTestDebugStartFailure extends EventWithMessage { }
 
+export class RazorDevModeActive implements BaseEvent { }
 export class ProjectModified implements BaseEvent { }
 export class ActivationFailure implements BaseEvent { }
 export class ShowOmniSharpChannel implements BaseEvent { }

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -22,9 +22,11 @@ export class Options {
         public disableMSBuildDiagnosticWarning: boolean,
         public minFindSymbolsFilterLength: number,
         public maxFindSymbolsItems: number,
+        public razorDisabled: boolean,
+        public razorDevMode: boolean,
+        public razorPluginPath?: string,
         public defaultLaunchSolution?: string,
-        public monoPath?: string,
-        public razorDisabled?: boolean) { }
+        public monoPath?: string) { }
 
 
     public static Read(vscode: vscode): Options {
@@ -71,6 +73,8 @@ export class Options {
         const maxFindSymbolsItems = omnisharpConfig.get<number>('maxFindSymbolsItems', 1000);   // The limit is applied only when this setting is set to a number greater than zero
 
         const razorDisabled = !!razorConfig && razorConfig.get<boolean>('disabled', false);
+        const razorDevMode = !!razorConfig && razorConfig.get<boolean>('devmode', false);
+        const razorPluginPath = razorConfig ? razorConfig.get<string>('plugin.path', undefined) : undefined;
 
         return new Options(
             path, 
@@ -88,9 +92,11 @@ export class Options {
             disableMSBuildDiagnosticWarning,
             minFindSymbolsFilterLength,
             maxFindSymbolsItems,
+            razorDisabled,
+            razorDevMode,
+            razorPluginPath,
             defaultLaunchSolution,
             monoPath,
-            razorDisabled
         );
     }
 

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, undefined, "", "");
 }

--- a/test/unitTests/logging/RazorLoggerObserver.test.ts
+++ b/test/unitTests/logging/RazorLoggerObserver.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { use, should, expect } from 'chai';
+import { getNullChannel } from '../testAssets/Fakes';
+import { RazorLoggerObserver } from '../../../src/observers/RazorLoggerObserver';
+import { RazorPluginPathSpecified, RazorPluginPathDoesNotExist, RazorDevModeActive } from '../../../src/omnisharp/loggingEvents';
+
+use(require("chai-string"));
+
+suite("RazorLoggerObserver", () => {
+    suiteSetup(() => should());
+    let logOutput = "";
+    let observer = new RazorLoggerObserver({
+        ...getNullChannel(),
+        append: (text: string) => { logOutput += text; },
+    });
+
+    setup(() => {
+        logOutput = "";
+    });
+
+    test(`RazorPluginPathSpecified: Path is logged`, () => {
+        let event = new RazorPluginPathSpecified("somePath");
+        observer.post(event);
+        expect(logOutput).to.contain(event.path);
+    });
+
+    test(`RazorPluginPathDoesNotExist: Path is logged`, () => {
+        let event = new RazorPluginPathDoesNotExist("somePath");
+        observer.post(event);
+        expect(logOutput).to.contain(event.path);
+    });
+
+    test(`RazorDevModeActive: Logs dev mode active`, () => {
+        let event = new RazorDevModeActive();
+        observer.post(event);
+        expect(logOutput).to.contain('Razor dev mode active');
+    });
+});


### PR DESCRIPTION
- Added a `razor.devmode` configuration that suppresses the default Razor attachment to `aspnetcorerazor` documents. This is required to properly run the https://github.com/aspnet/Razor.VSCode extension in a dev environment.
- Added a `razor.plugin.path` configuration to enable easy debugging and deving of the Razor plugin.
- Changed `razor.languageServer.trace` to `razor.trace` since the configuration controls both the client and server log levels of the Razor component.
- Added a `RazorLoggerObserver` that understands users setting `razor.devmode` and the `razor.plugin.path`.
- Added `RazorLoggerObserver.test` to verify the 3 added logging events.

aspnet/Razor.VSCode#190
aspnet/Razor.VSCode#189

@rchande @akshita31 @SteveSandersonMS 