### PR TITLE
Fix DefinitionProvider being overly defensive

### DIFF
--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -21,7 +21,7 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
         this._definitionMetadataDocumentProvider = definitionMetadataDocumentProvider;
     }
 
-    public async provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Location> {
+    public async provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Promise<Location[]> {
 
         let req = <GoToDefinitionRequest>createRequest(document, position);
         req.WantMetadata = true;
@@ -65,14 +65,10 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
 
             // Allow language middlewares to re-map its edits if necessary.
             const result = await this._languageMiddlewareFeature.remap("remapLocations", [location], token);
-            if (result && result.length == 1) {
-                return result[0];
-            }
-
-            return location;
+            return result;
         }
         catch (error) {
-            return;
+            return [];
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore/issues/17867

This was an oversight. We don't need the if condition here because we can safely trust the results of `remap` as we try-catch around the whole block inside `remap`.