### PR TITLE
Update ctor snippet in csharp.json 

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -452,7 +452,7 @@
     "constructor": {
         "prefix": "ctor",
         "body": [
-            "${1:public} ${2:ClassName}(${3:Parameters})",
+            "${1:public} ${2:${TM_FILENAME_BASE}}(${3:Parameters})",
             "{",
             "    $0",
             "}"


### PR DESCRIPTION
This PR make `ctor` snippet a bit better. It because `ctor` can guess it's method name from it's file name for most of the case.