### PR TITLE
Update Razor to 1.0.0-alpha3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "csharp",
-  "version": "1.18.0-beta11",
+  "version": "1.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6151,11 +6151,11 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/d05e29c3f776b3b0f63641f5d93601c4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha2.1-20190322.5.tgz",
-      "integrity": "sha512-r2KcrxL7sLDnZl63xeA6UcauInnCRa+20XJ/Vo5iJm9xej6fMxeDfQAt6b+UCt3iVXAtIHX6GgUBshK2L2iMjw==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/bff013d366a0df66a3d0966213a95392/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190409.2.tgz",
+      "integrity": "sha512-43vAeAu9zBhehO7IUfdWXTxFItsialL72hqLTfTNYV90A76mFxuDE3GEsiuTYtFa5PkMnEpeJN6KGvRs6qiPqQ==",
       "requires": {
-        "vscode-html-languageservice": "^2.1.7",
-        "vscode-languageclient": "^5.1.0"
+        "vscode-html-languageservice": "2.1.7",
+        "vscode-languageclient": "5.2.1"
       }
     },
     "miller-rabin": {
@@ -10896,13 +10896,20 @@
       }
     },
     "vscode-html-languageservice": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.11.tgz",
-      "integrity": "sha512-wfENgWb7JjEhwsRHXhairumuxAGnFcMUwIut5P7SxGwNrJMDXkgfs6OUBZycQpbaXTkMEvwsKNKFqUQppW7P4g==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-2.1.7.tgz",
+      "integrity": "sha512-nJBfu3vYR8R2DFaXK6x8SCrJ23zDGGhI30/BfvUSTCi1Zrklhtw6BEPTMoDkalMGL3AaMQYF2JV52w6LO4KgAw==",
       "requires": {
-        "vscode-languageserver-types": "^3.13.0",
-        "vscode-nls": "^4.0.0",
+        "vscode-languageserver-types": "^3.12.0",
+        "vscode-nls": "^3.2.5",
         "vscode-uri": "^1.0.6"
+      },
+      "dependencies": {
+        "vscode-nls": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
+          "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+        }
       }
     },
     "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.32.13",
-    "razor": "1.0.0-alpha2.1-20190322.5"
+    "razor": "1.0.0-alpha3-20190409.2"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/d05e29c3f776b3b0f63641f5d93601c4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha2.1-20190322.5.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/bff013d366a0df66a3d0966213a95392/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190409.2.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "1.1.1",
     "remove-bom-buffer": "3.0.0",
@@ -302,8 +302,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/890063ec1dc258ca517d764c03b2d212/razorlanguageserver-win-x64-1.0.0-alpha2.1-20190322.5.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha2.1-20190322.5.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/47a9357ffad6eb90d4034d712bae1920/razorlanguageserver-win-x64-1.0.0-alpha3-20190409.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190409.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -315,8 +315,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/e8568cd3b28f1d7b947da4d1252fbf89/razorlanguageserver-win-x86-1.0.0-alpha2.1-20190322.5.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha2.1-20190322.5.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/8a0a1a71bd19dd1210f5d7bc91edb844/razorlanguageserver-win-x86-1.0.0-alpha3-20190409.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190409.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -328,8 +328,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/fe52ada3d813e9d5381af603346b9d7b/razorlanguageserver-linux-x64-1.0.0-alpha2.1-20190322.5.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha2.1-20190322.5.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/c9c6e4cdecbc7fd5e93d60da4f59f6bb/razorlanguageserver-linux-x64-1.0.0-alpha3-20190409.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190409.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -344,8 +344,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/61ad46e2-f624-422c-accd-666d2967399e/de81e6e1d243d743e3c0b569ebdd372e/razorlanguageserver-osx-x64-1.0.0-alpha2.1-20190322.5.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha2.1-20190322.5.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/ded6ebfd6ebcb62b48ee20266abd8d64/razorlanguageserver-osx-x64-1.0.0-alpha3-20190409.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190409.2.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"
@@ -826,6 +826,11 @@
       {
         "command": "extension.showRazorHtmlWindow",
         "title": "Show Razor Html",
+        "category": "Razor"
+      },
+      {
+        "command": "razor.reportIssue",
+        "title": "Report a Razor issue",
         "category": "Razor"
       }
     ],
@@ -2865,7 +2870,8 @@
       {
         "id": "aspnetcorerazor",
         "extensions": [
-          ".cshtml"
+          ".cshtml",
+          ".razor"
         ],
         "mimetypes": [
           "text/x-cshtml"
@@ -2888,6 +2894,10 @@
         },
         {
           "command": "extension.showRazorHtmlWindow",
+          "when": "resourceLangId == aspnetcorerazor"
+        },
+        {
+          "command": "razor.reportIssue",
           "when": "resourceLangId == aspnetcorerazor"
         }
       ],


### PR DESCRIPTION
At a high level this update adds support for:
- ASP.NET Core 3.0 preview 4 support
- Blazor/Razor Components
- TagHelpers
- Razor diagnostics
- Report an issue wizard
- More OS platform support
- Lots of bug fixes

_Note: For the ASP.NET Core 3.0 preview 4 support it requires OmniSharp-Roslyn >= 1.32.14 for most setups_

I'll work on updating the test plan for Razor after this PR.

/cc @rchande @akshita31 @danroth27 