### PR TITLE
Do not show the channel unless there is a package download

### DIFF
--- a/src/observers/CsharpChannelObserver.ts
+++ b/src/observers/CsharpChannelObserver.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent, InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, DownloadStart } from "../omnisharp/loggingEvents";
+import { BaseEvent, InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, PackageInstallStart } from "../omnisharp/loggingEvents";
 
 export class CsharpChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
-            case DownloadStart.name:
+            case PackageInstallStart.name:
             case InstallationFailure.name:
             case DebuggerNotInstalledFailure.name:
             case DebuggerPrerequisiteFailure.name:

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -34,6 +34,10 @@ export class OmnisharpLaunch implements BaseEvent {
     constructor(public monoVersion: string, public monoPath: string, public command: string, public pid: number) { }
 }
 
+export class PackageInstallStart implements BaseEvent {
+    constructor() { }
+}
+
 export class PackageInstallation implements BaseEvent {
     constructor(public packageInfo: string) { }
 }

--- a/src/packageManager/PackageManager.ts
+++ b/src/packageManager/PackageManager.ts
@@ -13,6 +13,7 @@ import { EventStream } from '../EventStream';
 import { NetworkSettingsProvider } from "../NetworkSettings";
 import { filterPackages } from "./PackageFilterer";
 import { AbsolutePathPackage } from "./AbsolutePathPackage";
+import { PackageInstallStart } from "../omnisharp/loggingEvents";
 
 export async function DownloadAndInstallPackages(packages: Package[], provider: NetworkSettingsProvider, platformInfo: PlatformInformation, eventStream: EventStream, extensionPath: string) {
     let absolutePathPackages = packages.map(pkg => AbsolutePathPackage.getAbsolutePathPackage(pkg, extensionPath));
@@ -20,6 +21,7 @@ export async function DownloadAndInstallPackages(packages: Package[], provider: 
     if (filteredPackages) {
         for (let pkg of filteredPackages) {
             try {
+                eventStream.post(new PackageInstallStart());
                 let buffer = await DownloadFile(pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
                 await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
             }

--- a/test/unitTests/OmnisharpDownloader.test.ts
+++ b/test/unitTests/OmnisharpDownloader.test.ts
@@ -14,7 +14,7 @@ import MockHttpsServer from "./testAssets/MockHttpsServer";
 import {expect} from 'chai';
 import TestZip from "./testAssets/TestZip";
 import { createTestFile } from "./testAssets/TestFile";
-import { PackageInstallation, LogPlatformInfo, DownloadStart, DownloadSizeObtained, DownloadProgress, DownloadSuccess, InstallationStart, InstallationSuccess } from "../../src/omnisharp/loggingEvents";
+import { PackageInstallation, LogPlatformInfo, DownloadStart, DownloadSizeObtained, DownloadProgress, DownloadSuccess, InstallationStart, InstallationSuccess, PackageInstallStart } from "../../src/omnisharp/loggingEvents";
 import TestEventBus from "./testAssets/TestEventBus";
 import { testPackageJSON } from "./testAssets/testAssets";
 
@@ -62,6 +62,7 @@ suite('OmnisharpDownloader', () => {
         let expectedSequence = [ 
             new PackageInstallation('OmniSharp Version = 1.2.3'), 
             new LogPlatformInfo(new PlatformInformation("win32", "x86")), 
+            new PackageInstallStart(),
             new DownloadStart('OmniSharp for Windows (.NET 4.6 / x86), Version = 1.2.3'), 
             new DownloadSizeObtained(testZip.size), 
             new DownloadProgress(100, 'OmniSharp for Windows (.NET 4.6 / x86), Version = 1.2.3'), 

--- a/test/unitTests/Packages/PackageManager.test.ts
+++ b/test/unitTests/Packages/PackageManager.test.ts
@@ -13,7 +13,7 @@ import { DownloadAndInstallPackages } from '../../../src/packageManager/PackageM
 import NetworkSettings from '../../../src/NetworkSettings';
 import { PlatformInformation } from '../../../src/platform';
 import { EventStream } from '../../../src/EventStream';
-import { DownloadStart, DownloadSizeObtained, DownloadProgress, DownloadSuccess, InstallationStart } from '../../../src/omnisharp/loggingEvents';
+import { DownloadStart, DownloadSizeObtained, DownloadProgress, DownloadSuccess, InstallationStart, PackageInstallStart } from '../../../src/omnisharp/loggingEvents';
 import MockHttpsServer from '../testAssets/MockHttpsServer';
 import { createTestFile } from '../testAssets/TestFile';
 import TestEventBus from '../testAssets/TestEventBus';
@@ -70,6 +70,7 @@ suite("Package Manager", () => {
 
     test("Events are created in the correct order", async () => {
         let eventsSequence = [
+            new PackageInstallStart(),
             new DownloadStart(packageDescription),
             new DownloadSizeObtained(testZip.size),
             new DownloadProgress(100, packageDescription),

--- a/test/unitTests/logging/CsharpChannelObserver.test.ts
+++ b/test/unitTests/logging/CsharpChannelObserver.test.ts
@@ -6,13 +6,13 @@
 import { should, expect } from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
 import { CsharpChannelObserver } from '../../../src/observers/CsharpChannelObserver';
-import { InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, BaseEvent, DownloadStart } from '../../../src/omnisharp/loggingEvents';
+import { InstallationFailure, DebuggerNotInstalledFailure, DebuggerPrerequisiteFailure, ProjectJsonDeprecatedWarning, BaseEvent, PackageInstallStart } from '../../../src/omnisharp/loggingEvents';
 
 suite("CsharpChannelObserver", () => {
     suiteSetup(() => should());
     [
         new InstallationFailure("someStage", "someError"),
-        new DownloadStart("somePackage"),
+        new PackageInstallStart(),
         new DebuggerNotInstalledFailure(),
         new DebuggerPrerequisiteFailure("some failure"),
         new ProjectJsonDeprecatedWarning()


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/2176

Often times when the user has set the path to "latest", the C# channel is shown inspite of the fact that there is no actual package download. This leads to annoying experince when the user starts typing something in the console and all of a sudden the channel is shown. We should show the channel when we are downloading an actual package and not show it everytime we download the "latest" information file.


Hence I created an event called "PackageInstallStart" and the C# channel will be shown if this event is triggered and not be shown when only the "latest" file is downloaded and since the package is already present, no actual download of the omnisharp package occurs.