### PR TITLE
Update OmniSharp to 1.34.11

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -119,8 +119,8 @@
                 "updatePackageDependencies"
             ],
             "env": {
-                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/c5dea00c97eb01516686d944801dce8a/omnisharp-linux-x64-1.34.10.zip,https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/d557fd237873e4e41835b150972c0f6d/omnisharp-linux-x86-1.34.10.zip,https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/9fb60fbaf6a2a21a063782ec64a3604b/omnisharp-osx-1.34.10.zip,https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/24bc14b24a159bd155a0a82560a9bbb4/omnisharp-win-x64-1.34.10.zip,https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/5b6193019dbeab0eceb1d6b7aa4baebf/omnisharp-win-x86-1.34.10.zip",
-                "NEW_DEPS_VERSION": "1.34.10"
+                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/b90373027676c50db323ac424f2ff1f4/omnisharp-linux-x64-1.34.11.zip,https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/c83ce7b1e7a9f642c892a0d77b8db57f/omnisharp-linux-x86-1.34.11.zip,https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/bbd8cf76d4c78513b0774cd9740276c7/omnisharp-osx-1.34.11.zip,https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/19ae4e7c8e788df2ae1d8b03f7c737d2/omnisharp-win-x64-1.34.11.zip,https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/7b7101973ef0ba0915df58b9d205f8c7/omnisharp-win-x86-1.34.11.zip",
+                "NEW_DEPS_VERSION": "1.34.11"
             },
             "cwd": "${workspaceFolder}"
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Known Issues in 1.21.10
+## Known Issues in 1.21.11
 
 * Known limitations with the preview Razor (cshtml) language service to be addressed in a future release:
   * Only ASP.NET Core projects are supported (no support for ASP.NET projects)
@@ -9,7 +9,13 @@
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
   * As an alternative, consider installing the [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools) extension by @tintoy.
 
