### PR TITLE
Hover consistency with Visual Studio

### DIFF
--- a/src/features/documentation.ts
+++ b/src/features/documentation.ts
@@ -32,43 +32,11 @@ export function extractSummaryText(xmlDocComment: string): string {
 
 export function GetDocumentationString(structDoc: protocol.DocumentationComment) {
     let newLine = "\n\n";
-    let indentSpaces = "\t\t";
     let documentation = "";
     
     if (structDoc) {
         if (structDoc.SummaryText) {
             documentation += structDoc.SummaryText + newLine;
-        }
-
-        if (structDoc.TypeParamElements && structDoc.TypeParamElements.length > 0) {
-            documentation += "Type Parameters:" + newLine;
-            documentation += indentSpaces + structDoc.TypeParamElements.map(displayDocumentationObject).join("\n" + indentSpaces) + newLine;
-        }
-
-        if (structDoc.ParamElements && structDoc.ParamElements.length > 0) {
-            documentation += "Parameters:" + newLine;
-            documentation += indentSpaces + structDoc.ParamElements.map(displayDocumentationObject).join("\n" + indentSpaces) + newLine;
-        }
-
-        if (structDoc.ReturnsText) {
-            documentation += structDoc.ReturnsText + newLine;
-        }
-
-        if (structDoc.RemarksText) {
-            documentation += structDoc.RemarksText + newLine;
-        }
-
-        if (structDoc.ExampleText) {
-            documentation += structDoc.ExampleText + newLine;
-        }
-
-        if (structDoc.ValueText) {
-            documentation += structDoc.ValueText + newLine;
-        }
-
-        if (structDoc.Exception && structDoc.Exception.length > 0) {
-            documentation += "Exceptions:" + newLine;
-            documentation += indentSpaces + structDoc.Exception.map(displayDocumentationObject).join("\n" + indentSpaces) + newLine;
         }
 
         documentation = documentation.trim();

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -21,7 +21,7 @@ export default class OmniSharpHoverProvider extends AbstractSupport implements H
             let value = await serverUtils.typeLookup(this._server, req, token);
             if (value && value.Type) {
                 let documentation = GetDocumentationString(value.StructuredDocumentation);
-                let contents = [documentation, { language: 'csharp', value: value.Type }];
+                let contents = [{ language: 'csharp', value: value.Type }, documentation];
                 return new Hover(contents);
             }
         }

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -34,14 +34,8 @@ suite(`Hover Provider: ${testAssetWorkspace.description}`, function () {
         await vscode.commands.executeCommand("vscode.open", fileUri);
         let c = <vscode.Hover[]>(await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri, new vscode.Position(10, 29)));
         let answer: string =
-            `Checks if object is tagged with the tag.
+            `Checks if object is tagged with the tag.`
 
-Parameters:
-
-\t\tgameObject: The game object.
-\t\ttagName: Name of the tag.
-
-Returns true if object is tagged with tag.`;
-        expect((<{ language: string; value: string }>c[0].contents[0]).value).to.equal(answer);
+        expect((<{ language: string; value: string }>c[0].contents[1]).value).to.equal(answer);
     });
 });


### PR DESCRIPTION
Fixes #2610 

I also changed the display order so that it looks similar to VS's behavior:

![image](https://user-images.githubusercontent.com/1414307/58734445-77031f00-83c5-11e9-897a-c76e32bad322.png)
