### PR TITLE
Fix listening to cancellation tokens in completionItemProvider

### DIFF
--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -41,9 +41,9 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         }
 
         try {
-            let responses = await serverUtils.autoComplete(this._server, req);
+            let responses = await serverUtils.autoComplete(this._server, req, token);
 
-            if (!responses || token && token.isCancellationRequested) {
+            if (!responses) {
                 return;
             }
 

--- a/src/features/completionItemProvider.ts
+++ b/src/features/completionItemProvider.ts
@@ -43,7 +43,7 @@ export default class OmniSharpCompletionItemProvider extends AbstractSupport imp
         try {
             let responses = await serverUtils.autoComplete(this._server, req);
 
-            if (!responses) {
+            if (!responses || token && token.isCancellationRequested) {
                 return;
             }
 

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -7,8 +7,8 @@ import { OmniSharpServer } from './server';
 import * as protocol from './protocol';
 import * as vscode from 'vscode';
 
-export async function autoComplete(server: OmniSharpServer, request: protocol.AutoCompleteRequest) {
-    return server.makeRequest<protocol.AutoCompleteResponse[]>(protocol.Requests.AutoComplete, request);
+export async function autoComplete(server: OmniSharpServer, request: protocol.AutoCompleteRequest, token: vscode.CancellationToken) {
+    return server.makeRequest<protocol.AutoCompleteResponse[]>(protocol.Requests.AutoComplete, request, token);
 }
 
 export async function codeCheck(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {


### PR DESCRIPTION
Should fix #2472 

I haven't tested this, since I don't know how to build Omnisharp for VSCode, but looking into the [VSCode API](https://code.visualstudio.com/api/references/vscode-api#CancellationToken) it appears we should actually take the passed `CancellationToken` into account and not return items if a cancellation was requested.

See this for a discussion on what goes wrong when the requests take longer than expected and the cancellation isn't observed:
https://github.com/OmniSharp/omnisharp-vscode/issues/2472#issuecomment-509036624

Also here in the VSCode repo it's noted that we need to listen to cancellations:
https://github.com/microsoft/vscode/issues/60753#issuecomment-430190566