### PR TITLE
Fix project detection to handle many CS files

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -37,16 +37,22 @@ export interface LaunchTarget {
  * (if it doesn't contain a `project.json` file, but `project.json` files exist). In addition, the root folder
  * is included if there are any `*.csproj` files present, but a `*.sln* file is not found.
  */
-export function findLaunchTargets(options: Options): Thenable<LaunchTarget[]> {
+export async function findLaunchTargets(options: Options): Promise<LaunchTarget[]> {
     if (!vscode.workspace.workspaceFolders) {
         return Promise.resolve([]);
     }
 
-    return vscode.workspace.findFiles(
-            /*include*/ '{**/*.sln,**/*.csproj,**/project.json,**/*.csx,**/*.cake,**/*.cs}',
-            /*exclude*/ '{**/node_modules/**,**/.git/**,**/bower_components/**}',
-            /*maxResults*/ options.maxProjectResults)
-        .then(resourcesToLaunchTargets);
+    const projectFiles = await vscode.workspace.findFiles(
+        /*include*/ '{**/*.sln,**/*.csproj,**/project.json,**/*.csx,**/*.cake}',
+        /*exclude*/ '{**/node_modules/**,**/.git/**,**/bower_components/**}',
+        /*maxResults*/ options.maxProjectResults);
+
+    const csFiles = await vscode.workspace.findFiles(
+        /*include*/ '{**/*.cs}',
+        /*exclude*/ '{**/node_modules/**,**/.git/**,**/bower_components/**}',
+        /*maxResults*/ options.maxProjectResults);
+
+    return resourcesToLaunchTargets(projectFiles.concat(csFiles));
 }
 
 function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[] {


### PR DESCRIPTION
Fix for #2720 

It seems that project files should take priority over CS files - this solution will look for project files first (up to the limit) and then look for CS files (up to the limit) so the project files come first.

It might make sense to skip the CS detection altogether if project files are located but I wanted to keep everything as close to the original implementation as possible to not break any existing use cases.