### PR TITLE
Detect Blazor WASM projects and add/update appropriate config to allow launching and debugging

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -98,8 +98,8 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
                 const buildOperations : AssetOperations = await getBuildOperations(generator);
                 await addTasksJsonIfNecessary(generator, buildOperations);
                 
-                const isWebProject = generator.hasWebServerDependency();
-                const launchJson: string = generator.createLaunchJson(isWebProject);
+                const programLaunchType = generator.computeProgramLaunchType();
+                const launchJson: string = generator.createLaunchJson(programLaunchType);
 
                 // jsonc-parser's parse function parses a JSON string with comments into a JSON object. However, this removes the comments. 
                 return parse(launchJson);

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -99,7 +99,7 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
                 await addTasksJsonIfNecessary(generator, buildOperations);
                 
                 const programLaunchType = generator.computeProgramLaunchType();
-                const launchJson: string = generator.createLaunchJson(programLaunchType);
+                const launchJson: string = generator.createLaunchJsonConfigurations(programLaunchType);
 
                 // jsonc-parser's parse function parses a JSON string with comments into a JSON object. However, this removes the comments. 
                 return parse(launchJson);

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -335,7 +335,8 @@ export interface MSBuildProject {
     IsExe: boolean;
     IsUnityProject: boolean;
     IsWebProject: boolean;
-    IsBlazorWebAssemblyProject: boolean;
+    IsBlazorWebAssemblyStandalone: boolean;
+    IsBlazorWebAssemblyHosted: boolean;
 }
 
 export interface TargetFramework {
@@ -792,7 +793,7 @@ export function findExecutableMSBuildProjects(projects: MSBuildProject[]) {
     let result: MSBuildProject[] = [];
 
     projects.forEach(project => {
-        if (project.IsExe && (findNetCoreAppTargetFramework(project) !== undefined || project.IsBlazorWebAssemblyProject)) {
+        if (project.IsExe && (findNetCoreAppTargetFramework(project) !== undefined || project.IsBlazorWebAssemblyStandalone)) {
             result.push(project);
         }
     });

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -334,6 +334,8 @@ export interface MSBuildProject {
     OutputPath: string;
     IsExe: boolean;
     IsUnityProject: boolean;
+    IsWebProject: boolean;
+    IsBlazorWebAssemblyProject: boolean;
 }
 
 export interface TargetFramework {
@@ -790,7 +792,7 @@ export function findExecutableMSBuildProjects(projects: MSBuildProject[]) {
     let result: MSBuildProject[] = [];
 
     projects.forEach(project => {
-        if (project.IsExe && findNetCoreAppTargetFramework(project) !== undefined) {
+        if (project.IsExe && (findNetCoreAppTargetFramework(project) !== undefined || project.IsBlazorWebAssemblyProject)) {
             result.push(project);
         }
     });

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -81,7 +81,7 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
         if (!blazorDetectionEnabled && response.MsBuild.Projects.some(project => isBlazorWebAssemblyProject(project))) {
             // There's a Blazor Web Assembly project but VSCode isn't configured to debug the WASM code, show a notification
             // to help the user configure their VSCode appropriately.
-            vscode.window.showInformationMessage('Your VSCode is not configured to debug Blazor web assembly applications.', 'Learn more', 'Close')
+            vscode.window.showInformationMessage('Additional setup is required to debug Blazor WebAssembly apps.', 'Learn more', 'Close')
                 .then(async result => {
                     if (result === 'Learn more') {
                         const uriToOpen = vscode.Uri.parse('https://aka.ms/blazordebugging#vscode');

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -77,6 +77,18 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
             project.IsBlazorWebAssemblyHosted = blazorDetectionEnabled && isBlazorWebAssemblyHosted(project);
             project.IsBlazorWebAssemblyStandalone = blazorDetectionEnabled && !project.IsBlazorWebAssemblyHosted && isBlazorWebAssemblyProject(project);
         }
+
+        if (!blazorDetectionEnabled && response.MsBuild.Projects.some(project => isBlazorWebAssemblyProject(project))) {
+            // There's a Blazor Web Assembly project but VSCode isn't configured to debug the WASM code, show a notification
+            // to help the user configure their VSCode appropriately.
+            vscode.window.showInformationMessage('Your VSCode is not configured to debug Blazor web assembly applications.', 'Learn more', 'Close')
+                .then(async result => {
+                    if (result === 'Learn more') {
+                        const uriToOpen = vscode.Uri.parse('https://aka.ms/blazordebugging#vscode');
+                        await vscode.commands.executeCommand('vscode.open', uriToOpen);
+                    }
+                });
+        }
     }
 
     return response;

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -81,7 +81,7 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
         if (!blazorDetectionEnabled && response.MsBuild.Projects.some(project => isBlazorWebAssemblyProject(project))) {
             // There's a Blazor Web Assembly project but VSCode isn't configured to debug the WASM code, show a notification
             // to help the user configure their VSCode appropriately.
-            vscode.window.showInformationMessage('Additional setup is required to debug Blazor WebAssembly apps.', 'Learn more', 'Close')
+            vscode.window.showInformationMessage('Additional setup is required to debug Blazor WebAssembly applications.', 'Learn more', 'Close')
                 .then(async result => {
                     if (result === 'Learn more') {
                         const uriToOpen = vscode.Uri.parse('https://aka.ms/blazordebugging#vscode');

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -65,7 +65,7 @@ suite("Asset generation: csproj", () => {
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Console), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
@@ -78,7 +78,7 @@ suite("Asset generation: csproj", () => {
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Console), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
@@ -86,12 +86,12 @@ suite("Asset generation: csproj", () => {
         segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
-    test("Create launch.json for Blazor web assembly project opened in workspace", () => {
+    test("Create launch.json for Blazor web assembly standalone project opened in workspace", () => {
         const rootPath = path.resolve('testRoot');
-        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyProject*/ true);
+        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
         const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        const launchJson = parse(generator.createLaunchJson(ProgramLaunchType.BlazorWebAssembly), undefined, { disallowComments: true });
+        const launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyStandalone), undefined, { disallowComments: true });
         const devServerLaunchConfig = launchJson[0];
         const chromeLaunchConfig = launchJson[1];
         const devProgram = devServerLaunchConfig.program;
@@ -101,12 +101,12 @@ suite("Asset generation: csproj", () => {
         chromeWebRoot.should.equal('${workspaceFolder}');
     });
 
-    test("Create launch.json for nested Blazor web assembly project opened in workspace", () => {
+    test("Create launch.json for nested Blazor web assembly standalone project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyProject*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.BlazorWebAssembly), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyStandalone), undefined, { disallowComments: true });
         const devServerLaunchConfig = launchJson[0];
         const chromeLaunchConfig = launchJson[1];
         const devProgram = devServerLaunchConfig.program;
@@ -116,12 +116,44 @@ suite("Asset generation: csproj", () => {
         chromeWebRoot.should.equal('${workspaceFolder}/nested');
     });
 
+    test("Create launch.json for Blazor web assembly hosted project opened in workspace", () => {
+        const rootPath = path.resolve('testRoot');
+        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
+        const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        const launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
+        const hostedServerLaunchConfig = launchJson[0];
+        const chromeLaunchConfig = launchJson[1];
+        const programPath = hostedServerLaunchConfig.program;
+        const chromeWebRoot = chromeLaunchConfig.webRoot;
+
+        let segments = programPath.split(path.posix.sep);
+        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp3.0', 'testApp.dll']);
+        chromeWebRoot.should.equal('${workspaceFolder}');
+    });
+
+    test("Create launch.json for nested Blazor web assembly hosted project opened in workspace", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
+        const hostedServerLaunchConfig = launchJson[0];
+        const chromeLaunchConfig = launchJson[1];
+        const programPath = hostedServerLaunchConfig.program;
+        const chromeWebRoot = chromeLaunchConfig.webRoot;
+
+        let segments = programPath.split(path.posix.sep);
+        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp3.0', 'testApp.dll']);
+        chromeWebRoot.should.equal('${workspaceFolder}/nested');
+    });
+
     test("Create launch.json for web project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Web), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
@@ -134,7 +166,7 @@ suite("Asset generation: csproj", () => {
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Web), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
@@ -151,7 +183,7 @@ function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
     };
 }
 
-function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, isExe: boolean = true, isWebProject: boolean = false, isBlazorWebAssemblyProject: boolean = false): protocol.WorkspaceInformationResponse {
+function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, isExe: boolean = true, isWebProject: boolean = false, isBlazorWebAssemblyStandalone: boolean = false, isBlazorWebAssemblyHosted: boolean = false): protocol.WorkspaceInformationResponse {
     return {
         MsBuild: {
             SolutionPath: '',
@@ -174,7 +206,8 @@ function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: st
                     IsExe: isExe,
                     IsUnityProject: false,
                     IsWebProject: isWebProject,
-                    IsBlazorWebAssemblyProject: isBlazorWebAssemblyProject,
+                    IsBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted,
+                    IsBlazorWebAssemblyStandalone: isBlazorWebAssemblyStandalone,
                 }
             ],
         }

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as protocol from '../../src/omnisharp/protocol';
 import * as vscode from 'vscode';
 
-import { AssetGenerator } from '../../src/assets';
+import { AssetGenerator, ProgramLaunchType } from '../../src/assets';
 import { parse } from 'jsonc-parser';
 import { should } from 'chai';
 
@@ -65,7 +65,7 @@ suite("Asset generation: csproj", () => {
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Console), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
@@ -78,7 +78,7 @@ suite("Asset generation: csproj", () => {
         let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ false), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Console), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
@@ -86,12 +86,42 @@ suite("Asset generation: csproj", () => {
         segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
     });
 
-    test("Create launch.json for web project opened in workspace", () => {
+    test("Create launch.json for Blazor web assembly project opened in workspace", () => {
+        const rootPath = path.resolve('testRoot');
+        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyProject*/ true);
+        const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        const launchJson = parse(generator.createLaunchJson(ProgramLaunchType.BlazorWebAssembly), undefined, { disallowComments: true });
+        const devServerLaunchConfig = launchJson[0];
+        const chromeLaunchConfig = launchJson[1];
+        const devProgram = devServerLaunchConfig.program;
+        const chromeWebRoot = chromeLaunchConfig.webRoot;
+
+        devProgram.should.equal('dotnet');
+        chromeWebRoot.should.equal('${workspaceFolder}');
+    });
+
+    test("Create launch.json for nested Blazor web assembly project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.BlazorWebAssembly), undefined, { disallowComments: true });
+        const devServerLaunchConfig = launchJson[0];
+        const chromeLaunchConfig = launchJson[1];
+        const devProgram = devServerLaunchConfig.program;
+        const chromeWebRoot = chromeLaunchConfig.webRoot;
+
+        devProgram.should.equal('dotnet');
+        chromeWebRoot.should.equal('${workspaceFolder}/nested');
+    });
+
+    test("Create launch.json for web project opened in workspace", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Web), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
@@ -101,10 +131,10 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for nested web project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
-        let launchJson = parse(generator.createLaunchJson(/*isWebProject*/ true), undefined, { disallowComments: true });
+        let launchJson = parse(generator.createLaunchJson(ProgramLaunchType.Web), undefined, { disallowComments: true });
         let programPath = launchJson[0].program;
 
         // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
@@ -121,7 +151,7 @@ function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
     };
 }
 
-function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, isExe: boolean = true): protocol.WorkspaceInformationResponse {
+function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, isExe: boolean = true, isWebProject: boolean = false, isBlazorWebAssemblyProject: boolean = false): protocol.WorkspaceInformationResponse {
     return {
         MsBuild: {
             SolutionPath: '',
@@ -142,7 +172,9 @@ function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: st
                     ],
                     OutputPath: '',
                     IsExe: isExe,
-                    IsUnityProject: false
+                    IsUnityProject: false,
+                    IsWebProject: isWebProject,
+                    IsBlazorWebAssemblyProject: isBlazorWebAssemblyProject,
                 }
             ],
         }


### PR DESCRIPTION
- Didn't want to pollute the omnisharp-roslyn language server with an understanding of Blazor WASM projects so built a heuristic on the client to decide if a project looks like a Blazor WASM project. This approach is similar to how web projects are detected today (look at the csproj and see if there's the line `sdk=microsoft.net.sdk.web` case insensitively). The heuristic for Blazor web assembly project requires the following from the project:
  1. User has the JavaScript Debugger (Nightly) extension installed
  1. User has the `debug.node.useV3` setting set to `true`
  1. User has the `debug.chrome.useV3` setting set to `true`
  1. Contains a `launchSettings.json` file containing the text `"inspectUri"`.
  1. (Blazor hosted only) Is executable
  1. (Blazor hosted only) References the web SDK
  1. (Blazor hosted only) Netcoreapp targetting

- Moved some core utility code such as `isWebProject` into the `util.ts` file.
- Created a new `ProgramLaunchType` enum to influence how launch.json's are created. There's a special case in this new launch enum that knows about Blazor web assembly project types.
- Added the understanding of the new `ProgramLaunchType.BlazorWebAssemblyStandalone` and  `ProgramLaunchType.BlazorWebAssemblyHosted` launch types to produce two `launch.json` configurations:
1. Launch the Blazor dev server
1. Launch the Blazor web assembly project in chrome while attached.

- Added asset tests to verify that we properly generate the new Blazor web assembly configurations.

Example launch.json output for a hosted application:
```
{
   // Use IntelliSense to find out which attributes exist for C# debugging
   // Use hover for the description of the existing attributes
   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
   "version": "0.2.0",
   "configurations": [
        {
            "name": ".NET Core Launch (Blazor Hosted)",
            "type": "coreclr",
            "request": "launch",
            // If you have changed target frameworks, make sure to update the program path.
            "program": "${workspaceFolder}/Server/bin/Debug/netcoreapp3.1/BlazorWasmHosted1.Server.dll",
            "args": [],
            "cwd": "${workspaceFolder}/Server",
            "stopAtEntry": false,
            "env": {
                "ASPNETCORE_ENVIRONMENT": "Development"
            },
            "preLaunchTask": "build"
        },
        {
            "name": ".NET Core Debug Blazor Web Assembly in Chrome",
            "type": "pwa-chrome",
            "request": "launch",
            "timeout": 30000,
            // If you have changed the default port / launch URL make sure to update the expectation below
            "url": "http://localhost:5000",
            "webRoot": "${workspaceFolder}/Server",
            "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}"
        }
    ]
}
```

https://github.com/dotnet/aspnetcore/issues/17549

/cc @pranavkm @SteveSandersonMS @mkArtakMSFT @rynowak @javiercn @danroth27 