### PR TITLE
Enabling setting breakpoints for Q# files

### DIFF
--- a/package.json
+++ b/package.json
@@ -870,6 +870,7 @@
           "languageIds": [
             "csharp",
             "razor",
+            "qsharp",
             "aspnetcorerazor"
           ]
         },
@@ -1938,6 +1939,7 @@
           "languageIds": [
             "csharp",
             "razor",
+            "qsharp",
             "aspnetcorerazor"
           ]
         },


### PR DESCRIPTION
It would be awesome if you would consider supporting also debugging of Q# files. Since we are actually code generating C# files during compilation, all that would be needed to do so is to list qsharp in the package.json. It would be awesome if we could add this extension to our recommendations and gain debugging support for our VS Code users. 