### PR TITLE
do not use --stdio argument anymore when starting OmniSharp

### DIFF
--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -294,7 +294,6 @@ export class OmniSharpServer {
         let args = [
             '-s', solutionPath,
             '--hostPID', process.pid.toString(),
-            '--stdio',
             'DotNet:enablePackageRestore=false',
             '--encoding', 'utf-8',
             '--loglevel', options.loggingLevel

--- a/tasks/spawnNode.ts
+++ b/tasks/spawnNode.ts
@@ -18,7 +18,6 @@ export default async function spawnNode(args?: string[], options?: SpawnOptions)
     
     let optionsWithFullEnvironment = {
         cwd: rootPath,
-        stdio: 'inherit', 
         ...options,
         env: {
             ...process.env,


### PR DESCRIPTION
it's not necessary, since the entire build is STDIO and the argument has been removed (it was never even inspected).