### PR TITLE
Add ability to use custom runsettings for tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,32 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build --if-present
+    - run: npm test
+    - run: mkdir artifact
+    - run: vsce package -o ./artifact/omnisharp-vscode.vsix
+      env:
+        CI: true
+        
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: vsix
+        path: ./artifact/omnisharp-vscode.vsix

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -556,16 +556,24 @@ export namespace V2 {
     }
 
     // dotnet-test endpoints
-    export interface DebugTestGetStartInfoRequest extends Request {
+    interface SingleTestRequest extends Request {
         MethodName: string;
+        RunSettings: string;
         TestFrameworkName: string;
         TargetFrameworkVersion: string;
     }
 
-    export interface DebugTestClassGetStartInfoRequest extends Request {
+    interface MultiTestRequest extends Request {
         MethodNames: string[];
+        RunSettings: string;
         TestFrameworkName: string;
         TargetFrameworkVersion: string;
+    }
+
+    export interface DebugTestGetStartInfoRequest extends SingleTestRequest {
+    }
+
+    export interface DebugTestClassGetStartInfoRequest extends MultiTestRequest {
     }
 
     export interface DebugTestGetStartInfoResponse {
@@ -588,10 +596,7 @@ export namespace V2 {
     export interface DebugTestStopResponse {
     }
 
-    export interface GetTestStartInfoRequest extends Request {
-        MethodName: string;
-        TestFrameworkName: string;
-        TargetFrameworkVersion: string;
+    export interface GetTestStartInfoRequest extends SingleTestRequest {
     }
 
     export interface GetTestStartInfoResponse {
@@ -600,16 +605,10 @@ export namespace V2 {
         WorkingDirectory: string;
     }
 
-    export interface RunTestRequest extends Request {
-        MethodName: string;
-        TestFrameworkName: string;
-        TargetFrameworkVersion: string;
+    export interface RunTestRequest extends SingleTestRequest {
     }
 
-    export interface RunTestsInClassRequest extends Request {
-        MethodNames: string[];
-        TestFrameworkName: string;
-        TargetFrameworkVersion: string;
+    export interface RunTestsInClassRequest extends MultiTestRequest {
     }
 
     export module TestOutcomes {


### PR DESCRIPTION
RunSettings are set as a path by the omnisharp.testRunSettings setting, and then forwarded to the server to use when it run tests.

Related PR - https://github.com/OmniSharp/omnisharp-roslyn/pull/1708
