### PR TITLE
Feed VSCode diagnostic code to Roslyn diagnostic id

### DIFF
--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -335,6 +335,7 @@ class DiagnosticsProvider extends AbstractSupport {
         let message = `${quickFix.Text} [${quickFix.Projects.map(n => this._asProjectLabel(n)).join(', ')}]`;
 
         let diagnostic = new vscode.Diagnostic(toRange(quickFix), message, display.severity);
+        diagnostic.source = 'csharp';
         diagnostic.code = quickFix.Id;
 
         if (display.isFadeout) {

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -335,6 +335,7 @@ class DiagnosticsProvider extends AbstractSupport {
         let message = `${quickFix.Text} [${quickFix.Projects.map(n => this._asProjectLabel(n)).join(', ')}]`;
 
         let diagnostic = new vscode.Diagnostic(toRange(quickFix), message, display.severity);
+        diagnostic.code = quickFix.Id;
 
         if (display.isFadeout) {
             diagnostic.tags = [vscode.DiagnosticTag.Unnecessary];

--- a/test/integrationTests/diagnostics.integration.test.ts
+++ b/test/integrationTests/diagnostics.integration.test.ts
@@ -44,7 +44,7 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
     test("Return unnecessary tag in case of unnesessary using", async function () {
         let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15*1000, 500);
 
-        let cs8019 = result.find(x => x.message.includes("CS8019"));
+        let cs8019 = result.find(x => x.source == "csharp" && x.code == "CS8019");
         expect(cs8019).to.not.be.undefined;
         expect(cs8019.tags).to.include(vscode.DiagnosticTag.Unnecessary);
     });
@@ -53,8 +53,8 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
         this.skip(); // Remove this once https://github.com/OmniSharp/omnisharp-roslyn/issues/1458 is resolved.
         let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15*1000, 500);
 
-        let ide0005 = result.find(x => x.message.includes("IDE0005"));
-        expect(ide0005).to.not.be(undefined);
+        let ide0005 = result.find(x => x.source == "csharp" && x.code == "IDE0005");
+        expect(ide0005).to.not.be.undefined;
         expect(ide0005.tags).to.include(vscode.DiagnosticTag.Unnecessary);
     });
 });


### PR DESCRIPTION
Relates to https://github.com/OmniSharp/omnisharp-roslyn/issues/1622

Diagnostic code is useful for code actions, since the list of diagnostics are passed to the code action handler, and having a proper code is better than having to rely only on the diagnostic message.

To avoid duplicate display of the diagnostic id in VSCode UI, the diagnostic id should stop being appended to the message:
https://github.com/OmniSharp/omnisharp-roslyn/pull/1623

Still to facilitate handling of code actions, but even in VSCode UI, I have added a source = "csharp" to all diagnostics created by this extension. It will help to distinguish them from other diagnostics created by other extensions.