### PR TITLE
Stop activating the C# extension on all debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.17.1",
+  "version": "1.18.0-beta1",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -325,7 +325,9 @@
     "vscode": "^1.28.0"
   },
   "activationEvents": [
-    "onDebug",
+    "onDebugInitialConfigurations",
+    "onDebugResolve:coreclr",
+    "onDebugResolve:clr",
     "onLanguage:csharp",
     "onLanguage:aspnetcorerazor",
     "onCommand:o.restart",


### PR DESCRIPTION
This updates the C# extension to activate only on debugging operations that involve C# scenarios.

Testing:
* Verified that C# launch.json templates are correctly shown and work when attempt to start debugging from an empty folder
* Verified that we can start debugging with a work space folder that contains no C# files

This fixes #2658