### PR TITLE
fixed the integration tests/debugging warnings raised from configuration

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -450,7 +450,7 @@ async function addLaunchJsonIfNecessary(generator: AssetGenerator, operations: O
         }
 
         // Read existing launch configuration
-        const launchConfigs = vscode.workspace.getConfiguration('launch');
+        const launchConfigs = vscode.workspace.getConfiguration('launch', null);
         let existingLaunchConfigs = launchConfigs.get<{}[]>('configurations');
 
         const isWebProject = generator.hasWebServerDependency();

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -243,8 +243,8 @@ export async function launchOmniSharp(cwd: string, args: string[], launchInfo: L
 
 async function launch(cwd: string, args: string[], launchInfo: LaunchInfo, platformInfo: PlatformInformation, options: Options, monoResolver: IMonoResolver): Promise<LaunchResult> {
     if (options.useEditorFormattingSettings) {
-        let globalConfig = vscode.workspace.getConfiguration();
-        let csharpConfig = vscode.workspace.getConfiguration('[csharp]');
+        let globalConfig = vscode.workspace.getConfiguration('', null);
+        let csharpConfig = vscode.workspace.getConfiguration('[csharp]', null);
 
         args.push(`formattingOptions:useTabs=${!getConfigurationValue(globalConfig, csharpConfig, 'editor.insertSpaces', true)}`);
         args.push(`formattingOptions:tabSize=${getConfigurationValue(globalConfig, csharpConfig, 'editor.tabSize', 4)}`);


### PR DESCRIPTION
Fixes these warnings:

```
[ms-vscode.csharp] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for '[csharp]', provide the URI of a resource or 'null' for any resource.
[ms-vscode.csharp] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'editor.insertSpaces', provide the URI of a resource or 'null' for any resource.
[ms-vscode.csharp] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'editor.tabSize', provide the URI of a resource or 'null' for any resource.
[ms-vscode.csharp] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'editor.tabSize', provide the URI of a resource or 'null' for any resource.
```