### PR TITLE
Add csharp.supressBuildAssetsNotification setting to allow the 'Required assets to build and debug' notifications to be supressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -612,10 +612,10 @@
           "default": false,
           "description": "Suppress the notification window to perform a 'dotnet restore' when dependencies can't be resolved."
         },
-        "csharp.suppressProjectJsonWarning": {
+        "csharp.supressBuildAssetsNotification": {
           "type": "boolean",
           "default": false,
-          "description": "Suppress the warning that project.json is no longer a supported project format for .NET Core applications"
+          "description": "Suppress the notification window to add missing assets to build or debug the application."
         },
         "csharp.suppressHiddenDiagnostics": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -612,6 +612,11 @@
           "default": false,
           "description": "Suppress the notification window to perform a 'dotnet restore' when dependencies can't be resolved."
         },
+        "csharp.suppressProjectJsonWarning": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress the warning that project.json is no longer a supported project format for .NET Core applications"
+        },
         "csharp.supressBuildAssetsNotification": {
           "type": "boolean",
           "default": false,

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -455,9 +455,12 @@ async function promptToAddAssets(workspaceFolder: vscode.WorkspaceFolder) {
 
         const projectName = path.basename(workspaceFolder.uri.fsPath);
 
-        vscode.window.showWarningMessage(
-            `Required assets to build and debug are missing from '${projectName}'. Add them?`, disableItem, noItem, yesItem)
-            .then(selection => resolve(selection.result));
+        let csharpConfig = vscode.workspace.getConfiguration('csharp');
+        if (!csharpConfig.get<boolean>('supressBuildAssetsNotification')) {
+            vscode.window.showWarningMessage(
+                `Required assets to build and debug are missing from '${projectName}'. Add them?`, disableItem, noItem, yesItem)
+                .then(selection => resolve(selection.result));
+        }
     });
 }
 


### PR DESCRIPTION
I regularly teach classes around using the .NET CLI and this setting is pretty obtrusive.

![image](https://user-images.githubusercontent.com/5067401/73472869-c08f7980-4359-11ea-9bb2-73b1868994ce.png)

I have students run ``dotnet build`` and ``dotnet run`` manually so I reguarly get asked if there is a way to suppress this notification.

I'll share an example:

- I'm teaching a class on how to create a new project using the CLI and build it
- Open an empty folder
- Run ``dotnet new console``
- Open the folder in Visual Studio Code
- The prompt will show up. We are not ready to do a build yet. We can dismiss the notification for this project, but not for future folders

This PR proposes to fix this issue by adding a new setting.
