### PR TITLE
Fix flakiness in test

### DIFF
--- a/test/integrationTests/languageMiddleware.integration.test.ts
+++ b/test/integrationTests/languageMiddleware.integration.test.ts
@@ -32,6 +32,10 @@ suite(`${LanguageMiddlewareFeature.name}: ${testAssetWorkspace.description}`, ()
     });
 
     test("Returns the remapped workspaceEdit", async() => {
+
+        // Avoid flakiness with renames.
+        await new Promise(r => setTimeout(r, 2000));
+
         let workspaceEdit = <vscode.WorkspaceEdit>(await vscode.commands.executeCommand(
             "vscode.executeDocumentRenameProvider",
             fileUri,


### PR DESCRIPTION
Verified locally that this fixes the flakiness with renames. We had to do this in some of our Razor rename tests as well.

cc @JoeRobich @NTaylorMullen 