### PR TITLE
Updating debug adapter executable to new API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "csharp",
-  "version": "1.18.0-beta1",
+  "version": "1.18.0-beta2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1790,7 +1790,7 @@
     },
     "deep-assign": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
       "dev": true,
       "requires": {
@@ -2239,7 +2239,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2321,7 +2321,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -3734,7 +3734,7 @@
       "dependencies": {
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -3989,7 +3989,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -4001,13 +4001,13 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             },
             "through2": {
               "version": "0.6.5",
-              "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
@@ -4080,7 +4080,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4101,7 +4101,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -4753,7 +4753,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5384,7 +5384,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -5399,7 +5399,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -9269,7 +9269,7 @@
     },
     "queue": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
       "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
       "dev": true,
       "requires": {
@@ -10249,7 +10249,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -10264,7 +10264,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -10370,7 +10370,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -335,7 +335,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.28.0"
+    "vscode": "^1.30.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",
@@ -818,7 +818,6 @@
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess"
         },
-        "adapterExecutableCommand": "csharp.coreclrAdapterExecutableCommand",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {
@@ -1886,7 +1885,6 @@
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess"
         },
-        "adapterExecutableCommand": "csharp.clrAdapterExecutableCommand",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
           "launch": {

--- a/src/coreclr-debug/ClrDebugDescriptorFactory.ts
+++ b/src/coreclr-debug/ClrDebugDescriptorFactory.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as common from './../common';
+import { CoreClrDebugUtil } from './util';
+import { PlatformInformation } from './../platform';
+import { DebuggerNotInstalledFailure } from '../omnisharp/loggingEvents';
+import { EventStream } from '../EventStream';
+import { getRuntimeDependencyPackageWithId } from '../tools/RuntimeDependencyPackageUtils';
+import { completeDebuggerInstall } from './activate';
+
+export class ClrDebugDescriptorFactory  implements vscode.DebugAdapterDescriptorFactory {
+    public static CORECLR_DEBUG_TYPE : string = "coreclr";
+    public static CLR_DEBUG_TYPE : string = "clr";
+
+    private platformInfo: PlatformInformation;
+    private eventStream: EventStream;
+    private packageJSON: any;
+    private extensionPath: string;
+
+    constructor(platformInfo: PlatformInformation, eventStream: EventStream, packageJSON: any, extensionPath: string) {
+        this.platformInfo = platformInfo;
+        this.eventStream = eventStream;
+        this.packageJSON = packageJSON;
+        this.extensionPath = extensionPath;
+    }
+
+    createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+        
+        return new Promise<void>(async (resolve, reject) => {
+            let util = new CoreClrDebugUtil(common.getExtensionPath());
+
+            // Check for .debugger folder. Handle if it does not exist.
+            if (!CoreClrDebugUtil.existsSync(util.debugAdapterDir())) {
+                // our install.complete file does not exist yet, meaning we have not completed the installation. Try to figure out what if anything the package manager is doing
+                // the order in which files are dealt with is this:
+                // 1. install.Begin is created
+                // 2. install.Lock is created
+                // 3. install.Begin is deleted
+                // 4. install.complete is created
+    
+                // install.Lock does not exist, need to wait for packages to finish downloading.
+                let installLock = false;
+    
+                let debuggerPackage = getRuntimeDependencyPackageWithId("Debugger", this.packageJSON, this.platformInfo, this.extensionPath);
+                if (debuggerPackage && debuggerPackage.installPath)
+                {
+                    installLock = await common.installFileExists(debuggerPackage.installPath, common.InstallFileType.Lock);
+                }
+    
+                if (!installLock) {
+                    this.eventStream.post(new DebuggerNotInstalledFailure());
+                    reject(new Error('The C# extension is still downloading packages. Please see progress in the output window below.'));
+                }
+                // install.complete does not exist, check dotnetCLI to see if we can complete.
+                else if (!CoreClrDebugUtil.existsSync(util.installCompleteFilePath())) {
+                    let success = await completeDebuggerInstall(this.platformInfo, this.eventStream);
+
+                    if (!success) {
+                        this.eventStream.post(new DebuggerNotInstalledFailure());
+                        reject(new Error('Failed to complete the installation of the C# extension. Please see the error in the output window below.'));
+                    }
+                }
+            }
+
+            resolve();
+        }).then(() => {
+            // debugger has finished installation, kick off our debugger process
+            return new vscode.DebugAdapterExecutable(path.join(common.getExtensionPath(), ".debugger", "vsdbg-ui" + CoreClrDebugUtil.getPlatformExeExtension()));
+        });
+    }
+}

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -3,15 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
-import * as common from './../common';
 import { CoreClrDebugUtil, DotnetInfo, } from './util';
 import { PlatformInformation } from './../platform';
 import { DebuggerPrerequisiteWarning, DebuggerPrerequisiteFailure, DebuggerNotInstalledFailure } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
 import CSharpExtensionExports from '../CSharpExtensionExports';
-import { getRuntimeDependencyPackageWithId } from '../tools/RuntimeDependencyPackageUtils';
 
 let _debugUtil: CoreClrDebugUtil = null;
 
@@ -103,75 +100,5 @@ function showDotnetToolsWarning(message: string): void {
                     vscode.commands.executeCommand('workbench.action.openGlobalSettings');
                 }
             });
