### PR TITLE
UpdateDependencies to be able to update omnisharp and razor packages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,7 +104,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Launch gulp task",
+            "name": "Update package dependencies",
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
             "args": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,6 +2606,24 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-versions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
+      "integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^2.0.0",
+        "semver-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "array-uniq": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
+          "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+          "dev": true
+        }
+      }
+    },
     "findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -9826,6 +9844,12 @@
       "requires": {
         "sver-compat": "^1.5.0"
       }
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -463,12 +463,12 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                   "default": []
                 },
                 "searchMicrosoftSymbolServer": {
                   "type": "boolean",
-                  "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                   "default": false
                 },
                 "cachePath": {
@@ -1312,12 +1312,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1713,12 +1713,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2380,12 +2380,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2781,12 +2781,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "copyfiles": "2.0.0",
     "cross-env": "5.1.4",
     "del": "3.0.0",
-    "find-versions": "3.0.0",
+    "find-versions": "^3.0.0",
     "get-port": "3.2.0",
     "glob-promise": "3.4.0",
     "gulp": "4.0.0",
@@ -149,18 +149,17 @@
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/ed7cfe88-470c-421d-8078-062aea0f0ead/e9e2a6b82a6084fa4de82cb1515098fc/omnisharp-win-x86-1.32.7.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.32.7.zip",
-      "installPath": ".omnisharp/1.32.7",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/515dbb33-d644-4ba6-9ee4-8ca7227ab580/02621f196a581cb3062dbeab2ec28429/omnisharp-win-x86-1.32.8.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.32.8.zip",
+      "installPath": ".omnisharp/1.32.8",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86"
       ],
-      "installTestPath": "./.omnisharp/1.32.7/OmniSharp.exe",
-      "platformId": "win-x86",
-      "integrity": "30AE34B885D448D5677A85FB0D3ECA568F79EF135C3F34B5698F17AD90E2D3D2"
+      "installTestPath": "./.omnisharp/1.32.8/OmniSharp.exe",
+      "platformId": "win-x86"
     },
     {
       "id": "OmniSharp",

--- a/package.json
+++ b/package.json
@@ -149,17 +149,18 @@
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/515dbb33-d644-4ba6-9ee4-8ca7227ab580/02621f196a581cb3062dbeab2ec28429/omnisharp-win-x86-1.32.8.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.32.8.zip",
-      "installPath": ".omnisharp/1.32.8",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/ed7cfe88-470c-421d-8078-062aea0f0ead/e9e2a6b82a6084fa4de82cb1515098fc/omnisharp-win-x86-1.32.7.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.32.7.zip",
+      "installPath": ".omnisharp/1.32.7",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86"
       ],
