### PR TITLE
Install .NET Core SDK 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo dpkg -i packages-microsoft-prod.deb
   - sudo apt-get install apt-transport-https
   - sudo apt-get update
-  - sudo apt-get install dotnet-sdk-2.2
+  - sudo apt-get install dotnet-sdk-3.1
   - sudo apt install xvfb
 
 addons:


### PR DESCRIPTION
Saw travis ci builds failing (https://travis-ci.org/OmniSharp/omnisharp-vscode/jobs/627044440) because it is unable to install .net core sdk 2.2. Going to try and install a more recent version.