### PR TITLE
Update Razor.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,8 +6151,8 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/bff013d366a0df66a3d0966213a95392/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190409.2.tgz",
-      "integrity": "sha512-43vAeAu9zBhehO7IUfdWXTxFItsialL72hqLTfTNYV90A76mFxuDE3GEsiuTYtFa5PkMnEpeJN6KGvRs6qiPqQ==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/88ef3084e81a41773ad6cd875fa4a653/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190425.1.tgz",
+      "integrity": "sha512-9ixxkzrkhqqKytqkF6D2BX2BYSGvkd0Bami2AsMIlEOqJoRasGssFX9f7+yrmhFFn4CFCEeovablM6Un4dGIJQ==",
       "requires": {
         "vscode-html-languageservice": "2.1.7",
         "vscode-languageclient": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.32.18",
-    "razor": "1.0.0-alpha3-20190409.2"
+    "razor": "1.0.0-alpha3-20190425.1"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/bff013d366a0df66a3d0966213a95392/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190409.2.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/88ef3084e81a41773ad6cd875fa4a653/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190425.1.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "1.1.1",
     "remove-bom-buffer": "3.0.0",
@@ -302,8 +302,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/47a9357ffad6eb90d4034d712bae1920/razorlanguageserver-win-x64-1.0.0-alpha3-20190409.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190409.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/b724216349e3fbf0bcc9adc852245385/razorlanguageserver-win-x64-1.0.0-alpha3-20190425.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190425.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -315,8 +315,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/8a0a1a71bd19dd1210f5d7bc91edb844/razorlanguageserver-win-x86-1.0.0-alpha3-20190409.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190409.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/edb817f3223ba1aafc6f63b264055db0/razorlanguageserver-win-x86-1.0.0-alpha3-20190425.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190425.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -328,8 +328,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/c9c6e4cdecbc7fd5e93d60da4f59f6bb/razorlanguageserver-linux-x64-1.0.0-alpha3-20190409.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190409.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/10304fbbf28c7595017652c751870d73/razorlanguageserver-linux-x64-1.0.0-alpha3-20190425.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190425.1.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -344,8 +344,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d1213515-40bb-4adc-821d-3c89723fcd38/ded6ebfd6ebcb62b48ee20266abd8d64/razorlanguageserver-osx-x64-1.0.0-alpha3-20190409.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190409.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/b573694261493d9ad305a4a5c72268c6/razorlanguageserver-osx-x64-1.0.0-alpha3-20190425.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190425.1.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- This version is still alpha3, it addresses an issue where if a user just had the 22 SDK on their box that Razor apps would be flooded with ambiguous errors.

/cc @rchande @akshita31 