### PR TITLE
Add support for EnableEditorConfigSupport flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Updates to Razor support
 * Made QuickInfo display more consistent with Visual Studio. ([#2610](https://github.com/OmniSharp/omnisharp-vscode/issues/2610))  (_Contributed by_ [@paladique](https://github.com/paladique))(PR: [#3090](https://github.com/OmniSharp/omnisharp-vscode/pull/3090/))
 * Added support for fading unnecessary code and using statements [#2873](https://github.com/OmniSharp/omnisharp-vscode/pull/2873)
-* Added a `omnisharp.enableEditorConfigSupport` setting to enable support for .editorconfig [#3136](https://github.com/OmniSharp/omnisharp-vscode/pull/3136) (_Contributed by_ [@hoffs](https://github.com/hoffs))(PR: [omnisharp-roslyn#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))
+* Added a `omnisharp.enableEditorConfigSupport` setting to enable support for .editorconfig [#3136](https://github.com/OmniSharp/omnisharp-vscode/pull/3136) (_Contributed by_ [@hoffs](https://github.com/hoffs))(PR: [omnisharp-roslyn#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526) (_Contributed by_ [@filipw](https://github.com/filipw)))
 
 ## 1.19.1 (May 6, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Updates to Razor support
 * Made QuickInfo display more consistent with Visual Studio. ([#2610](https://github.com/OmniSharp/omnisharp-vscode/issues/2610))  (_Contributed by_ [@paladique](https://github.com/paladique))(PR: [#3090](https://github.com/OmniSharp/omnisharp-vscode/pull/3090/))
 * Added support for fading unnecessary code and using statements [#2873](https://github.com/OmniSharp/omnisharp-vscode/pull/2873)
-* Added a `omnisharp.enableEditorConfigSupport` setting to enable support for .editorconfig [#3136](https://github.com/OmniSharp/omnisharp-vscode/pull/3136) (PR: [omnisharp-roslyn#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))
+* Added a `omnisharp.enableEditorConfigSupport` setting to enable support for .editorconfig [#3136](https://github.com/OmniSharp/omnisharp-vscode/pull/3136) (_Contributed by_ [@hoffs](https://github.com/hoffs))(PR: [omnisharp-roslyn#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))
 
 ## 1.19.1 (May 6, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Updates to Razor support
 * Made QuickInfo display more consistent with Visual Studio. ([#2610](https://github.com/OmniSharp/omnisharp-vscode/issues/2610))  (_Contributed by_ [@paladique](https://github.com/paladique))(PR: [#3090](https://github.com/OmniSharp/omnisharp-vscode/pull/3090/))
 * Added support for fading unnecessary code and using statements [#2873](https://github.com/OmniSharp/omnisharp-vscode/pull/2873)
+* Added a `omnisharp.enableEditorConfigSupport` setting to enable support for .editorconfig [#3136](https://github.com/OmniSharp/omnisharp-vscode/pull/3136) (PR: [omnisharp-roslyn#1526](https://github.com/OmniSharp/omnisharp-roslyn/pull/1526))
 
 ## 1.19.1 (May 6, 2019)
 

--- a/package.json
+++ b/package.json
@@ -709,6 +709,11 @@
           "default": false,
           "description": "Enables support for roslyn analyzers, code fixes and rulesets."
         },
+        "omnisharp.enableEditorConfigSupport": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables support for reading code style, naming convention and analyzer settings from .editorconfig."
+        },
         "razor.plugin.path": {
           "type": [
             "string",

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -26,6 +26,7 @@ export class Options {
         public razorDevMode: boolean,
         public enableMsBuildLoadProjectsOnDemand: boolean,
         public enableRoslynAnalyzers: boolean,
+        public enableEditorConfigSupport: boolean,
         public razorPluginPath?: string,
         public defaultLaunchSolution?: string,
         public monoPath?: string,
@@ -64,8 +65,9 @@ export class Options {
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const defaultLaunchSolution = omnisharpConfig.get<string>('defaultLaunchSolution', undefined);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
-
+        
         const enableRoslynAnalyzers = omnisharpConfig.get<boolean>('enableRoslynAnalyzers', false);
+        const enableEditorConfigSupport = omnisharpConfig.get<boolean>('enableEditorConfigSupport', false);
 
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
@@ -123,6 +125,7 @@ export class Options {
             razorDevMode,
             enableMsBuildLoadProjectsOnDemand,
             enableRoslynAnalyzers,
+            enableEditorConfigSupport,
             razorPluginPath,
             defaultLaunchSolution,
             monoPath,

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -336,6 +336,10 @@ export class OmniSharpServer {
             args.push('RoslynExtensionsOptions:EnableAnalyzersSupport=true');
         }
 
+        if (options.enableEditorConfigSupport === true) {
+            args.push('FormattingOptions:EnableEditorConfigSupport=true');
+        }
+
         let launchInfo: LaunchInfo;
         try {
             launchInfo = await this._omnisharpManager.GetOmniSharpLaunchInfo(this.packageJSON.defaults.omniSharp, options.path, serverUrl, latestVersionFileServerPath, installPath, this.extensionPath);

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, false, undefined, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, false, false, undefined, "", "");
 }

--- a/test/unitTests/optionStream.test.ts
+++ b/test/unitTests/optionStream.test.ts
@@ -52,6 +52,7 @@ suite('OptionStream', () => {
             options.maxFindSymbolsItems.should.equal(1000);
             options.enableMsBuildLoadProjectsOnDemand.should.equal(false);
             options.enableRoslynAnalyzers.should.equal(false);
+            options.enableEditorConfigSupport.should.equal(false);
             expect(options.defaultLaunchSolution).to.be.undefined;
         });
 

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -32,6 +32,7 @@ suite("Options tests", () => {
         options.maxFindSymbolsItems.should.equal(1000);
         options.enableMsBuildLoadProjectsOnDemand.should.equal(false);
         options.enableRoslynAnalyzers.should.equal(false);
+        options.enableEditorConfigSupport.should.equal(false);
         expect(options.defaultLaunchSolution).to.be.undefined;
     });
 


### PR DESCRIPTION
Similar to https://github.com/OmniSharp/omnisharp-vscode/pull/2836

Requires https://github.com/OmniSharp/omnisharp-roslyn/pull/1526

Added flag:
```
"omnisharp.enableEditorConfigSupport": true
```
which adds `FormattingOptions:EnableEditorConfigSupport=true` to omnisharp args