### PR TITLE
Ignore screen size error reported by ps

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -90,6 +90,16 @@ export async function getUnixChildProcessIds(pid: number): Promise<number[]> {
         });
 
         ps.on('error', reject);
+
+        ps.stderr.setEncoding('utf8');
+        ps.stderr.on('data', data => {
+            const e = data.toString();
+            if (e.indexOf('screen size is bogus') >= 0) {
+                // ignore this error silently; see https://github.com/microsoft/vscode/issues/75932
+            } else {
+                reject(new Error(data.toString()));
+            }
+        });
     });
 }
 


### PR DESCRIPTION
As suggested in https://github.com/microsoft/vscode/issues/75932#issuecomment-595848213 we can ignore the screen size error reported on stderr.

May resolve #3580