### PR TITLE
Do not focus on the C# channel when installing dependencies

### DIFF
--- a/src/observers/BaseChannelObserver.ts
+++ b/src/observers/BaseChannelObserver.ts
@@ -13,8 +13,8 @@ export abstract class BaseChannelObserver {
 
     abstract post: (event: BaseEvent) => void;
 
-    public showChannel(preserveFocusOrColumn?: boolean) {
-        this.channel.show(preserveFocusOrColumn);
+    public showChannel(preserveFocus?: boolean) {
+        this.channel.show(preserveFocus);
     }
 
     public clearChannel() {

--- a/src/observers/CsharpChannelObserver.ts
+++ b/src/observers/CsharpChannelObserver.ts
@@ -10,6 +10,8 @@ export class CsharpChannelObserver extends BaseChannelObserver {
     public post = (event: BaseEvent) => {
         switch (event.constructor.name) {
             case PackageInstallStart.name:
+                this.showChannel(true);
+                break;
             case InstallationFailure.name:
             case DebuggerNotInstalledFailure.name:
             case DebuggerPrerequisiteFailure.name:

--- a/test/unitTests/logging/CsharpChannelObserver.test.ts
+++ b/test/unitTests/logging/CsharpChannelObserver.test.ts
@@ -12,7 +12,6 @@ suite("CsharpChannelObserver", () => {
     suiteSetup(() => should());
     [
         new InstallationFailure("someStage", "someError"),
-        new PackageInstallStart(),
         new DebuggerNotInstalledFailure(),
         new DebuggerPrerequisiteFailure("some failure"),
         new ProjectJsonDeprecatedWarning()
@@ -29,4 +28,21 @@ suite("CsharpChannelObserver", () => {
             expect(hasShown).to.be.true;
         });
     });
+
+    test(`${PackageInstallStart.name}: Channel is shown and preserveFocus is set to true`, () => {
+        let hasShown = false;
+        let preserveFocus = false;
+        let event = new PackageInstallStart();
+        let observer = new CsharpChannelObserver({
+            ...getNullChannel(),
+            show: (preserve) => {
+                hasShown = true;
+                preserveFocus = preserve;
+            }
+        });
+
+        observer.post(event);
+        expect(hasShown).to.be.true;
+        expect(preserveFocus).to.be.true;
+    })
 });


### PR DESCRIPTION
Fixes: #2717 

We should not take the focus when we show the C# channel when the dependencies are being downloaded.