### PR TITLE
Fix Go to definition on Metadata

### DIFF
--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -46,21 +46,21 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
                 const metadataSource: MetadataSource = gotoDefinitionResponse.MetadataSource;
 
                 // go to metadata endpoint for more information
-                serverUtils.getMetadata(this._server, <MetadataRequest>{
+                const metadataResponse = await serverUtils.getMetadata(this._server, <MetadataRequest>{
                     Timeout: 5000,
                     AssemblyName: metadataSource.AssemblyName,
                     VersionNumber: metadataSource.VersionNumber,
                     ProjectName: metadataSource.ProjectName,
                     Language: metadataSource.Language,
                     TypeName: metadataSource.TypeName
-                }).then(metadataResponse => {
-                    if (!metadataResponse || !metadataResponse.Source || !metadataResponse.SourceName) {
-                        return;
-                    }
-
-                    const uri: Uri = this._definitionMetadataDocumentProvider.addMetadataResponse(metadataResponse);
-                    location = new Location(uri, new Position(gotoDefinitionResponse.Line - 1, gotoDefinitionResponse.Column - 1));
                 });
+
+                if (!metadataResponse || !metadataResponse.Source || !metadataResponse.SourceName) {
+                    return;
+                }
+
+                const uri: Uri = this._definitionMetadataDocumentProvider.addMetadataResponse(metadataResponse);
+                location = new Location(uri, new Position(gotoDefinitionResponse.Line - 1, gotoDefinitionResponse.Column - 1));
             }
 
             // Allow language middlewares to re-map its edits if necessary.

--- a/test/integrationTests/definitionProvider.test.ts
+++ b/test/integrationTests/definitionProvider.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import CSharpDefinitionProvider from "../../src/features/definitionProvider";
+import * as path from "path";
+import testAssetWorkspace from "./testAssets/testAssetWorkspace";
+import { expect } from "chai";
+import { activateCSharpExtension } from './integrationHelpers';
+
+suite(`${CSharpDefinitionProvider.name}: ${testAssetWorkspace.description}`, () => {
+    let fileUri: vscode.Uri;
+
+    suiteSetup(async () => {
+        await activateCSharpExtension();
+        await testAssetWorkspace.restore();
+
+        let fileName = 'definition.cs';
+        let projectDirectory = testAssetWorkspace.projects[0].projectDirectoryPath;
+        fileUri = vscode.Uri.file(path.join(projectDirectory, fileName));
+        await vscode.commands.executeCommand("vscode.open", fileUri);
+    });
+
+    suiteTeardown(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test("Returns the definition", async() => {
+        let definitionList = <vscode.Location[]>(await vscode.commands.executeCommand("vscode.executeDefinitionProvider", fileUri, new vscode.Position(10, 31)));
+        expect(definitionList.length).to.be.equal(1);
+        expect(definitionList[0]).to.exist;
+        expect(definitionList[0].uri.path).to.contain("definition.cs");
+    });
+
+    // Skipping due to https://github.com/OmniSharp/omnisharp-vscode/issues/3458
+    test.skip("Returns the definition from Metadata", async() => {
+        let definitionList = <vscode.Location[]>(await vscode.commands.executeCommand("vscode.executeDefinitionProvider", fileUri, new vscode.Position(10, 25)));
+        expect(definitionList.length).to.be.equal(1);
+        expect(definitionList[0]).to.exist;
+        expect(definitionList[0].uri.path).to.contain("[metadata] Console.cs");
+    });
+});

--- a/test/integrationTests/testAssets/singleCsproj/definition.cs
+++ b/test/integrationTests/testAssets/singleCsproj/definition.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Test
+{
+    public class Definition
+    {
+        public static string Foo { get; set; }
+
+        public void MyMethod()
+        {
+            Console.WriteLine(Foo);
+        }
+    }
+}

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/definition.cs
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/definition.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Test
+{
+    public class Definition
+    {
+        public static string Foo { get; set; }
+
+        public void MyMethod()
+        {
+            Console.WriteLine(Foo);
+        }
+    }
+}


### PR DESCRIPTION
This broke when I made refactors to include language middleware remapping.

@JoeRobich @NTaylorMullen 