### PR TITLE
Improvements to launch.json/tasks.json

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -16,8 +16,11 @@ require('./tasks/offlinePackagingTasks');
 require('./tasks/backcompatTasks');
 require('./tasks/coverageTasks');
 
-gulp.task('generateOptionsSchema', () : void => {
+// Disable warning about wanting an async function
+// tslint:disable-next-line
+gulp.task('generateOptionsSchema', () : Promise<void> => {
     optionsSchemaGenerator.GenerateOptionsSchema();
+    return Promise.resolve();
 });
 
 // Disable warning about wanting an async function

--- a/package.json
+++ b/package.json
@@ -463,12 +463,12 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                   "default": []
                 },
                 "searchMicrosoftSymbolServer": {
                   "type": "boolean",
-                  "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                   "default": false
                 },
                 "cachePath": {
@@ -888,20 +888,12 @@
               "launchBrowser": {
                 "description": "Describes options to launch a web browser as part of launch",
                 "default": {
-                  "enabled": true,
-                  "args": "${auto-detect-url}",
-                  "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                  },
-                  "osx": {
-                    "command": "open"
-                  },
-                  "linux": {
-                    "command": "xdg-open"
-                  }
+                  "enabled": true
                 },
                 "type": "object",
+                "required": [
+                  "enabled"
+                ],
                 "properties": {
                   "enabled": {
                     "type": "boolean",
@@ -909,78 +901,76 @@
                     "default": true
                   },
                   "args": {
-                    "anyOf": [
-                      {
-                        "type": "array",
-                        "description": "Command line arguments passed to the program.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "default": []
-                      },
-                      {
-                        "type": "string",
-                        "description": "Stringified version of command line arguments passed to the program.",
-                        "default": ""
-                      }
-                    ],
+                    "type": "string",
+                    "description": "The arguments to pass to the command to open the browser. This is used only if the platform-specific element (`osx`, `linux` or `windows`) doesn't specify a value for `args`. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                     "default": "${auto-detect-url}"
                   },
                   "osx": {
-                    "description": "OSX-specific web launch configuration options",
+                    "description": "OSX-specific web launch configuration options. By default, this will start the browser using `open`.",
                     "default": {
-                      "command": "open"
+                      "command": "open",
+                      "args": "${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "open"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                         "default": "${auto-detect-url}"
                       }
                     }
                   },
                   "linux": {
-                    "description": "Linux-specific web launch configuration options",
+                    "description": "Linux-specific web launch configuration options. By default, this will start the browser using `xdg-open`.",
                     "default": {
-                      "command": "xdg-open"
+                      "command": "xdg-open",
+                      "args": "${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "xdg-open"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                         "default": "${auto-detect-url}"
                       }
                     }
                   },
                   "windows": {
-                    "description": "Windows-specific web launch configuration options",
+                    "description": "Windows-specific web launch configuration options. By default, this will start the browser using `cmd /c start`.",
                     "default": {
                       "command": "cmd.exe",
                       "args": "/C start ${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "cmd.exe"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
-                        "default": "${auto-detect-url}"
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
+                        "default": "/C start ${auto-detect-url}"
                       }
                     }
                   }
@@ -1312,12 +1302,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1713,12 +1703,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1838,18 +1828,7 @@
               "cwd": "^\"\\${workspaceFolder}\"",
               "stopAtEntry": false,
               "launchBrowser": {
-                "enabled": true,
-                "args": "^\"\\${auto-detect-url}\"",
-                "windows": {
-                  "command": "cmd.exe",
-                  "args": "^\"/C start \\${auto-detect-url}\""
-                },
-                "osx": {
-                  "command": "open"
-                },
-                "linux": {
-                  "command": "xdg-open"
-                }
+                "enabled": true
               },
               "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
@@ -1956,20 +1935,12 @@
               "launchBrowser": {
                 "description": "Describes options to launch a web browser as part of launch",
                 "default": {
-                  "enabled": true,
-                  "args": "${auto-detect-url}",
-                  "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                  },
-                  "osx": {
-                    "command": "open"
-                  },
-                  "linux": {
-                    "command": "xdg-open"
-                  }
+                  "enabled": true
                 },
                 "type": "object",
+                "required": [
+                  "enabled"
+                ],
                 "properties": {
                   "enabled": {
                     "type": "boolean",
@@ -1977,78 +1948,76 @@
                     "default": true
                   },
                   "args": {
-                    "anyOf": [
-                      {
-                        "type": "array",
-                        "description": "Command line arguments passed to the program.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "default": []
-                      },
-                      {
-                        "type": "string",
-                        "description": "Stringified version of command line arguments passed to the program.",
-                        "default": ""
-                      }
-                    ],
+                    "type": "string",
+                    "description": "The arguments to pass to the command to open the browser. This is used only if the platform-specific element (`osx`, `linux` or `windows`) doesn't specify a value for `args`. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                     "default": "${auto-detect-url}"
                   },
                   "osx": {
-                    "description": "OSX-specific web launch configuration options",
+                    "description": "OSX-specific web launch configuration options. By default, this will start the browser using `open`.",
                     "default": {
-                      "command": "open"
+                      "command": "open",
+                      "args": "${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "open"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                         "default": "${auto-detect-url}"
                       }
                     }
                   },
                   "linux": {
-                    "description": "Linux-specific web launch configuration options",
+                    "description": "Linux-specific web launch configuration options. By default, this will start the browser using `xdg-open`.",
                     "default": {
-                      "command": "xdg-open"
+                      "command": "xdg-open",
+                      "args": "${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "xdg-open"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
                         "default": "${auto-detect-url}"
                       }
                     }
                   },
                   "windows": {
-                    "description": "Windows-specific web launch configuration options",
+                    "description": "Windows-specific web launch configuration options. By default, this will start the browser using `cmd /c start`.",
                     "default": {
                       "command": "cmd.exe",
                       "args": "/C start ${auto-detect-url}"
                     },
                     "type": "object",
+                    "required": [
+                      "command"
+                    ],
                     "properties": {
                       "command": {
                         "type": "string",
-                        "description": "The command to execute for launching the web browser",
+                        "description": "The executable which will start the web browser",
                         "default": "cmd.exe"
                       },
                       "args": {
                         "type": "string",
-                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
-                        "default": "${auto-detect-url}"
+                        "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
+                        "default": "/C start ${auto-detect-url}"
                       }
                     }
                   }
@@ -2380,12 +2349,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2781,12 +2750,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -9,10 +9,10 @@ import * as serverUtils from './omnisharp/utils';
 import * as vscode from 'vscode';
 import { ParsedEnvironmentFile } from './coreclr-debug/ParsedEnvironmentFile';
 
-import { AssetGenerator, addTasksJsonIfNecessary, createAttachConfiguration, createLaunchConfiguration, createWebLaunchConfiguration } from './assets';
+import { AssetGenerator, AssetOperations, addTasksJsonIfNecessary, createAttachConfiguration, createFallbackLaunchConfiguration, getBuildOperations } from './assets';
 
 import { OmniSharpServer } from './omnisharp/server';
-import { containsDotNetCoreProjects } from './omnisharp/protocol';
+import { WorkspaceInformationResponse } from './omnisharp/protocol';
 import { isSubfolderOf } from './common';
 import { parse } from 'jsonc-parser';
 import { MessageItem } from './vscodeAdapter';
@@ -30,11 +30,12 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
      * Note: serverUtils.requestWorkspaceInformation only retrieves one folder for multi-root workspaces. Therefore, generator will be incorrect for all folders
      * except the first in a workspace. Currently, this only works if the requested folder is the same as the server's solution path or folder.
      */
-    private async checkWorkspaceInformationMatchesWorkspaceFolder(folder: vscode.WorkspaceFolder | undefined): Promise<boolean> {
+    private async checkWorkspaceInformationMatchesWorkspaceFolder(folder: vscode.WorkspaceFolder): Promise<boolean> {
+
         const solutionPathOrFolder: string = this.server.getSolutionPathOrFolder();
 
         // Make sure folder, folder.uri, and solutionPathOrFolder are defined.
-        if (!folder || !folder.uri || !solutionPathOrFolder)
+        if (!solutionPathOrFolder)
         {
             return Promise.resolve(false);
         }
@@ -60,46 +61,63 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
     /**
 	 * Returns a list of initial debug configurations based on contextual information, e.g. package.json or folder.
 	 */
-    provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-        return serverUtils.requestWorkspaceInformation(this.server).then(async info => {
-            return this.checkWorkspaceInformationMatchesWorkspaceFolder(folder).then(async workspaceMatches => { 
-                const generator = new AssetGenerator(info);
-                if (workspaceMatches && containsDotNetCoreProjects(info)) {
-                    const dotVscodeFolder: string = path.join(folder.uri.fsPath, '.vscode');
-                    const tasksJsonPath: string = path.join(dotVscodeFolder, 'tasks.json');
-                    
-                    // Make sure .vscode folder exists, addTasksJsonIfNecessary will fail to create tasks.json if the folder does not exist. 
-                    return fs.ensureDir(dotVscodeFolder).then(async () => {
-                        // Check to see if tasks.json exists.
-                        return fs.pathExists(tasksJsonPath);
-                    }).then(async tasksJsonExists => {
-                        // Enable addTasksJson if it does not exist.
-                        return addTasksJsonIfNecessary(generator, {addTasksJson: !tasksJsonExists});
-                    }).then(() => {
-                        const isWebProject = generator.hasWebServerDependency();
-                        const launchJson: string = generator.createLaunchJson(isWebProject);
+    async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
 
-                        // jsonc-parser's parse function parses a JSON string with comments into a JSON object. However, this removes the comments. 
-                        return parse(launchJson);
-                    });
-                }
+        if (!folder || !folder.uri) {
+            vscode.window.showErrorMessage("Cannot create .NET debug configurations. No workspace folder was selected.");
+            return [];
+        }
+
+        if (!this.server.isRunning()) {
+            vscode.window.showErrorMessage("Cannot create .NET debug configurations. The OmniSharp server is still initializing or has exited unexpectedly.");
+            return [];
+        }
+
+        try
+        {
+            let hasWorkspaceMatches : boolean = await this.checkWorkspaceInformationMatchesWorkspaceFolder(folder); 
+            if (!hasWorkspaceMatches) {
+                vscode.window.showErrorMessage(`Cannot create .NET debug configurations. The active C# project is not within folder '${folder.uri.fsPath}'.`);
+                return [];
+            }
+
+            let info: WorkspaceInformationResponse = await serverUtils.requestWorkspaceInformation(this.server);           
+
+            const generator = new AssetGenerator(info, folder);
+            if (generator.hasExecutableProjects()) {
                 
+                if (!await generator.selectStartupProject())
+                {
+                    return [];
+                }
+               
+                // Make sure .vscode folder exists, addTasksJsonIfNecessary will fail to create tasks.json if the folder does not exist. 
+                await fs.ensureDir(generator.vscodeFolder);
+
+                // Add a tasks.json
+                const buildOperations : AssetOperations = await getBuildOperations(generator);
+                await addTasksJsonIfNecessary(generator, buildOperations);
+                
+                const isWebProject = generator.hasWebServerDependency();
+                const launchJson: string = generator.createLaunchJson(isWebProject);
+
+                // jsonc-parser's parse function parses a JSON string with comments into a JSON object. However, this removes the comments. 
+                return parse(launchJson);
+
+            } else {               
                 // Error to be caught in the .catch() below to write default C# configurations
                 throw new Error("Does not contain .NET Core projects.");
-            });
-        }).catch((err) => {
+            }
+        }
+        catch
+        {
             // Provider will always create an launch.json file. Providing default C# configurations.
             // jsonc-parser's parse to convert to JSON object without comments. 
             return [
-                parse(createLaunchConfiguration(
-                    "${workspaceFolder}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll", 
-                    '${workspaceFolder}')), 
-                parse(createWebLaunchConfiguration(
-                    "${workspaceFolder}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll", 
-                    '${workspaceFolder}')),
+                createFallbackLaunchConfiguration(),                  
                 parse(createAttachConfiguration())
             ];
-        });
+        }
     }
 
     /**
@@ -135,13 +153,28 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
 	 */
     resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
 
-        // read from envFile and set config.env
-        if (config.envFile) {
-            config = this.parseEnvFile(config.envFile.replace(/\${workspaceFolder}/g, folder.uri.fsPath), config);
+        if (!config.type)
+        {
+            // If the config doesn't look functional force VSCode to open a configuration file https://github.com/Microsoft/vscode/issues/54213
+            return null;
         }
 
-        // If the config looks functional return it, otherwise force VSCode to open a configuration file https://github.com/Microsoft/vscode/issues/54213
-        return config && config.type ? config : null;
+        if (config.request === "launch")
+        {
+            if (!config.cwd && !config.pipeTransport) {
+                config.cwd = "${workspaceFolder}";
+            }
+            if (!config.internalConsoleOptions) {
+                config.internalConsoleOptions = "openOnSessionStart";
+            }
+
+            // read from envFile and set config.env
+            if (config.envFile) {
+                config = this.parseEnvFile(config.envFile.replace(/\${workspaceFolder}/g, folder.uri.fsPath), config);
+            }
+        }
+
+        return config;
     }
 
     private static async showFileWarningAsync(message: string, fileName: string) {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -778,31 +778,3 @@ export function findExecutableMSBuildProjects(projects: MSBuildProject[]) {
 
     return result;
 }
-
-export function findExecutableProjectJsonProjects(projects: DotNetProject[], configurationName: string) {
-    let result: DotNetProject[] = [];
-
-    projects.forEach(project => {
-        project.Configurations.forEach(configuration => {
-            if (configuration.Name === configurationName && configuration.EmitEntryPoint === true) {
-                if (project.Frameworks.length > 0) {
-                    result.push(project);
-                }
-            }
-        });
-    });
-
-    return result;
-}
-
-export function containsDotNetCoreProjects(workspaceInfo: WorkspaceInformationResponse) {
-    if (workspaceInfo.DotNet && findExecutableProjectJsonProjects(workspaceInfo.DotNet.Projects, 'Debug').length > 0) {
-        return true;
-    }
-
-    if (workspaceInfo.MsBuild && findExecutableMSBuildProjects(workspaceInfo.MsBuild.Projects).length > 0) {
-        return true;
-    }
-
-    return false;
-}

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -501,7 +501,7 @@ export class OmniSharpServer {
     public async makeRequest<TResponse>(command: string, data?: any, token?: CancellationToken): Promise<TResponse> {
 
         if (!this.isRunning()) {
-            return Promise.reject<TResponse>('server has been stopped or not started');
+            return Promise.reject<TResponse>('OmniSharp server is not running.');
         }
 
         let startTime: number;

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -176,35 +176,26 @@
     },
     "LaunchBrowserPlatformOptions": {
       "type": "object",
+      "required": [ "command" ],
       "properties": {
         "command": {
           "type": "string",
-          "description": "The command to execute for launching the web browser",
+          "description": "The executable which will start the web browser",
           "default": "open"
         },
         "args": {
           "type": "string",
-          "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to",
+          "description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
           "default": "${auto-detect-url}"
         }
       }
     },
     "LaunchBrowser": {
       "type": "object",
-      "description": "Describes options to launch a web browser as part of launch",
+      "required": [ "enabled" ],
+      "description": "Configures starting a web browser as part of the launch -- should a web browser be started, and if so, what command should be run to start it. This option can be modified to launch a specific browser.",
       "default": {
-        "enabled": true,
-        "args": "${auto-detect-url}",
-        "windows": {
-          "command": "cmd.exe",
-          "args": "/C start ${auto-detect-url}"
-        },
-        "osx": {
-          "command": "open"
-        },
-        "linux": {
-          "command": "xdg-open"
-        }
+        "enabled": true
       },
       "properties": {
         "enabled": {
@@ -213,39 +204,29 @@
           "default": true
         },
         "args": {
-          "anyOf": [
-            {
-              "type": "array",
-              "description": "Command line arguments passed to the program.",
-              "items": {
-                "type": "string"
-              },
-              "default": []
-            },
-            {
-              "type": "string",
-              "description": "Stringified version of command line arguments passed to the program.",
-              "default": ""
-            }
-          ]
+          "type": "string",
+          "description": "The arguments to pass to the command to open the browser. This is used only if the platform-specific element (`osx`, `linux` or `windows`) doesn't specify a value for `args`. Use ${auto-detect-url} to automatically use the address the server is listening to.",
+          "default": "${auto-detect-url}"
         },
         "osx": {
           "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-          "description": "OSX-specific web launch configuration options",
+          "description": "OSX-specific web launch configuration options. By default, this will start the browser using `open`.",
           "default": {
-            "command": "open"
+            "command": "open",
+            "args": "${auto-detect-url}"
           }
         },
         "linux": {
           "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-          "description": "Linux-specific web launch configuration options",
+          "description": "Linux-specific web launch configuration options. By default, this will start the browser using `xdg-open`.",
           "default": {
-            "command": "xdg-open"
+            "command": "xdg-open",
+            "args": "${auto-detect-url}"
           }
         },
         "windows": {
           "$ref": "#/definitions/LaunchBrowserPlatformOptions",
-          "description": "Windows-specific web launch configuration options",
+          "description": "Windows-specific web launch configuration options. By default, this will start the browser using `cmd /c start`.",
           "default": {
             "command": "cmd.exe",
             "args": "/C start ${auto-detect-url}"
@@ -295,18 +276,7 @@
           "$ref": "#/definitions/LaunchBrowser",
           "description": "Describes options to launch a web browser as part of launch",
           "default": {
-            "enabled": true,
-            "args": "${auto-detect-url}",
-            "windows": {
-              "command": "cmd.exe",
-              "args": "/C start ${auto-detect-url}"
-            },
-            "osx": {
-              "command": "open"
-            },
-            "linux": {
-              "command": "xdg-open"
-            }
+            "enabled": true
           }
         },
         "env": {

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -2,7 +2,7 @@
 OptionsSchema.json defines the type for Launch/Attach options.
 
 # GenerateOptionsSchema
-If there are any modifications to the OptionsSchema.json file. Please run `gulp generateOptionsSchema` at the repo root.
+If there are any modifications to the OptionsSchema.json file. Please run `npm run gulp generateOptionsSchema` at the repo root.
 This will call GenerateOptionsSchema and update the package.json file.
 
 ### Important notes:

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -11,82 +11,6 @@ import { AssetGenerator } from '../../src/assets';
 import { parse } from 'jsonc-parser';
 import { should } from 'chai';
 
-suite("Asset generation: project.json", () => {
-    suiteSetup(() => should());
-
-    test("Create tasks.json for project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(rootPath, 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let tasksJson = generator.createTasksConfiguration();
-        let buildPath = tasksJson.tasks[0].args[1];
-
-        // ${workspaceFolder}/project.json
-        let segments = buildPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'project.json']);
-    });
-
-    test("Create tasks.json for nested project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(path.join(rootPath, 'nested'), 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let tasksJson = generator.createTasksConfiguration();
-        let buildPath = tasksJson.tasks[0].args[1];
-
-        // ${workspaceFolder}/nested/project.json
-        let segments = buildPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'project.json']);
-    });
-
-    test("Create launch.json for project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(rootPath, 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
-
-        // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
-    });
-
-    test("Create launch.json for nested project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(path.join(rootPath, 'nested'), 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
-
-        // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
-    });
-
-    test("Create launch.json for web project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(rootPath, 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
-
-        // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
-    });
-
-    test("Create launch.json for nested web project opened in workspace", () => {
-        let rootPath = path.resolve('testRoot');
-        let info = createDotNetWorkspaceInformation(path.join(rootPath, 'nested'), 'testApp.dll', 'netcoreapp1.0');
-        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
-
-        // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
-    });
-});
-
 suite("Asset generation: csproj", () => {
     suiteSetup(() => should());
 
@@ -94,6 +18,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let tasksJson = generator.createTasksConfiguration();
         let buildPath = tasksJson.tasks[0].args[1];
 
@@ -106,6 +31,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let tasksJson = generator.createTasksConfiguration();
         let buildPath = tasksJson.tasks[0].args[1];
 
@@ -118,6 +44,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
@@ -130,6 +57,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
@@ -142,6 +70,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
@@ -154,6 +83,7 @@ suite("Asset generation: csproj", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
@@ -168,38 +98,6 @@ function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
         uri: vscode.Uri.file(rootPath),
         name: undefined,
         index: undefined
-    };
-}
-
-function createDotNetWorkspaceInformation(projectPath: string, compilationOutputAssemblyFile: string, targetFrameworkShortName: string, emitEntryPoint: boolean = true): protocol.WorkspaceInformationResponse {
-    return {
-        DotNet: {
-            Projects: [
-                {
-                    Path: projectPath,
-                    Name: '',
-                    ProjectSearchPaths: [],
-                    Configurations: [
-                        {
-                            Name: 'Debug',
-                            CompilationOutputPath: '',
-                            CompilationOutputAssemblyFile: compilationOutputAssemblyFile,
-                            CompilationOutputPdbFile: '',
-                            EmitEntryPoint: emitEntryPoint
-                        }
-                    ],
-                    Frameworks: [
-                        {
-                            Name: '',
-                            FriendlyName: '',
-                            ShortName: targetFrameworkShortName
-                        }
-                    ],
-                    SourceFiles: []
-                }
-            ],
-            RuntimePath: ''
-        }
     };
 }
 


### PR DESCRIPTION
This commit contains many improvements to our launch.json and task.json generation. Highlights:

- Schema related changes:
  - Make most of the 'launchBrowser' attributes optional, remove the extra properties from the templates, and improve the schema
  - In the configuration resolver, add a default value for 'cwd' if we are local debugging

- Generator related fixes:
  - Use a quick pick to allow the user to select which project to launch. Before we would always launch the first one OmniSharp returned.
  - Remove 'internalConsoleOptions' from the generated templates, and instead default it in the configuration resolver.
  - Fix several problems with regenerating launch/tasks.json in the case that the file already existed. We had code to delete the files and recreate it, but the logic was wrong leading us to sometimes duplicate content or not create the file at all.
  - Switch to using the '$tsc' problem matcher. We were using the '$msCompile' matcher, but that assumes that file names will be absolute paths, which isn't what 'dotnet build' provides.
  - Stop supporting project.json based projects for purposes of generating launch/tasks.json. Continuing to support these now that we let the user pick the startup project was going to be more work than it made sense to support.
  - In the case of generating launch.json through the configuration provider, we will no longer generate a set of generic configurations in error cases. We will now either use a fall back configuration which is designed to feel like an error, or we will put up an error prompt and return nothing.
  - Allow generating a tasks.json even if there is no launchable project. Note that we will not automatically generate a tasks.json in this case as I wasn't sure people would really like this, but the 'Generate Assets' command will force it.

Testing: Verified open folders/workspaces with the following conditions:
- A single class library project
- A single console app
- A single ASP.NET app
- A folder containing many launchable projects
- A workspace with multiple folders, each of which has a launchable project

This fixes: #310, #2673 and #2703