### PR TITLE
Modify tasks.json tasks

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -184,52 +184,47 @@ export class AssetGenerator {
     private createBuildTaskDescription(): tasks.TaskDescription {
         let commandArgs = ['build'];
 
-        let buildProject = this.startupProject;
-        if (!buildProject) {
-            buildProject = this.fallbackBuildProject;
-        }
-        if (buildProject) {
-            const buildPath = path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, buildProject.Path));
-            commandArgs.push(util.convertNativePathToPosix(buildPath));
-        }
+        this.AddAdditionalCommandArgs(commandArgs);
 
         return {
             label: 'build',
             command: 'dotnet',
             type: 'process',
             args: commandArgs,
-            // NOTE: The "$msCompile" matcher isn't the correct matcher for 'dotnet build' as it expects all
-            // file paths to be fully qualified. The tsc matcher seems to work as we would like.
-            problemMatcher: '$tsc'
+            problemMatcher: '$msCompile'
         };
     }
 
+    
     private createPublishTaskDescription(): tasks.TaskDescription {
         let commandArgs = ['publish'];
-
-        let buildProject = this.startupProject;
-        if (!buildProject) {
-            buildProject = this.fallbackBuildProject;
-        }
-        if (buildProject) {
-            const buildPath = path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, buildProject.Path));
-            commandArgs.push(util.convertNativePathToPosix(buildPath));
-        }
-
+        
+        this.AddAdditionalCommandArgs(commandArgs);
+        
         return {
             label: 'publish',
             command: 'dotnet',
             type: 'process',
             args: commandArgs,
-            // NOTE: The "$msCompile" matcher isn't the correct matcher for 'dotnet build' as it expects all
-            // file paths to be fully qualified. The tsc matcher seems to work as we would like.
-            problemMatcher: '$tsc'
+            problemMatcher: '$msCompile'
         };
     }
-
+    
     private createWatchTaskDescription(): tasks.TaskDescription {
         let commandArgs = ['watch','run'];
-
+        
+        this.AddAdditionalCommandArgs(commandArgs);
+        
+        return {
+            label: 'watch',
+            command: 'dotnet',
+            type: 'process',
+            args: commandArgs,
+            problemMatcher: '$msCompile'
+        };
+    }
+    
+    private AddAdditionalCommandArgs(commandArgs: string[]) {
         let buildProject = this.startupProject;
         if (!buildProject) {
             buildProject = this.fallbackBuildProject;
@@ -239,17 +234,10 @@ export class AssetGenerator {
             commandArgs.push(util.convertNativePathToPosix(buildPath));
         }
 
-        return {
-            label: 'watch',
-            command: 'dotnet',
-            type: 'process',
-            args: commandArgs,
-            // NOTE: The "$msCompile" matcher isn't the correct matcher for 'dotnet build' as it expects all
-            // file paths to be fully qualified. The tsc matcher seems to work as we would like.
-            problemMatcher: '$tsc'
-        };
+        commandArgs.push("/property:GenerateFullPaths=true");
+        commandArgs.push("/consoleloggerparameters:NoSummary");
     }
-
+    
     public createTasksConfiguration(): tasks.TaskConfiguration {
         return {
             version: "2.0.0",

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -27,6 +27,26 @@ suite("Asset generation: csproj", () => {
         segments.should.deep.equal(['${workspaceFolder}', 'testApp.csproj']);
     });
 
+    test("Generated tasks.json has the property GenerateFullPaths set to true ", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let tasksJson = generator.createTasksConfiguration();
+
+        tasksJson.tasks.forEach(task => task.args.should.contain("/property:GenerateFullPaths=true"));
+    });
+
+    test("Generated tasks.json has the consoleloggerparameters argument set to NoSummary", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let tasksJson = generator.createTasksConfiguration();
+
+        tasksJson.tasks.forEach(task=> task.args.should.contain("/consoleloggerparameters:NoSummary"));
+    });
+
     test("Create tasks.json for nested project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');


### PR DESCRIPTION
Modified the tasks that are provided in the default tasks.json to:

1. Use msCompile as the problem matcher
2. GenerateFullPaths as msCompile expects full paths(https://github.com/OmniSharp/omnisharp-vscode/issues/1197)
3. Do not produce summary as that is leading to duplicate errors in the problem window(https://github.com/OmniSharp/omnisharp-vscode/issues/1198)