### PR TITLE
Update Razor.VSCode version to 20190606.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5875,8 +5875,8 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/459eed6241652e1fa96ed4d7b8b64fd4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190605.1.tgz",
-      "integrity": "sha512-HZ4oAGpL9yvJk5vOp9Pc10lvr4wtpgDdWTpRdMamCCT/Rbuevl7ucNa4iMtp19VHkOnMuRD2G4lEikw8BnQ78g==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/468f2aef7d13d112b5de2cc0fc5eda86/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190606.2.tgz",
+      "integrity": "sha512-OarubFtAlSVrfX/cuCemjJy61+dVFcJWbGk3UAtQa0o79TXqEUxWt1Vh81DQjW+2pDDaPJ8Ej/7T1OQuZJNWPg==",
       "requires": {
         "vscode-html-languageservice": "2.1.7",
         "vscode-languageclient": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.32.20",
-    "razor": "1.0.0-alpha3-20190605.1"
+    "razor": "1.0.0-alpha3-20190606.2"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/459eed6241652e1fa96ed4d7b8b64fd4/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190605.1.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/468f2aef7d13d112b5de2cc0fc5eda86/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190606.2.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "1.1.1",
     "remove-bom-buffer": "3.0.0",
@@ -302,8 +302,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/b62756b88aa67c38e5558e58464f7d1a/razorlanguageserver-win-x64-1.0.0-alpha3-20190605.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190605.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/22c5f59fe3ff59afac4f332bbdfe85d2/razorlanguageserver-win-x64-1.0.0-alpha3-20190606.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190606.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -315,8 +315,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/be0542cdd74a5911cd9a10631fc948fc/razorlanguageserver-win-x86-1.0.0-alpha3-20190605.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190605.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/b3cc70d8a96526b9499cf44b9595fcd3/razorlanguageserver-win-x86-1.0.0-alpha3-20190606.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190606.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -328,8 +328,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/00b3bf13bd056d103047f302fb45a0c0/razorlanguageserver-linux-x64-1.0.0-alpha3-20190605.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190605.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/d231bfff6313e0820c63fdb6ded17d67/razorlanguageserver-linux-x64-1.0.0-alpha3-20190606.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190606.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -344,8 +344,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/d149bc7f-b24b-46c6-b30f-21ac2981e333/93c8d2bac1e92d9e4a0b43381260d4d6/razorlanguageserver-osx-x64-1.0.0-alpha3-20190605.1.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190605.1.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/60003d5d-c896-4db6-a0af-069e1181d0d2/723b5edee657a47e047e16a3c88a370a/razorlanguageserver-osx-x64-1.0.0-alpha3-20190606.2.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190606.2.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- This addresses an exception that gets thrown when doing `@attribute` in an `_Imports.razor` file.