-    }
-}
-
-export class DebugAdapterDecriptor implements vscode.DebugAdapterDescriptorFactory {
-    public static CORECLR_DEBUG_TYPE : string = "coreclr";
-    public static CLR_DEBUG_TYPE : string = "clr";
-
-    private platformInfo: PlatformInformation;
-    private eventStream: EventStream;
-    private packageJSON: any;
-    private extensionPath: string;
-
-    constructor(platformInfo: PlatformInformation, eventStream: EventStream, packageJSON: any, extensionPath: string) {
-        this.platformInfo = platformInfo;
-        this.eventStream = eventStream;
-        this.packageJSON = packageJSON;
-        this.extensionPath = extensionPath;
-    }
-
-    createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-        
-        return new Promise<void>((resolve, reject) => {
-            let util = new CoreClrDebugUtil(common.getExtensionPath());
-
-            // Check for .debugger folder. Handle if it does not exist.
-            if (!CoreClrDebugUtil.existsSync(util.debugAdapterDir())) {
-                // our install.complete file does not exist yet, meaning we have not completed the installation. Try to figure out what if anything the package manager is doing
-                // the order in which files are dealt with is this:
-                // 1. install.Begin is created
-                // 2. install.Lock is created
-                // 3. install.Begin is deleted
-                // 4. install.complete is created
-    
-                // install.Lock does not exist, need to wait for packages to finish downloading.
-                let installLock = Promise.resolve(false);
-    
-                let debuggerPackage = getRuntimeDependencyPackageWithId("Debugger", this.packageJSON, this.platformInfo, this.extensionPath);
-                if (debuggerPackage && debuggerPackage.installPath)
-                {
-                    installLock = common.installFileExists(debuggerPackage.installPath, common.InstallFileType.Lock);
-                }
-    
-                installLock.then(installLock => {
-                    if (!installLock) {
-                        this.eventStream.post(new DebuggerNotInstalledFailure());
-                        reject(new Error('The C# extension is still downloading packages. Please see progress in the output window below.'));
-                    }
-                    // install.complete does not exist, check dotnetCLI to see if we can complete.
-                    else if (!CoreClrDebugUtil.existsSync(util.installCompleteFilePath())) {
-                        completeDebuggerInstall(this.platformInfo, this.eventStream).then(success => {
-                            if (!success) {
-                                this.eventStream.post(new DebuggerNotInstalledFailure());
-                                reject(new Error('Failed to complete the installation of the C# extension. Please see the error in the output window below.'));
-                            }
-                        });
-                    }
-
-                    resolve();
-                });
-            }
-            else
-            {
-                resolve();
-            }
-        }).then(() => {
-            // debugger has finished installation, kick off our debugger process
-            return new vscode.DebugAdapterExecutable(path.join(common.getExtensionPath(), ".debugger", "vsdbg-ui" + CoreClrDebugUtil.getPlatformExeExtension()));
-        }, error => {
-            throw error;
-        });
     }
 }

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -13,7 +13,7 @@ import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
 import { DotNetAttachItemsProviderFactory, AttachPicker, RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
-import { getAdapterExecutionCommand } from '../coreclr-debug/activate';
+import { DebugAdapterDecriptor } from '../coreclr-debug/activate';
 import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
 import { PlatformInformation } from '../platform';
@@ -47,8 +47,8 @@ export default function registerCommands(server: OmniSharpServer, platformInfo: 
     disposable.add(vscode.commands.registerCommand('csharp.listRemoteProcess', async (args) => RemoteAttachPicker.ShowAttachEntries(args, platformInfo)));
 
     // Register command for adapter executable command.
-    disposable.add(vscode.commands.registerCommand('csharp.coreclrAdapterExecutableCommand', async (args) => getAdapterExecutionCommand(platformInfo, eventStream, packageJSON, extensionPath)));
-    disposable.add(vscode.commands.registerCommand('csharp.clrAdapterExecutableCommand', async (args) => getAdapterExecutionCommand(platformInfo, eventStream, packageJSON, extensionPath)));
+    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(DebugAdapterDecriptor.CORECLR_DEBUG_TYPE, new DebugAdapterDecriptor(platformInfo, eventStream, packageJSON, extensionPath)));
+    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(DebugAdapterDecriptor.CLR_DEBUG_TYPE, new DebugAdapterDecriptor(platformInfo, eventStream, packageJSON, extensionPath)));
     disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver)));
 
     return new CompositeDisposable(disposable);

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -13,7 +13,7 @@ import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
 import { DotNetAttachItemsProviderFactory, AttachPicker, RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
-import { DebugAdapterDecriptor } from '../coreclr-debug/activate';
+import { ClrDebugDescriptorFactory } from '../coreclr-debug/clrDebugDescriptorFactory';
 import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
 import { PlatformInformation } from '../platform';
@@ -47,8 +47,8 @@ export default function registerCommands(server: OmniSharpServer, platformInfo: 
     disposable.add(vscode.commands.registerCommand('csharp.listRemoteProcess', async (args) => RemoteAttachPicker.ShowAttachEntries(args, platformInfo)));
 
     // Register command for adapter executable command.
-    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(DebugAdapterDecriptor.CORECLR_DEBUG_TYPE, new DebugAdapterDecriptor(platformInfo, eventStream, packageJSON, extensionPath)));
-    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(DebugAdapterDecriptor.CLR_DEBUG_TYPE, new DebugAdapterDecriptor(platformInfo, eventStream, packageJSON, extensionPath)));
+    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(ClrDebugDescriptorFactory.CORECLR_DEBUG_TYPE, new ClrDebugDescriptorFactory(platformInfo, eventStream, packageJSON, extensionPath)));
+    disposable.add(vscode.debug.registerDebugAdapterDescriptorFactory(ClrDebugDescriptorFactory.CLR_DEBUG_TYPE, new ClrDebugDescriptorFactory(platformInfo, eventStream, packageJSON, extensionPath)));
     disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver)));
 
     return new CompositeDisposable(disposable);


### PR DESCRIPTION
https://code.visualstudio.com/updates/v1_30#_debugging-api has
depricated adapterExecutableCommand. This PR updates the extension to
use DebugAdapterDescriptorFactory.

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/2743