### PR TITLE
Update debugger template/docs to use `serverReadyAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
   * As an alternative, consider installing the [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools) extension by @tintoy.
 
+## 1.20.0 (Not yet released)
+
+* Updated the auto-generated launch.json to use new mechanism for starting web browser. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+
 ## 1.19.1 (Not yet released)
 
 * Updated debugger to work correctly on Linux distributions with openssl 1.1 such as Ubuntu 19.04 ([#3010](https://github.com/OmniSharp/omnisharp-vscode/issues/3010))

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See our [change log](https://github.com/OmniSharp/omnisharp-vscode/blob/v1.19.1/
   * X64 operating systems:
     * Windows 7 SP1 and newer
     * macOS 10.12 (Sierra) and newer
-    * Linux: see [.NET Core documentation](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0-supported-os.md#linux) for the list of supported distributions. Note that other Linux distributions will likely work as well as long as they include glibc and OpenSSL.
+    * Linux: see [.NET Core documentation](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2-supported-os.md#linux) for the list of supported distributions. Note that other Linux distributions will likely work as well as long as they include glibc and OpenSSL.
   * ARM operating systems:
     * Linux is supported as a remote debugging target
 
@@ -52,10 +52,6 @@ To file a new issue to include all the related config information directly from 
 (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on macOS) and running `CSharp: Report an issue` command. This will open a browser window with all the necessary information related to the installed extensions, dotnet version, mono version, etc. Enter all the remaining information and hit submit. More information can be found on the [wiki](https://github.com/OmniSharp/omnisharp-vscode/wiki/Reporting-Issues).
 
 Alternatively you could visit https://github.com/OmniSharp/omnisharp-vscode/issues and file a new one.
-
-### Debugging
-
-The C# extension now supports basic debugging capabilities! See http://aka.ms/vscclrdebugger for details.
 
 ### Development
 

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -38,12 +38,69 @@ These are the arguments that will be passed to your program.
 ## Stop at Entry
 If you need to stop at the entry point of the target, you can optionally set `stopAtEntry` to be "true".
 
-## Launch Browser
-The launch browser field can be optionally added if you need to launch with a web browser.
-If there are web server dependencies in your project.json, the auto generated launch file will add launch 
-browser for you. It will open with the default program to handle URLs.
+## Starting a Web Browser
 
-Note that `launchBrowser` requires `"console": "internalConsole"`, as the browser launcher scrapes the standard output of the target process to know when the web server has initialized itself.
+The default launch.json template (as of C# extension v1.20.0) for ASP.NET Core projects will use the following to configure VS Code to launch a web browser when ASP.NET starts:
+
+```json
+    "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"
+    }
+```
+
+Notes about this:
+1. If you do **NOT** want the browser to automatically start, you can just delete this element 
+    (and a `launchBrowser` element if your launch.json has that instead).
+2. This pattern will launch the web browser using the URL that ASP.NET Core writes 
+    to the console. If you want to modify the URL see [specifying the browser's URL](#specifying-the-browsers-url).
+    This may be useful if the target application is running on another machine or container, 
+    or if `applicationUrl` has a special host name (example: `"applicationUrl": "http://*:1234/"`).
+3. `serverReadyAction` is a new feature from VS Code. It is recommended over the previous 
+    `launchBrowser` feature that is built into the C# extension's debugger as it can work when
+    the C# extension is running on a remote machine, it uses the default browser configured for VS 
+    Code, and it also allows using a script debugger. You can continue using `launchBrowser` instead 
+    if none of those features are important to you. You also can continue to use `launchBrowser` if
+    you want to run a specific program instead of starting the default browser.
+4. More documentation for `servereReadyAction` can be found in the [Visual Studio Code February 2019 release notes](https://code.visualstudio.com/updates/v1_32#_automatically-open-a-uri-when-debugging-a-server-program).
+5. The way this works is that VS Code will scrape the output which is set to the console. If a line 
+    matches the pattern, it will launch a browser against the URL which was 'captured' by the pattern.
+    Here is an explanation of what the pattern does:
+    * `^`: This indicates that the pattern should only be matched against the beginning of a line.
+    * `\\s*` : Matches zero or more whitespace characters. Note that `\s` indicates a whitespace character, but because this is in a json string, the `\` needs to be escaped, hence `\\s`.
+    * `Now listening on:` : This is a string literal, meaning that the next text must be `Now listening on:`.
+    * `\\s+` : Matches one or more space characters.
+    * `(` : This is the beginning of a 'capture group' -- this indicates which region of text will be saved and used to launch the browser.
+    * `http` : String literal.
+    * `s?` : Either the character `s` or nothing.
+    * `://` : String literal.
+    * `\\S+` : One or more non-whitespace characters.
+    * `)` : The end of the capture group.
+6. Both forms of browser launch require `"console": "internalConsole"`, as the browser launcher scrapes 
+    the standard output of the target process to know when the web server has initialized itself.
+
+### Specifying the browser's URL
+
+If you want to ignore the URL from the console output, you can remove the 
+`(` and `)` from the pattern, and the set `uriFormat` to what you want to launch. Example:
+
+```json
+    "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "^\\s*Now listening on:\\s+https?://\\S",
+        "uriFormat": "http://localhost:1234"
+    }
+```
+
+If you want to use the port number from the console output, but not the host name, you can also use something like this:
+
+```json
+    "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "^\\s*Now listening on:\\s+http://\\S+:([0-9]+)",
+        "uriFormat": "http://localhost:%s"
+    }
+```
 
 ## Environment variables
 Environment variables may be passed to your program using this schema:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.19.1",
+  "version": "1.20.0-beta1",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -481,12 +481,12 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                   "default": []
                 },
                 "searchMicrosoftSymbolServer": {
                   "type": "boolean",
-                  "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                   "default": false
                 },
                 "cachePath": {
@@ -914,7 +914,7 @@
                 "default": false
               },
               "launchBrowser": {
-                "description": "Describes options to launch a web browser as part of launch",
+                "description": "Legacy option used to enable launching a web browser. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser",
                 "default": {
                   "enabled": true
                 },
@@ -1330,12 +1330,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1731,12 +1731,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1855,8 +1855,9 @@
               "args": [],
               "cwd": "^\"\\${workspaceFolder}\"",
               "stopAtEntry": false,
-              "launchBrowser": {
-                "enabled": true
+              "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\"^\\\\\\\\s*Now listening on:\\\\\\\\s+(https?://\\\\\\\\S+)\""
               },
               "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
@@ -1961,7 +1962,7 @@
                 "default": false
               },
               "launchBrowser": {
-                "description": "Describes options to launch a web browser as part of launch",
+                "description": "Legacy option used to enable launching a web browser. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser",
                 "default": {
                   "enabled": true
                 },
@@ -2377,12 +2378,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2778,12 +2779,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -270,8 +270,10 @@ export function createWebLaunchConfiguration(programPath: string, workingDirecto
     "args": [],
     "cwd": "${util.convertNativePathToPosix(workingDirectory)}",
     "stopAtEntry": false,
-    "launchBrowser": {
-        "enabled": true
+    // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+    "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "^\\\\s*Now listening on:\\\\s+(https?://\\\\S+)"                
     },
     "env": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -293,7 +295,7 @@ export function createLaunchConfiguration(programPath: string, workingDirectory:
     "program": "${util.convertNativePathToPosix(programPath)}",
     "args": [],
     "cwd": "${util.convertNativePathToPosix(workingDirectory)}",
-    // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+    // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
     "console": "internalConsole",
     "stopAtEntry": false
 }`;

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -274,7 +274,7 @@
         },
         "launchBrowser": {
           "$ref": "#/definitions/LaunchBrowser",
-          "description": "Describes options to launch a web browser as part of launch",
+          "description": "Legacy option used to enable launching a web browser. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser",
           "default": {
             "enabled": true
           }


### PR DESCRIPTION
Back in February, the VS Code team added a new feature to allow VS Code to launch web browsers. This changes the templates used by the C# extension to use this.

This also makes some slight improvements to README.md that I noticed while I was fixing up docs.