### PR TITLE
Make launchSettings.json search performant.

### DIFF
--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs-extra';
-import * as glob from 'glob';
 import { OmniSharpServer } from './server';
 import * as path from 'path';
 import * as protocol from './protocol';
@@ -170,9 +169,21 @@ function isBlazorWebAssemblyHosted(project: protocol.MSBuildProject): boolean {
     return true;
 }
 
+function getLaunchSettingsJson(projectDirectory: string) {
+    const rootOfProjectSettings = path.join(projectDirectory, 'launchSettings.json');
+    if (fs.existsSync(rootOfProjectSettings)) {
+        return rootOfProjectSettings;
+    }
+
+    const inPropertiesOfProject = path.join(projectDirectory, 'Properties', 'launchSettings.json');
+    if (fs.existsSync(inPropertiesOfProject)) {
+        return inPropertiesOfProject;
+    }
+}
+
 function isBlazorWebAssemblyProject(project: MSBuildProject): boolean {
     const projectDirectory = path.dirname(project.Path);
-    const launchSettings = glob.sync('**/launchSettings.json', { cwd: projectDirectory });
+    const launchSettings = getLaunchSettingsJson(projectDirectory);
     if (!launchSettings) {
         return false;
     }


### PR DESCRIPTION
- Stopped globbing for the `launchSettings.json` and instead we search for it at the root and in the Properties folder.

Fixes omnisharp/omnisharp-vscode#3664

@danroth27 is this awful? I don't think people move this file around all that much so wanted to take the approach that impacted O# the least.