### PR TITLE
Add Error Message for Unsupported Platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ mono:
   - latest
 
 env:
-- CODE_VERSION=1.33.0
+- CODE_VERSION=1.36.0
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then

--- a/package.json
+++ b/package.json
@@ -359,7 +359,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.31.0"
+    "vscode": "^1.36.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
 
     if (!isSupportedPlatform(platformInfo)) {
         const platform: string = platformInfo.platform ? platformInfo.platform : "this platform";
-        const architecture: string = platformInfo.architecture ? platformInfo.architecture : " and architecture";
+        const architecture: string = platformInfo.architecture ? platformInfo.architecture : " and <unknown processor architecture>";
         let errorMessage: string = `The C# extension for Visual Studio Code (powered by OmniSharp) is incompatiable on ${platform} ${architecture}`;
         const messageOptions: vscode.MessageOptions = {
         };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -191,6 +191,9 @@ export class PlatformInformation {
             if (process.env.PROCESSOR_ARCHITECTURE === 'x86' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
                 resolve('x86');
             }
+            else if (process.env.PROCESSOR_ARCHITECTURE === 'ARM64' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
+                resolve('ARM64');
+            }
             else {
                 resolve('x86_64');
             }

--- a/src/vscodeAdapter.ts
+++ b/src/vscodeAdapter.ts
@@ -943,7 +943,7 @@ export interface vscode {
     };
     extensions: {
         getExtension(extensionId: string): Extension<any> | undefined;
-        all: Extension<any>[];
+        all: ReadonlyArray<Extension<any>>;
     };
     Uri: {
         parse(value: string): Uri;


### PR DESCRIPTION
This PR adds in a check to see what platform the extension is running on. 
If it is running via Remote SSH, we reccomend users to code on their host machine and debug remotely. 
If they are running VS Code somehow on an unsupported platform, we will mention that the C# extension is incompatiable with the current platform and arch.

Bumping up vscode engine to 1.36 for `extension.ExtensionKind` checks. [More Info](https://code.visualstudio.com/api/advanced-topics/remote-extensions#varying-behaviors-when-running-remotely-or-vs-onlines-browser-editor) Had to modify vscodeAdapter.ts to match vscode engine 1.36

Addresses #3425

Example error message:
![image](https://user-images.githubusercontent.com/3953714/74578710-1ca5f080-4f4b-11ea-9def-eb34d7b25855.png)
