### PR TITLE
Update Razor.VSCode version to 20190605.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5875,8 +5875,8 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/88ef3084e81a41773ad6cd875fa4a653/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190425.1.tgz",
-      "integrity": "sha512-9ixxkzrkhqqKytqkF6D2BX2BYSGvkd0Bami2AsMIlEOqJoRasGssFX9f7+yrmhFFn4CFCEeovablM6Un4dGIJQ==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/459eed6241652e1fa96ed4d7b8b64fd4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190605.1.tgz",
+      "integrity": "sha512-HZ4oAGpL9yvJk5vOp9Pc10lvr4wtpgDdWTpRdMamCCT/Rbuevl7ucNa4iMtp19VHkOnMuRD2G4lEikw8BnQ78g==",
       "requires": {
         "vscode-html-languageservice": "2.1.7",
         "vscode-languageclient": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.32.20",
-    "razor": "1.0.0-alpha3-20190425.1"
+    "razor": "1.0.0-alpha3-20190605.1"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/88ef3084e81a41773ad6cd875fa4a653/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190425.1.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/459eed6241652e1fa96ed4d7b8b64fd4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190605.1.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "1.1.1",
     "remove-bom-buffer": "3.0.0",
@@ -302,8 +302,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/b724216349e3fbf0bcc9adc852245385/razorlanguageserver-win-x64-1.0.0-alpha3-20190425.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190425.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/b62756b88aa67c38e5558e58464f7d1a/razorlanguageserver-win-x64-1.0.0-alpha3-20190605.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190605.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -315,8 +315,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/edb817f3223ba1aafc6f63b264055db0/razorlanguageserver-win-x86-1.0.0-alpha3-20190425.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190425.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/be0542cdd74a5911cd9a10631fc948fc/razorlanguageserver-win-x86-1.0.0-alpha3-20190605.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190605.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -328,8 +328,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/10304fbbf28c7595017652c751870d73/razorlanguageserver-linux-x64-1.0.0-alpha3-20190425.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190425.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/00b3bf13bd056d103047f302fb45a0c0/razorlanguageserver-linux-x64-1.0.0-alpha3-20190605.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190605.1.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -344,8 +344,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/0e0f8c6d-f6d0-43a9-9ad4-29d160de5a31/b573694261493d9ad305a4a5c72268c6/razorlanguageserver-osx-x64-1.0.0-alpha3-20190425.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190425.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/93c8d2bac1e92d9e4a0b43381260d4d6/razorlanguageserver-osx-x64-1.0.0-alpha3-20190605.1.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190605.1.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- These Razor changes align OmniSharp with the 3.0.0-preview6 release.