### PR TITLE
use displayName in documentSymbolProvider

### DIFF
--- a/src/features/documentSymbolProvider.ts
+++ b/src/features/documentSymbolProvider.ts
@@ -45,7 +45,7 @@ function createSymbolForElement(element: Structure.CodeElement): vscode.Document
     const fullRange = element.Ranges[SymbolRangeNames.Full];
     const nameRange = element.Ranges[SymbolRangeNames.Name];
 
-    return new vscode.DocumentSymbol(element.Name, /*detail*/ "", toSymbolKind(element.Kind), toRange3(fullRange), toRange3(nameRange));
+    return new vscode.DocumentSymbol(element.DisplayName, /*detail*/ "", toSymbolKind(element.Kind), toRange3(fullRange), toRange3(nameRange));
 }
 
 const kinds: { [kind: string]: vscode.SymbolKind; } = { };


### PR DESCRIPTION
Fixes #2684 

OmniSharp exposes `displayName` along the `name` https://github.com/OmniSharp/omnisharp-roslyn/blob/v1.32.8/src/OmniSharp.Roslyn.CSharp/Services/Structure/CodeStructureService.cs#L227