-      "installTestPath": "./.omnisharp/1.32.8/OmniSharp.exe",
-      "platformId": "win-x86"
+      "installTestPath": "./.omnisharp/1.32.7/OmniSharp.exe",
+      "platformId": "win-x86",
+      "integrity": "30AE34B885D448D5677A85FB0D3ECA568F79EF135C3F34B5698F17AD90E2D3D2"
     },
     {
       "id": "OmniSharp",
@@ -463,12 +464,12 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                   "default": []
                 },
                 "searchMicrosoftSymbolServer": {
                   "type": "boolean",
-                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                   "default": false
                 },
                 "cachePath": {
@@ -1312,12 +1313,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1713,12 +1714,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2380,12 +2381,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2781,12 +2782,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "copyfiles": "2.0.0",
     "cross-env": "5.1.4",
     "del": "3.0.0",
+    "find-versions": "3.0.0",
     "get-port": "3.2.0",
     "glob-promise": "3.4.0",
     "gulp": "4.0.0",

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -95,7 +95,7 @@ export async function updatePackageDependencies(): Promise<void> {
     const networkSettingsProvider: NetworkSettingsProvider = () => new NetworkSettings(/*proxy:*/ null, /*stringSSL:*/ true);
 
     const downloadAndGetHash = async (url: string): Promise<string> => {
-        console.log(`Downlodaing from '${url}'`);
+        console.log(`Downloading from '${url}'`);
         const buffer: Buffer = await DownloadFile(url, eventStream, networkSettingsProvider, url, null);
         return getBufferIntegrityHash(buffer);
     };
@@ -143,7 +143,7 @@ function replaceVersion(value: string, newVersion: string): string {
     dottedVersionRegExp.lastIndex = 0;
 
     if (!regex.test(value)) {
-        return value; //If the string doesnt contain any version return the same string
+        return value; //If the string doesn't contain any version return the same string
     }
 
     return value.replace(regex, newValue);
@@ -169,10 +169,10 @@ function verifyMatchCount(value: string, shouldContainVersion = false): void {
     const matchCount: number = dottedMatches + dashedMatches;
 
     if (shouldContainVersion && matchCount == 0) {
-        throw new Error(`Version number not found in fallback URL '${value}'.`);
+        throw new Error(`Version number not found in '${value}'.`);
     }
     if (matchCount > 1) {
-        throw new Error(`Ambiguous version pattern found in fallback URL '${value}'. Multiple version strings found.`);
+        throw new Error(`Ambiguous version pattern found in '${value}'. Multiple version strings found.`);
     }
 }
 
@@ -192,7 +192,7 @@ function getLowercaseFileNameFromUrl(url: string): string {
     if (!versions || versions.length == 0) {
         return fileName;
     }
-    
+
     if (versions.length > 1) {
         //we expect only one version string to be present in the last part of the url
         throw new Error(`Ambiguous version pattern found in fallback URL '${url}'. Multiple version strings found.`);

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -15,6 +15,9 @@ const findVersions = require('find-versions');
 
 interface PackageJSONFile {
     runtimeDependencies: Package[];
+    defaults: {
+        [key: string]: string;
+    };
 }
 
 const dottedVersionRegExp = /[0-9]+\.[0-9]+\.[0-9]+/g;
@@ -107,6 +110,12 @@ export async function updatePackageDependencies(): Promise<void> {
         dependency.fallbackUrl = replaceVersion(dependency.fallbackUrl, newVersion);
         dependency.installPath = replaceVersion(dependency.installPath, newVersion);
         dependency.installTestPath = replaceVersion(dependency.installTestPath, newVersion);
+        Object.keys(packageJSON.defaults).forEach(key => {
+            //Update the version present in the defaults
+            if (key.toLowerCase() == dependency.id.toLowerCase()) {
+                packageJSON.defaults[key] = newVersion;
+            }
+        });
 
         if (dependency.fallbackUrl) {
             const fallbackUrlIntegrity = await downloadAndGetHash(dependency.fallbackUrl);
@@ -195,7 +204,7 @@ function getLowercaseFileNameFromUrl(url: string): string {
 
     if (versions.length > 1) {
         //we expect only one version string to be present in the last part of the url
-        throw new Error(`Ambiguous version pattern found in fallback URL '${url}'. Multiple version strings found.`);
+        throw new Error(`Ambiguous version pattern found URL '${url}'. Multiple version strings found.`);
     }
 
     let versionIndex = fileName.indexOf(versions[0]);

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -12,6 +12,7 @@ import * as Event from "../omnisharp/loggingEvents";
 import NetworkSettings, { NetworkSettingsProvider } from '../NetworkSettings';
 import { getBufferIntegrityHash } from '../packageManager/isValidDownload';
 const findVersions = require('find-versions');
+
 interface PackageJSONFile {
     runtimeDependencies: Package[];
 }
@@ -141,7 +142,7 @@ function replaceVersion(value: string, newVersion: string): string {
     }
     dottedVersionRegExp.lastIndex = 0;
 
-    if (!dashedVersionRegExp.test(value)) {
+    if (!regex.test(value)) {
         return value; //If the string doesnt contain any version return the same string
     }
 
@@ -191,6 +192,7 @@ function getLowercaseFileNameFromUrl(url: string): string {
     if (!versions || versions.length == 0) {
         return fileName;
     }
+    
     if (versions.length > 1) {
         //we expect only one version string to be present in the last part of the url
         throw new Error(`Ambiguous version pattern found in fallback URL '${url}'. Multiple version strings found.`);

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -11,17 +11,19 @@ import { EventStream } from '../EventStream';
 import * as Event from "../omnisharp/loggingEvents";
 import NetworkSettings, { NetworkSettingsProvider } from '../NetworkSettings';
 import { getBufferIntegrityHash } from '../packageManager/isValidDownload';
-
-interface PackageJSONFile
-{
-    runtimeDependencies : Package[];
+const findVersions = require('find-versions');
+interface PackageJSONFile {
+    runtimeDependencies: Package[];
 }
 
-export async function updatePackageDependencies() : Promise<void> {
+const dottedVersionRegExp = /[0-9]+\.[0-9]+\.[0-9]+/g;
+const dashedVersionRegExp = /[0-9]+-[0-9]+-[0-9]+/g;
+
+export async function updatePackageDependencies(): Promise<void> {
 
     const newPrimaryUrls = process.env["NEW_DEPS_URLS"];
     const newVersion = process.env["NEW_DEPS_VERSION"];
-    
+
     if (!newPrimaryUrls || !newVersion) {
         console.log();
         console.log("'npm run gulp updatePackageDependencies' will update package.json with new URLs of dependencies.");
@@ -46,9 +48,9 @@ export async function updatePackageDependencies() : Promise<void> {
     if (! /^[0-9]+\.[0-9]+\.[0-9]+$/.test(newVersion)) {
         throw new Error("Unexpected 'NEW_DEPS_VERSION' value. Expected format similar to: 1.2.3.");
     }
-   
+
     let packageJSON: PackageJSONFile = JSON.parse(fs.readFileSync('package.json').toString());
-    
+
     // map from lowercase filename to Package
     const mapFileNameToDependency: { [key: string]: Package } = {};
 
@@ -61,8 +63,8 @@ export async function updatePackageDependencies() : Promise<void> {
         }
         mapFileNameToDependency[fileName] = dependency;
     });
-    
-    let findDependencyToUpdate = (url : string): Package => {
+
+    let findDependencyToUpdate = (url: string): Package => {
         let fileName = getLowercaseFileNameFromUrl(url);
         let dependency = mapFileNameToDependency[fileName];
         if (dependency === undefined) {
@@ -71,34 +73,13 @@ export async function updatePackageDependencies() : Promise<void> {
         return dependency;
     };
 
-    const dottedVersionRegExp = /[0-9]+\.[0-9]+\.[0-9]+/g;
-    const dashedVersionRegExp = /[0-9]+-[0-9]+-[0-9]+/g;
-    
-    const getMatchCount = (regexp: RegExp, searchString: string) : number => {
-        regexp.lastIndex = 0;
-        let retVal = 0;
-        while (regexp.test(searchString)) {
-            retVal++;
-        }
-        regexp.lastIndex = 0;
-        return retVal;
-    };
-
     // First quickly make sure we could match up the URL to an existing item.
     for (let urlToUpdate of newPrimaryUrlArray) {
         const dependency = findDependencyToUpdate(urlToUpdate);
-        if (dependency.fallbackUrl) {
-            const dottedMatches : number = getMatchCount(dottedVersionRegExp, dependency.fallbackUrl);
-            const dashedMatches : number = getMatchCount(dashedVersionRegExp, dependency.fallbackUrl);
-            const matchCount : number = dottedMatches + dashedMatches;
-
-            if (matchCount == 0) {
-                throw new Error(`Version number not found in fallback URL '${dependency.fallbackUrl}'.`);
-            }
-            if (matchCount > 1) {
-                throw new Error(`Ambiguous version pattern found in fallback URL '${dependency.fallbackUrl}'. Multiple version strings found.`);
-            }
-        }
+        //Fallback url should contain a version
+        verifyMatchCount(dependency.fallbackUrl, true);
+        verifyMatchCount(dependency.installPath);
+        verifyMatchCount(dependency.installTestPath);
     }
 
     // Next take another pass to try and update to the URL  
@@ -110,11 +91,11 @@ export async function updatePackageDependencies() : Promise<void> {
                 break;
         }
     });
-    const networkSettingsProvider : NetworkSettingsProvider = () => new NetworkSettings(/*proxy:*/ null, /*stringSSL:*/ true);
+    const networkSettingsProvider: NetworkSettingsProvider = () => new NetworkSettings(/*proxy:*/ null, /*stringSSL:*/ true);
 
-    const downloadAndGetHash = async (url:string) : Promise<string> => {
+    const downloadAndGetHash = async (url: string): Promise<string> => {
         console.log(`Downlodaing from '${url}'`);
-        const buffer : Buffer = await DownloadFile(url, eventStream, networkSettingsProvider, url, null);
+        const buffer: Buffer = await DownloadFile(url, eventStream, networkSettingsProvider, url, null);
         return getBufferIntegrityHash(buffer);
     };
 
@@ -122,21 +103,12 @@ export async function updatePackageDependencies() : Promise<void> {
         let dependency = findDependencyToUpdate(urlToUpdate);
         dependency.url = urlToUpdate;
         dependency.integrity = await downloadAndGetHash(dependency.url);
+        dependency.fallbackUrl = replaceVersion(dependency.fallbackUrl, newVersion);
+        dependency.installPath = replaceVersion(dependency.installPath, newVersion);
+        dependency.installTestPath = replaceVersion(dependency.installTestPath, newVersion);
 
         if (dependency.fallbackUrl) {
-            
-            // NOTE: We already verified in the first loop that one of these patterns will work, grab the one that does
-            let regex: RegExp = dottedVersionRegExp;
-            let newValue: string = newVersion;
-            if (!dottedVersionRegExp.test(dependency.fallbackUrl)) {
-                regex = dashedVersionRegExp;
-                newValue = newVersion.replace(/\./g, "-");
-            }
-            dottedVersionRegExp.lastIndex = 0;
-
-            dependency.fallbackUrl = dependency.fallbackUrl.replace(regex, newValue);
             const fallbackUrlIntegrity = await downloadAndGetHash(dependency.fallbackUrl);
-
             if (dependency.integrity !== fallbackUrlIntegrity) {
                 throw new Error(`File downloaded from primary URL '${dependency.url}' doesn't match '${dependency.fallbackUrl}'.`);
             }
@@ -155,7 +127,55 @@ export async function updatePackageDependencies() : Promise<void> {
     fs.writeFileSync('package.json', content);
 }
 
-function getLowercaseFileNameFromUrl(url : string) : string {
+
+function replaceVersion(value: string, newVersion: string): string {
+    if (!value) {
+        return value; //if the value is null or undefined return the same one
+    }
+
+    let regex: RegExp = dottedVersionRegExp;
+    let newValue: string = newVersion;
+    if (!dottedVersionRegExp.test(value)) {
+        regex = dashedVersionRegExp;
+        newValue = newVersion.replace(/\./g, "-");
+    }
+    dottedVersionRegExp.lastIndex = 0;
+
+    if (!dashedVersionRegExp.test(value)) {
+        return value; //If the string doesnt contain any version return the same string
+    }
+
+    return value.replace(regex, newValue);
+}
+
+function verifyMatchCount(value: string, shouldContainVersion = false): void {
+    const getMatchCount = (regexp: RegExp, searchString: string): number => {
+        regexp.lastIndex = 0;
+        let retVal = 0;
+        while (regexp.test(searchString)) {
+            retVal++;
+        }
+        regexp.lastIndex = 0;
+        return retVal;
+    };
+    
+    if (!value) {
+        return;
+    }
+    
+    const dottedMatches: number = getMatchCount(dottedVersionRegExp, value);
+    const dashedMatches: number = getMatchCount(dashedVersionRegExp, value);
+    const matchCount: number = dottedMatches + dashedMatches;
+
+    if (shouldContainVersion && matchCount == 0) {
+        throw new Error(`Version number not found in fallback URL '${value}'.`);
+    }
+    if (matchCount > 1) {
+        throw new Error(`Ambiguous version pattern found in fallback URL '${value}'. Multiple version strings found.`);
+    }
+}
+
+function getLowercaseFileNameFromUrl(url: string): string {
 
     if (!url.startsWith("https://")) {
         throw new Error(`Unexpected URL '${url}'. URL expected to start with 'https://'.`);
@@ -166,5 +186,17 @@ function getLowercaseFileNameFromUrl(url : string) : string {
     }
 
     let index = url.lastIndexOf("/");
-    return url.substr(index + 1).toLowerCase();    
+    let fileName = url.substr(index + 1).toLowerCase();
+    let versions = findVersions(fileName);
+    if (!versions || versions.length == 0) {
+        return fileName;
+    }
+    if (versions.length > 1) {
+        //we expect only one version string to be present in the last part of the url
+        throw new Error(`Ambiguous version pattern found in fallback URL '${url}'. Multiple version strings found.`);
+    }
+
+    let versionIndex = fileName.indexOf(versions[0]);
+    //remove the dash before the version number
+    return fileName.substr(0, versionIndex - 1).toLowerCase();
 }

--- a/src/tools/UpdatePackageDependencies.ts
+++ b/src/tools/UpdatePackageDependencies.ts
@@ -81,9 +81,9 @@ export async function updatePackageDependencies(): Promise<void> {
     for (let urlToUpdate of newPrimaryUrlArray) {
         const dependency = findDependencyToUpdate(urlToUpdate);
         //Fallback url should contain a version
-        verifyMatchCount(dependency.fallbackUrl, true);
-        verifyMatchCount(dependency.installPath);
-        verifyMatchCount(dependency.installTestPath);
+        verifyVersionSubstringCount(dependency.fallbackUrl, true);
+        verifyVersionSubstringCount(dependency.installPath);
+        verifyVersionSubstringCount(dependency.installTestPath);
     }
 
     // Next take another pass to try and update to the URL  
@@ -138,27 +138,27 @@ export async function updatePackageDependencies(): Promise<void> {
 }
 
 
-function replaceVersion(value: string, newVersion: string): string {
-    if (!value) {
-        return value; //if the value is null or undefined return the same one
+function replaceVersion(fileName: string, newVersion: string): string {
+    if (!fileName) {
+        return fileName; //if the value is null or undefined return the same one
     }
 
     let regex: RegExp = dottedVersionRegExp;
     let newValue: string = newVersion;
-    if (!dottedVersionRegExp.test(value)) {
+    if (!dottedVersionRegExp.test(fileName)) {
         regex = dashedVersionRegExp;
         newValue = newVersion.replace(/\./g, "-");
     }
     dottedVersionRegExp.lastIndex = 0;
 
-    if (!regex.test(value)) {
-        return value; //If the string doesn't contain any version return the same string
+    if (!regex.test(fileName)) {
+        return fileName; //If the string doesn't contain any version return the same string
     }
 
-    return value.replace(regex, newValue);
+    return fileName.replace(regex, newValue);
 }
 
-function verifyMatchCount(value: string, shouldContainVersion = false): void {
+function verifyVersionSubstringCount(value: string, shouldContainVersion = false): void {
     const getMatchCount = (regexp: RegExp, searchString: string): number => {
         regexp.lastIndex = 0;
         let retVal = 0;


### PR DESCRIPTION
The UpdateDependencies script used to match the last part of the url to match the urls against the runtimeDependencies. However the urls for omnisharp and razor include the version as well, hence the names would never directly match, so added some logic that trims the versions before performing the matching.

Also update the version in the installPath, installTestPath and the defaults property which is present in the package.json