### PR TITLE
Split the acquisition event into two

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.18.0-beta8",
+  "version": "1.18.0-beta9",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",

--- a/src/InstallRuntimeDependencies.ts
+++ b/src/InstallRuntimeDependencies.ts
@@ -10,19 +10,17 @@ import { getRuntimeDependenciesPackages } from './tools/RuntimeDependencyPackage
 import { getAbsolutePathPackagesToInstall } from './packageManager/getAbsolutePathPackagesToInstall';
 import IInstallDependencies from './packageManager/IInstallDependencies';
 
-export async function installRuntimeDependencies(packageJSON: any, extensionPath: string, installDependencies: IInstallDependencies, eventStream: EventStream, platformInfo: PlatformInformation): Promise<boolean>{
+export async function installRuntimeDependencies(packageJSON: any, extensionPath: string, installDependencies: IInstallDependencies, eventStream: EventStream, platformInfo: PlatformInformation): Promise<boolean> {
     let runTimeDependencies = getRuntimeDependenciesPackages(packageJSON);
     let packagesToInstall = await getAbsolutePathPackagesToInstall(runTimeDependencies, platformInfo, extensionPath);
     if (packagesToInstall && packagesToInstall.length > 0) {
         eventStream.post(new PackageInstallation("C# dependencies"));
-        try {
-            // Display platform information and RID
-            eventStream.post(new LogPlatformInfo(platformInfo));
-            await installDependencies(packagesToInstall);
+        // Display platform information and RID
+        eventStream.post(new LogPlatformInfo(platformInfo));
+        if (await installDependencies(packagesToInstall)) {
             eventStream.post(new InstallationSuccess());
-            return true;
         }
-        catch (error) {
+        else {
             return false;
         }
     }

--- a/src/observers/TelemetryObserver.ts
+++ b/src/observers/TelemetryObserver.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PlatformInformation } from "../platform";
-import { BaseEvent, InstallationFailure, TestExecutionCountReport, TelemetryEventWithMeasures, TelemetryEvent, ProjectConfiguration} from "../omnisharp/loggingEvents";
+import { BaseEvent, InstallationFailure, TestExecutionCountReport, TelemetryEventWithMeasures, TelemetryEvent, ProjectConfiguration } from "../omnisharp/loggingEvents";
 import { PackageError } from "../packageManager/PackageError";
 import { EventType } from "../omnisharp/EventType";
 
@@ -61,7 +61,7 @@ export class TelemetryObserver {
 
     private handleInstallationSuccess(telemetryProps: { [key: string]: string; }) {
         telemetryProps['installStage'] = 'completeSuccess';
-        this.reporter.sendTelemetryEvent('Acquisition', telemetryProps);
+        this.reporter.sendTelemetryEvent('AcquisitionSucceeded', telemetryProps);
     }
 
     private handleInstallationFailure(event: InstallationFailure, telemetryProps: { [key: string]: string; }) {
@@ -75,7 +75,7 @@ export class TelemetryObserver {
             }
         }
 
-        this.reporter.sendTelemetryEvent('Acquisition', telemetryProps);
+        this.reporter.sendTelemetryEvent('AcquisitionFailed', telemetryProps);
     }
 
     private handleTestExecutionCountReport(event: TestExecutionCountReport) {

--- a/src/omnisharp/OmnisharpDownloader.ts
+++ b/src/omnisharp/OmnisharpDownloader.ts
@@ -24,15 +24,19 @@ export class OmnisharpDownloader {
         private extensionPath: string) {
     }
 
-    public async DownloadAndInstallOmnisharp(version: string, serverUrl: string, installPath: string) {
+    public async DownloadAndInstallOmnisharp(version: string, serverUrl: string, installPath: string): Promise<boolean> {
         let runtimeDependencies = getRuntimeDependenciesPackages(this.packageJSON);
         let omniSharpPackages = GetPackagesFromVersion(version, runtimeDependencies, serverUrl, installPath);
         let packagesToInstall = await getAbsolutePathPackagesToInstall(omniSharpPackages, this.platformInfo, this.extensionPath);
         if (packagesToInstall && packagesToInstall.length > 0) {
             this.eventStream.post(new PackageInstallation(`OmniSharp Version = ${version}`));
             this.eventStream.post(new LogPlatformInfo(this.platformInfo));
-            await downloadAndInstallPackages(packagesToInstall, this.networkSettingsProvider, this.eventStream, isValidDownload);
-            this.eventStream.post(new InstallationSuccess());
+            if (await downloadAndInstallPackages(packagesToInstall, this.networkSettingsProvider, this.eventStream, isValidDownload)) {
+                this.eventStream.post(new InstallationSuccess());
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/src/packageManager/IInstallDependencies.ts
+++ b/src/packageManager/IInstallDependencies.ts
@@ -6,5 +6,5 @@
 import { AbsolutePathPackage } from "./AbsolutePathPackage";
 
 export default interface IInstallDependencies {
-    (packages: AbsolutePathPackage[]): Promise<void>;
+    (packages: AbsolutePathPackage[]): Promise<boolean>;
 }

--- a/src/packageManager/downloadAndInstallPackages.ts
+++ b/src/packageManager/downloadAndInstallPackages.ts
@@ -16,7 +16,7 @@ import { mkdirpSync } from "fs-extra";
 import { PackageInstallStart } from "../omnisharp/loggingEvents";
 import { DownloadValidator } from './isValidDownload';
 
-export async function downloadAndInstallPackages(packages: AbsolutePathPackage[], provider: NetworkSettingsProvider, eventStream: EventStream, downloadValidator: DownloadValidator) {
+export async function downloadAndInstallPackages(packages: AbsolutePathPackage[], provider: NetworkSettingsProvider, eventStream: EventStream, downloadValidator: DownloadValidator): Promise<boolean> {
     if (packages) {
         eventStream.post(new PackageInstallStart());
         for (let pkg of packages) {
@@ -46,12 +46,12 @@ export async function downloadAndInstallPackages(packages: AbsolutePathPackage[]
                 if (error instanceof NestedError) {
                     let packageError = new PackageError(error.message, pkg, error.err);
                     eventStream.post(new InstallationFailure(installationStage, packageError));
-                    throw packageError;
                 }
                 else {
                     eventStream.post(new InstallationFailure(installationStage, error));
-                    throw error;
                 }
+
+                return false;
             }
             finally {
                 try {
@@ -62,5 +62,7 @@ export async function downloadAndInstallPackages(packages: AbsolutePathPackage[]
                 catch (error) { }
             }
         }
+
+        return true; //if all packages succeded in installing return true
     }
 }

--- a/src/packageManager/downloadAndInstallPackages.ts
+++ b/src/packageManager/downloadAndInstallPackages.ts
@@ -28,8 +28,10 @@ export async function downloadAndInstallPackages(packages: AbsolutePathPackage[]
                 let willTryInstallingPackage = () => count <= 2; // try 2 times
                 while (willTryInstallingPackage()) {
                     count = count + 1;
+                    installationStage = "downloadPackage";
                     let buffer = await DownloadFile(pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
                     if (downloadValidator(buffer, pkg.integrity, eventStream)) {
+                        installationStage = "installPackage";
                         await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
                         installationStage = 'touchLockFile';
                         await touchInstallFile(pkg.installPath, InstallFileType.Lock);
@@ -41,7 +43,6 @@ export async function downloadAndInstallPackages(packages: AbsolutePathPackage[]
                 }
             }
             catch (error) {
-                eventStream.post(new InstallationFailure(installationStage, error));
                 if (error instanceof NestedError) {
                     let packageError = new PackageError(error.message, pkg, error.err);
                     eventStream.post(new InstallationFailure(installationStage, packageError));

--- a/test/unitTests/InstallRuntimeDependencies.test.ts
+++ b/test/unitTests/InstallRuntimeDependencies.test.ts
@@ -29,7 +29,7 @@ suite(`${installRuntimeDependencies.name}`, () => {
     setup(() => {
         eventStream = new EventStream(); 
         eventBus = new TestEventBus(eventStream);
-        installDependencies = async() => Promise.resolve();
+        installDependencies = async() => Promise.resolve(true);
     });
     
     suite("When all the dependencies already exist", () => {
@@ -75,7 +75,7 @@ suite(`${installRuntimeDependencies.name}`, () => {
             let inputPackage: AbsolutePathPackage[];
             installDependencies = async(packages) => {
                 inputPackage = packages;
-                return Promise.resolve();
+                return Promise.resolve(true);
             };
 
             let installed = await installRuntimeDependencies(packageJSON, extensionPath, installDependencies, eventStream, platformInfo);
@@ -84,8 +84,8 @@ suite(`${installRuntimeDependencies.name}`, () => {
             expect(inputPackage[0]).to.be.deep.equal(AbsolutePathPackage.getAbsolutePathPackage(packageToInstall, extensionPath));
         });
 
-        test("Returns false when installDependencies throws exception", async () => {
-            installDependencies = async() => Promise.reject("some reason");
+        test("Returns false when installDependencies returns false", async () => {
+            installDependencies = async() => Promise.resolve(false);
             let installed = await installRuntimeDependencies(packageJSON, extensionPath, installDependencies, eventStream, platformInfo);
             expect(installed).to.be.false;
         });

--- a/test/unitTests/OmnisharpDownloader.test.ts
+++ b/test/unitTests/OmnisharpDownloader.test.ts
@@ -46,8 +46,8 @@ suite('OmnisharpDownloader', () => {
         }, testZip.buffer);
     });
 
-    test('Throws error if request is made for a version that doesnot exist on the server', () => {
-        expect(downloader.DownloadAndInstallOmnisharp("1.00000001.0000", server.baseUrl, installPath)).to.be.rejectedWith(Error);
+    test('Returns false if request is made for a version that doesnot exist on the server', async() => {
+        expect(await downloader.DownloadAndInstallOmnisharp("1.00000001.0000", server.baseUrl, installPath)).to.be.false;
     });
 
     test('Packages are downloaded and installed', async () => {

--- a/test/unitTests/Packages/downloadAndInstallPackages.test.ts
+++ b/test/unitTests/Packages/downloadAndInstallPackages.test.ts
@@ -152,7 +152,6 @@ suite(`${downloadAndInstallPackages.name}`, () => {
                 new PackageInstallStart(),
                 new DownloadStart(packageDescription),
                 new DownloadFailure(`Failed to download from ${notDownloadablePackage[0].url}. Error code '404')`),
-                new InstallationFailure("downloadPackage", new PackageError("404", notDownloadablePackage[0]))
             ];
 
             await downloadAndInstallPackages(notDownloadablePackage, networkSettingsProvider, eventStream, downloadValidator);
@@ -162,6 +161,7 @@ suite(`${downloadAndInstallPackages.name}`, () => {
             expect(obtainedEvents[2]).to.be.deep.equal(eventsSequence[2]);
             let installationFailureEvent = <InstallationFailure>obtainedEvents[3];
             expect(installationFailureEvent.stage).to.be.equal("downloadPackage");
+            expect(installationFailureEvent.error).to.not.be.null;
         });
 
         test("install.Lock is not present when the download fails", async () => {

--- a/test/unitTests/Packages/downloadAndInstallPackages.test.ts
+++ b/test/unitTests/Packages/downloadAndInstallPackages.test.ts
@@ -19,7 +19,6 @@ import TestEventBus from '../testAssets/TestEventBus';
 import { AbsolutePathPackage } from '../../../src/packageManager/AbsolutePathPackage';
 import { AbsolutePath } from '../../../src/packageManager/AbsolutePath';
 import { DownloadValidator } from '../../../src/packageManager/isValidDownload';
-import { PackageError } from '../../../src/packageManager/PackageError';
 
 chai.use(chaiAsPromised);
 let expect = chai.expect;

--- a/test/unitTests/logging/TelemetryObserver.test.ts
+++ b/test/unitTests/logging/TelemetryObserver.test.ts
@@ -45,7 +45,7 @@ suite('TelemetryReporterObserver', () => {
     test('InstallationSuccess: Telemetry props contain installation stage', () => {
         let event = new InstallationSuccess();
         observer.post(event);
-        expect(name).to.be.equal("Acquisition");
+        expect(name).to.be.equal("AcquisitionSucceeded");
         expect(property).to.have.property("installStage", "completeSuccess");
     });
 
@@ -91,16 +91,17 @@ suite('TelemetryReporterObserver', () => {
         test("Telemetry Props contains platform information, install stage and an event name", () => {
             let event = new InstallationFailure("someStage", "someError");
             observer.post(event);
+            expect(name).to.be.equal("AcquisitionFailed");
             expect(property).to.have.property("platform.architecture", platformInfo.architecture);
             expect(property).to.have.property("platform.platform", platformInfo.platform);
             expect(property).to.have.property("installStage");
-            expect(name).to.not.be.empty;
         });
 
         test(`Telemetry Props contains message and packageUrl if error is package error`, () => {
             let error = new PackageError("someError", <Package>{ "description": "foo", "url": "someurl" });
             let event = new InstallationFailure("someStage", error);
             observer.post(event);
+            expect(name).to.be.equal("AcquisitionFailed");
             expect(property).to.have.property("error.message", error.message);
             expect(property).to.have.property("error.packageUrl", error.pkg.url);
         });


### PR DESCRIPTION
Related issue: https://github.com/OmniSharp/omnisharp-vscode/issues/2902
If there is a download failure we should log it as an "AcquisitionFailed" otherwise as an "AcquisitionSucceded"