### PR TITLE
Do not send a symbol search request to OmniSharp if search term is shorter than "omnisharp.minFindSymbolsFilterLength" 

### DIFF
--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -23,10 +23,15 @@ export default class OmnisharpWorkspaceSymbolProvider extends AbstractSupport im
         let options = this.optionProvider.GetLatestOptions();
         let minFilterLength = options.minFindSymbolsFilterLength > 0 ? options.minFindSymbolsFilterLength : undefined;
         let maxItemsToReturn = options.maxFindSymbolsItems > 0 ? options.maxFindSymbolsItems : undefined;
-        return serverUtils.findSymbols(this._server, { Filter: search, MinFilterLength: minFilterLength, MaxItemsToReturn: maxItemsToReturn, FileName: '' }, token).then(res => {
+
+        if (minFilterLength != undefined && search.length < minFilterLength) {
+            return [];
+        }
+
+        return serverUtils.findSymbols(this._server, { Filter: search, MaxItemsToReturn: maxItemsToReturn, FileName: '' }, token).then(res => {
             if (res && Array.isArray(res.QuickFixes)) {
                 return res.QuickFixes.map(OmnisharpWorkspaceSymbolProvider._asSymbolInformation);
-            }
+            } 
         });
     }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -128,7 +128,6 @@ export interface FindUsagesRequest extends Request {
 
 export interface FindSymbolsRequest extends Request {
     Filter: string;
-    MinFilterLength?: number;
     MaxItemsToReturn?: number;
 }
 

--- a/test/integrationTests/workspaceSymbolProvider.integration.test.ts
+++ b/test/integrationTests/workspaceSymbolProvider.integration.test.ts
@@ -13,7 +13,7 @@ const chai = require('chai');
 chai.use(require('chai-arrays'));
 chai.use(require('chai-fs'));
 
-suite(`DocumentSymbolProvider: ${testAssetWorkspace.description}`, function () {
+suite(`WorkspaceSymbolProvider: ${testAssetWorkspace.description}`, function () {
 
     suiteSetup(async function () {
         should();
@@ -32,11 +32,27 @@ suite(`DocumentSymbolProvider: ${testAssetWorkspace.description}`, function () {
     });
 
     test("Returns elements", async function () {
-        let symbols = await GetWorkspaceSymbols();
+        let symbols = await GetWorkspaceSymbols("P");
+        expect(symbols.length).to.be.greaterThan(0);
+    });
+
+    test("Returns no elements when minimum filter length is configured and search term is shorter", async function () {
+        let omnisharpConfig = vscode.workspace.getConfiguration('omnisharp');
+        await omnisharpConfig.update('minFindSymbolsFilterLength', 2);
+
+        let symbols = await GetWorkspaceSymbols("P");
+        expect(symbols.length).to.be.equal(0);
+    });
+
+    test("Returns elements when minimum filter length is configured and search term is longer or equal", async function () {
+        let omnisharpConfig = vscode.workspace.getConfiguration('omnisharp');
+        await omnisharpConfig.update('minFindSymbolsFilterLength', 2);
+
+        let symbols = await GetWorkspaceSymbols("P1");
         expect(symbols.length).to.be.greaterThan(0);
     });
 });
 
-async function GetWorkspaceSymbols() {
-    return <vscode.SymbolInformation[]>await vscode.commands.executeCommand("vscode.executeWorkspaceSymbolProvider");
+async function GetWorkspaceSymbols(filter: string) {
+    return <vscode.SymbolInformation[]>await vscode.commands.executeCommand("vscode.executeWorkspaceSymbolProvider", filter);
 }

--- a/test/integrationTests/workspaceSymbolProvider.integration.test.ts
+++ b/test/integrationTests/workspaceSymbolProvider.integration.test.ts
@@ -3,7 +3,6 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information. 
 *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { should, expect } from 'chai';
 import { activateCSharpExtension } from './integrationHelpers';
@@ -20,11 +19,8 @@ suite(`WorkspaceSymbolProvider: ${testAssetWorkspace.description}`, function () 
         await testAssetWorkspace.restore();
         await activateCSharpExtension();
 
-        let fileName = 'documentSymbols.cs';
-        let projectDirectory = testAssetWorkspace.projects[0].projectDirectoryPath;
-        let filePath = path.join(projectDirectory, fileName);
-        let fileUri = vscode.Uri.file(filePath);
-        await vscode.commands.executeCommand("vscode.open", fileUri);
+        let projectDirectory = vscode.Uri.file(testAssetWorkspace.projects[0].projectDirectoryPath);
+        await vscode.commands.executeCommand("vscode.openFolder", projectDirectory);
     });
 
     suiteTeardown(async () => {

--- a/test/integrationTests/workspaceSymbolProvider.integration.tests.ts
+++ b/test/integrationTests/workspaceSymbolProvider.integration.tests.ts
@@ -1,0 +1,42 @@
+/*--------------------------------------------------------------------------------------------- 
+*  Copyright (c) Microsoft Corporation. All rights reserved. 
+*  Licensed under the MIT License. See License.txt in the project root for license information. 
+*--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { should, expect } from 'chai';
+import { activateCSharpExtension } from './integrationHelpers';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+
+const chai = require('chai');
+chai.use(require('chai-arrays'));
+chai.use(require('chai-fs'));
+
+suite(`DocumentSymbolProvider: ${testAssetWorkspace.description}`, function () {
+
+    suiteSetup(async function () {
+        should();
+        await testAssetWorkspace.restore();
+        await activateCSharpExtension();
+
+        let fileName = 'documentSymbols.cs';
+        let projectDirectory = testAssetWorkspace.projects[0].projectDirectoryPath;
+        let filePath = path.join(projectDirectory, fileName);
+        let fileUri = vscode.Uri.file(filePath);
+        await vscode.commands.executeCommand("vscode.open", fileUri);
+    });
+
+    suiteTeardown(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test("Returns elements", async function () {
+        let symbols = await GetWorkspaceSymbols();
+        expect(symbols.length).to.be.greaterThan(0);
+    });
+});
+
+async function GetWorkspaceSymbols() {
+    return <vscode.SymbolInformation[]>await vscode.commands.executeCommand("vscode.executeWorkspaceSymbolProvider");
+}


### PR DESCRIPTION
Instead of doing the validation on the server, we do it on the client.