### PR TITLE
 add a new configuration 'csharp.diagnosticLevel' to control what should be displayed in problems panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out
 .razor
 dist/
 *.razor.json
+yarn.lock
 
 install.*
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,28 @@
 {
     "version": "0.2.0",
-    "configurations": [    
+    "configurations": [
+        {
+            "name": "Debug Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensions-dir=${env:HOME}/.vscode/debugext",
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": ["${workspaceRoot}/dist/*.js"]
+        },
         {
             "name": "Launch Extension",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceRoot}"
-            ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/dist/*.js"],
             "preLaunchTask": "buildDev"
         },
         {
@@ -31,9 +40,7 @@
             ],
             "sourceMaps": true,
             "internalConsoleOptions": "openOnSessionStart",
-            "outFiles": [
-                "${workspaceRoot}/out/test/**/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/out/test/**/*.js"],
             "preLaunchTask": "build"
         },
         {
@@ -54,9 +61,7 @@
             },
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/out/test/**/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/out/test/**/*.js"],
             "preLaunchTask": "build"
         },
         {
@@ -79,9 +84,7 @@
             },
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/dist/*.js"],
             "preLaunchTask": "buildDev"
         },
         {
@@ -104,9 +107,7 @@
             },
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/dist/*.js"],
             "preLaunchTask": "buildDev"
         },
         {
@@ -129,9 +130,7 @@
             },
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/dist/*.js"
-            ],
+            "outFiles": ["${workspaceRoot}/dist/*.js"],
             "preLaunchTask": "buildDev"
         },
         {
@@ -140,11 +139,9 @@
             "name": "Update package dependencies",
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
-            "args": [
-                "updatePackageDependencies"
-            ],
+            "args": ["updatePackageDependencies"],
             "env": {
-                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/78355d5ef10b31e8b72e077b6bbabbca/omnisharp-linux-x64-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/572c0f88abe6a55a6a5a474f0c8f1965/omnisharp-linux-x86-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/df8feab37b0c49457b9f6fe62f940207/omnisharp-osx-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/8ac6cdbef1b99c6dc6485a79020d2c49/omnisharp-win-x64-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/235f92e460725e0b2053f94d69858241/omnisharp-win-x86-1.34.0.zip" ,
+                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/78355d5ef10b31e8b72e077b6bbabbca/omnisharp-linux-x64-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/572c0f88abe6a55a6a5a474f0c8f1965/omnisharp-linux-x86-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/df8feab37b0c49457b9f6fe62f940207/omnisharp-osx-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/8ac6cdbef1b99c6dc6485a79020d2c49/omnisharp-win-x64-1.34.0.zip,https://download.visualstudio.microsoft.com/download/pr/73cab26d-cc33-42ee-bbee-4ee2399bcd00/235f92e460725e0b2053f94d69858241/omnisharp-win-x86-1.34.0.zip",
                 "NEW_DEPS_VERSION": "1.34.0"
             },
             "cwd": "${workspaceFolder}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     },
 
     "csharp.suppressDotnetRestoreNotification": true,
+    "prettier.disableLanguages": ["typescript"],
 
     "tslint.rulesDirectory": "node_modules/tslint-microsoft-contrib",
     "typescript.tsdk": "./node_modules/typescript/lib",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "compile": "tsc -p ./ && gulp tslint",
     "compileDev": "tsc -p ./ && gulp tslint && webpack --mode development",
     "watch": "tsc -watch -p ./",
+    "watch2": "tsc -p ./ && webpack --mode development --watch",
     "tdd": "mocha --opts ./mocha.opts --watch --watch-extensions ts test/unitTests/**/*.test.ts*",
     "test": "gulp test",
     "test:unit": "gulp test:unit",
@@ -395,6 +396,16 @@
           "default": true,
           "description": "Enable/disable default C# formatter (requires restart)."
         },
+        "csharp.diagnosticLevel": {
+          "type": "string",
+          "enum": [
+            "none",
+            "error",
+            "warning"
+          ],
+          "default": "error",
+          "description": "which should show in problems panel"
+        },
         "csharp.suppressDotnetInstallWarning": {
           "type": "boolean",
           "default": false,
@@ -486,12 +497,12 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                  "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                   "default": []
                 },
                 "searchMicrosoftSymbolServer": {
                   "type": "boolean",
-                  "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                  "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                   "default": false
                 },
                 "cachePath": {
@@ -1350,12 +1361,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -1761,12 +1772,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2418,12 +2429,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {
@@ -2829,12 +2840,12 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
+                    "description": "Array of symbol server URLs (example: http​://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
                     "default": []
                   },
                   "searchMicrosoftSymbolServer": {
                     "type": "boolean",
-                    "description": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
+                    "description": "If 'true' the Microsoft Symbol server (https​://msdl.microsoft.com​/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
                     "default": false
                   },
                   "cachePath": {

--- a/package.json
+++ b/package.json
@@ -403,7 +403,7 @@
             "error",
             "warning"
           ],
-          "default": "error",
+          "default": "warning",
           "description": "which should show in problems panel"
         },
         "csharp.suppressDotnetInstallWarning": {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -27,13 +27,14 @@ export class Options {
         public enableMsBuildLoadProjectsOnDemand: boolean,
         public enableRoslynAnalyzers: boolean,
         public enableEditorConfigSupport: boolean,
+        public diagnosticLevel: string,
         public razorPluginPath?: string,
         public defaultLaunchSolution?: string,
         public monoPath?: string,
         public excludePaths?: string[],
-        public maxProjectFileCountForDiagnosticAnalysis?: number | null) 
-        {    
-        }
+        public maxProjectFileCountForDiagnosticAnalysis?: number | null,
+    ) {
+    }
 
     public static Read(vscode: vscode): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -65,9 +66,10 @@ export class Options {
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const defaultLaunchSolution = omnisharpConfig.get<string>('defaultLaunchSolution', undefined);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
-        
+
         const enableRoslynAnalyzers = omnisharpConfig.get<boolean>('enableRoslynAnalyzers', false);
         const enableEditorConfigSupport = omnisharpConfig.get<boolean>('enableEditorConfigSupport', false);
+        const diagnosticLevel = csharpConfig.get<string>('diagnosticLevel', 'error');
 
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
@@ -91,11 +93,9 @@ export class Options {
 
         let workspaceConfig = vscode.workspace.getConfiguration();
         let excludePaths = [];
-        if (workspaceConfig)
-        {
+        if (workspaceConfig) {
             let excludeFilesOption = workspaceConfig.get<{ [i: string]: boolean }>('files.exclude');
-            if (excludeFilesOption)
-            {
+            if (excludeFilesOption) {
                 for (let field in excludeFilesOption) {
                     if (excludeFilesOption[field]) {
                         excludePaths.push(field);
@@ -103,7 +103,7 @@ export class Options {
                 }
             }
         }
-        
+
 
         return new Options(
             path,
@@ -126,6 +126,7 @@ export class Options {
             enableMsBuildLoadProjectsOnDemand,
             enableRoslynAnalyzers,
             enableEditorConfigSupport,
+            diagnosticLevel,
             razorPluginPath,
             defaultLaunchSolution,
             monoPath,


### PR DESCRIPTION
sometimes I don't want show all warnings ,
but vscode has no way to  control this itself,
so I add the option to omnisharp.