### PR TITLE
Update Razor to work for 3.1 SDKs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5895,8 +5895,8 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/12a03813486ddd38c2cd544d8d321d1e/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190819.3.tgz",
-      "integrity": "sha512-x4FXZrZRa9m56Y4WsjL6hjL1TkXAWRYc/NDTVmXWW4bA4MwIHK9FAFLd5zuFAa+rrSKCPi86xz1ipNVN4NKYfQ==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/340ebcda4c3e7ecccdc74dadcc13b035/microsoft.aspnetcore.razor.vscode-3.1.0-preview3.19563.3.tgz",
+      "integrity": "sha512-3AxTbP2Tygbi6ScqarUkXSqpA8u2KxvREjnhiyt2x4m8BYFYpzpz9EypVzXItUJ+x9phFz+ujQvLFMqIrWMzBA==",
       "requires": {
         "vscode-html-languageservice": "2.1.7",
         "vscode-languageclient": "5.2.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.34.7",
-    "razor": "1.0.0-alpha3-20190819.3"
+    "razor": "1.0.0-alpha3-3.1.0-preview3.19563.3"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "2.2.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/12a03813486ddd38c2cd544d8d321d1e/microsoft.aspnetcore.razor.vscode-1.0.0-alpha3-20190819.3.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/340ebcda4c3e7ecccdc74dadcc13b035/microsoft.aspnetcore.razor.vscode-3.1.0-preview3.19563.3.tgz",
     "mkdirp": "0.5.1",
     "node-filter-async": "1.1.1",
     "remove-bom-buffer": "3.0.0",
@@ -302,8 +302,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/4ce6a4c459232698e28d84cdc79e668a/razorlanguageserver-win-x64-1.0.0-alpha3-20190819.3.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-1.0.0-alpha3-20190819.3.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/43c1ad5dd8a424592bc7e32d1c037786/razorlanguageserver-win-x64-3.1.0-preview3.19563.3.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-3.1.0-preview3.19563.3.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -315,8 +315,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/d570fc38d428e31c5a37db15bb6b2705/razorlanguageserver-win-x86-1.0.0-alpha3-20190819.3.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-1.0.0-alpha3-20190819.3.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/042166ccbad8038151e1fd8178015fa7/razorlanguageserver-win-x86-3.1.0-preview3.19563.3.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-3.1.0-preview3.19563.3.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -328,8 +328,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/cd5616d18309cbd3813ca099d58ab757/razorlanguageserver-linux-x64-1.0.0-alpha3-20190819.3.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-1.0.0-alpha3-20190819.3.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/98bed97d3ae3b39317903f3c8f3e64cd/razorlanguageserver-linux-x64-3.1.0-preview3.19563.3.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-3.1.0-preview3.19563.3.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -344,8 +344,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/e9818322-b13b-44d7-b54b-16d2861ccdab/42ba9f6bc81c0add103523da2198c54d/razorlanguageserver-osx-x64-1.0.0-alpha3-20190819.3.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-1.0.0-alpha3-20190819.3.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/55ae404d-0619-4092-82ec-44c2fdac8730/769a544747adf45a6cea8cf8d7460336/razorlanguageserver-osx-x64-3.1.0-preview3.19563.3.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-3.1.0-preview3.19563.3.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- These bits include a new Razor language server, O# plugin and VSCode extension that update the Razor experience to work on 3.1 DSKs