-## 1.21.10 (Not yet released)
+## 1.21.11 (Not Yet Released)
+* Updated the bundled to Mono 6.8.0 and MSBuild to be copied from Mono 6.8.0 ([omnisharp-roslyn/#1693](https://github.com/OmniSharp/omnisharp-roslyn/issues/1693), PR: [omnisharp-roslyn/#1697](https://github.com/OmniSharp/omnisharp-roslyn/pull/1697))
+* Included NugetSDKResolver in the minimal MSBuild, which introduces support for Nuget based project SDKs like Arcade ([omnisharp-roslyn/#1678](https://github.com/OmniSharp/omnisharp-roslyn/issues/1678), PR: [omnisharp-roslyn/#1696](https://github.com/OmniSharp/omnisharp-roslyn/pull/1696))
+* Added option (`csharp.supressBuildAssetsNotification`) to surpress missing build asset notifications (PR:[#3538](https://github.com/OmniSharp/omnisharp-vscode/pull/3538))
+* The minimum Mono version required to run OmniSharp on has been increased to 6.4.0
+
+## 1.21.10 (February 2, 2020)
 * Updated Razor support (PR:[#3524](https://github.com/OmniSharp/omnisharp-vscode/pull/3524))
     * Added quick info (hover) support for TagHelper and Blazor components. You can now hover over TagHelpers, Components and their attributes to understand what associated C# type you're hovering over in addition to an attributes expected value type.
     * Migrated Razor's project understanding from the VSCode extension into the Language Server. This enables the language server to reboot without extra assistance (reliability) from an LSP client and also enables future Razor LSP clients to have richer functionality with less "work".

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnishar
 * [Documentation](https://code.visualstudio.com/docs/languages/csharp)
 * [Video Tutorial compiling with .NET Core](https://channel9.msdn.com/Blogs/dotnet/Get-started-VSCode-Csharp-NET-Core-Windows)
 
+## What's new in 1.21.11
+* Updated the bundled to Mono 6.8.0 and MSBuild to be copied from Mono 6.8.0 ([omnisharp-roslyn/#1693](https://github.com/OmniSharp/omnisharp-roslyn/issues/1693), PR: [omnisharp-roslyn/#1697](https://github.com/OmniSharp/omnisharp-roslyn/pull/1697))
+* Included NugetSDKResolver in the minimal MSBuild, which introduces support for Nuget based project SDKs like Arcade ([omnisharp-roslyn/#1678](https://github.com/OmniSharp/omnisharp-roslyn/issues/1678), PR: [omnisharp-roslyn/#1696](https://github.com/OmniSharp/omnisharp-roslyn/pull/1696))
+* Added option (`csharp.supressBuildAssetsNotification`) to surpress missing build asset notifications (PR:[#3538](https://github.com/OmniSharp/omnisharp-vscode/pull/3538))
+* The minimum Mono version required to run OmniSharp on has been increased to 6.4.0
+
 ## What's new in 1.21.10
 * Updated Razor support (PR:[#3524](https://github.com/OmniSharp/omnisharp-vscode/pull/3524))
     * Added quick info (hover) support for TagHelper and Blazor components. You can now hover over TagHelpers, Components and their attributes to understand what associated C# type you're hovering over in addition to an attributes expected value type.
@@ -57,10 +63,6 @@ The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnishar
 * Update Razor to work for 3.1 SDKs (PR:[#3406](https://github.com/OmniSharp/omnisharp-vscode/pull/3406))
 * Support plugins configuration in omnisharp.json (PR:[omnisharp-roslyn/#1615](https://github.com/OmniSharp/omnisharp-roslyn/pull/1615))
 * Improved support for .NET Core 3.1
-
-# What's new in  1.21.7
-* Updated the embedded Mono to 6.4.0 (PR:[omnisharp-roslyn/#1640](https://github.com/OmniSharp/omnisharp-roslyn/pull/1640))
-* Improved support for .NET Core 3
 
 ### Supported Operating Systems for Debugging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "csharp",
-  "version": "1.21.10",
+  "version": "1.21.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-vscode",
-  "version": "1.21.10",
+  "version": "1.21.11",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -29,7 +29,7 @@
     "dotnet"
   ],
   "defaults": {
-    "omniSharp": "1.34.10",
+    "omniSharp": "1.34.11",
     "razor": "1.0.0-alpha3-5.0.0-alpha.1.20073.7"
   },
   "main": "./dist/extension",
@@ -159,41 +159,41 @@
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/5b6193019dbeab0eceb1d6b7aa4baebf/omnisharp-win-x86-1.34.10.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.34.10.zip",
-      "installPath": ".omnisharp/1.34.10",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/7b7101973ef0ba0915df58b9d205f8c7/omnisharp-win-x86-1.34.11.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x86-1.34.11.zip",
+      "installPath": ".omnisharp/1.34.11",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86"
       ],
-      "installTestPath": "./.omnisharp/1.34.10/OmniSharp.exe",
+      "installTestPath": "./.omnisharp/1.34.11/OmniSharp.exe",
       "platformId": "win-x86",
-      "integrity": "FCE930D345C02BAB46BE22B3570A1DCEFFB3495CB71FDF02A83E7F74B210ECED"
+      "integrity": "3477A8343F4110E3996A1290E88CE27082F7F8C725186911F202D41FE38EB64A"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/24bc14b24a159bd155a0a82560a9bbb4/omnisharp-win-x64-1.34.10.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.34.10.zip",
-      "installPath": ".omnisharp/1.34.10",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/19ae4e7c8e788df2ae1d8b03f7c737d2/omnisharp-win-x64-1.34.11.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.34.11.zip",
+      "installPath": ".omnisharp/1.34.11",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86_64"
       ],
-      "installTestPath": "./.omnisharp/1.34.10/OmniSharp.exe",
+      "installTestPath": "./.omnisharp/1.34.11/OmniSharp.exe",
       "platformId": "win-x64",
-      "integrity": "00B46E3004D7A4FF5F9DEADDBAFDD62A44DBB74EF79E1A49B770E95A4DEC211B"
+      "integrity": "CE8FBB8B22FF9E25361EF78E677A3E600F61008FDB793E693060CFF6505EC200"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for OSX",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/9fb60fbaf6a2a21a063782ec64a3604b/omnisharp-osx-1.34.10.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-osx-1.34.10.zip",
-      "installPath": ".omnisharp/1.34.10",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/bbd8cf76d4c78513b0774cd9740276c7/omnisharp-osx-1.34.11.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-osx-1.34.11.zip",
+      "installPath": ".omnisharp/1.34.11",
       "platforms": [
         "darwin"
       ],
@@ -201,16 +201,16 @@
         "./mono.osx",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.34.10/run",
+      "installTestPath": "./.omnisharp/1.34.11/run",
       "platformId": "osx",
-      "integrity": "240668FF2771D682282DCE117ACDB7AEC977FF0445624933436A852257EA64CE"
+      "integrity": "6B63DCE0519E5BF1CFAA4DAEE19834A6B348C0ED450D05B53C2A694338C44DAA"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Linux (x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/d557fd237873e4e41835b150972c0f6d/omnisharp-linux-x86-1.34.10.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-linux-x86-1.34.10.zip",
-      "installPath": ".omnisharp/1.34.10",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/c83ce7b1e7a9f642c892a0d77b8db57f/omnisharp-linux-x86-1.34.11.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-linux-x86-1.34.11.zip",
+      "installPath": ".omnisharp/1.34.11",
       "platforms": [
         "linux"
       ],
@@ -222,16 +222,16 @@
         "./mono.linux-x86",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.34.10/run",
+      "installTestPath": "./.omnisharp/1.34.11/run",
       "platformId": "linux-x86",
-      "integrity": "399D4CCBE46573F5084657B5D0D7D56AED516EAEB673960BE80B475D1A70DF4B"
+      "integrity": "F550E3AD4A2A394CCE5023D2A8588B3D23FDDEE8E3B7FEEB694DB51BE1E5C8E2"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Linux (x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/b146ec31-8d19-45ca-96ff-d04a8b436b25/c5dea00c97eb01516686d944801dce8a/omnisharp-linux-x64-1.34.10.zip",
-      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-linux-x64-1.34.10.zip",
-      "installPath": ".omnisharp/1.34.10",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/c45cccfd-d481-48f9-941d-2f31712f3edc/b90373027676c50db323ac424f2ff1f4/omnisharp-linux-x64-1.34.11.zip",
+      "fallbackUrl": "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-linux-x64-1.34.11.zip",
+      "installPath": ".omnisharp/1.34.11",
       "platforms": [
         "linux"
       ],
@@ -242,9 +242,9 @@
         "./mono.linux-x86_64",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.34.10/run",
+      "installTestPath": "./.omnisharp/1.34.11/run",
       "platformId": "linux-x64",
-      "integrity": "6CAE32D0C60D9535C86F175FB71A0B16F8CD293947C1E674C85ECD1AFF970890"
+      "integrity": "B1E56C7AC62F6E8B6C6D680DA3A7FAD35599304D1F6BBA763D4E8301A3CAF362"
     },
     {
       "id": "Debugger",

--- a/package.json
+++ b/package.json
@@ -661,11 +661,11 @@
             "never"
           ],
           "enumDescriptions": [
-            "Automatically launch OmniSharp with \"mono\" if version 5.8.1 or greater is available on the PATH.",
-            "Always launch OmniSharp with \"mono\". If version 5.8.1 or greater is not available on the PATH, an error will be printed.",
+            "Automatically launch OmniSharp with \"mono\" if version 6.4.0 or greater is available on the PATH.",
+            "Always launch OmniSharp with \"mono\". If version 6.4.0 or greater is not available on the PATH, an error will be printed.",
             "Never launch OmniSharp on a globally-installed Mono."
           ],
-          "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 5.8.1 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 5.8.1 or greater is available on the PATH."
+          "description": "Launch OmniSharp with the globally-installed Mono. If set to \"always\", \"mono\" version 6.4.0 or greater must be available on the PATH. If set to \"auto\", OmniSharp will be launched with \"mono\" if version 6.4.0 or greater is available on the PATH."
         },
         "omnisharp.monoPath": {
           "type": [

--- a/src/omnisharp/OmniSharpMonoResolver.ts
+++ b/src/omnisharp/OmniSharpMonoResolver.ts
@@ -10,9 +10,9 @@ import { IMonoResolver } from '../constants/IMonoResolver';
 import { MonoInformation } from '../constants/MonoInformation';
 import { IGetMonoVersion } from '../constants/IGetMonoVersion';
 
-export class OmniSharpMonoResolver implements IMonoResolver { 
-    private minimumMonoVersion = "6.6.0";
-    
+export class OmniSharpMonoResolver implements IMonoResolver {
+    private minimumMonoVersion = "6.4.0";
+
     constructor(private getMonoVersion: IGetMonoVersion) {
     }
 
@@ -24,7 +24,7 @@ export class OmniSharpMonoResolver implements IMonoResolver {
             env['MONO_GAC_PREFIX'] = options.monoPath;
             monoPath = options.monoPath;
         }
-    
+
         let version = await this.getMonoVersion(env);
 
         return {

--- a/test/unitTests/omnisharp/OmniSharpMonoResolver.test.ts
+++ b/test/unitTests/omnisharp/OmniSharpMonoResolver.test.ts
@@ -19,9 +19,9 @@ suite(`${OmniSharpMonoResolver.name}`, () => {
 
     const monoPath = "monoPath";
 
-    const lowerMonoVersion = "6.4.0";
-    const requiredMonoVersion = "6.6.0";
-    const higherMonoVersion = "6.8.0";
+    const lowerMonoVersion = "6.2.0";
+    const requiredMonoVersion = "6.4.0";
+    const higherMonoVersion = "6.6.0";
 
     const getMono = (version: string) => async(env: NodeJS.ProcessEnv) => {
         getMonoCalled = true;


### PR DESCRIPTION
Fixes the minimal Mono libintl issue 
Choose 6.4.0 as the required version since it supports .NET Core 3.1