### PR TITLE
Use workspace.findFiles instead of glob

### DIFF
--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -119,26 +119,30 @@ export class Options {
         );
     }
 
-    public static getExcludedPaths(vscode: vscode): string[] {
-        let excludePaths: string[] = [];
-
+    public static getExcludedPaths(vscode: vscode, includeSearchExcludes: boolean = false): string[] {
         let workspaceConfig = vscode.workspace.getConfiguration();
         if (!workspaceConfig) {
-            return excludePaths;
+            return [];
         }
 
-        let excludeFilesOption = workspaceConfig.get<{ [i: string]: boolean }>('files.exclude');
-        if (!excludeFilesOption) {
-            return excludePaths;
-        }
+        let excludePaths = getExcludes(workspaceConfig, 'files.exclude');
 
-        for (let field in excludeFilesOption) {
-            if (excludeFilesOption[field]) {
-                excludePaths.push(field);
-            }
+        if (includeSearchExcludes) {
+            excludePaths = excludePaths.concat(getExcludes(workspaceConfig, 'search.exclude'));
         }
 
         return excludePaths;
+
+        function getExcludes(config: WorkspaceConfiguration, option: string): string[] {
+            let optionValue = config.get<{ [i: string]: boolean }>(option);
+            if (!optionValue) {
+                return [];
+            }
+
+            return Object.entries(optionValue)
+                .filter(([key, value]) => value)
+                .map(([key, value]) => key);
+        }
     }
 
     private static readPathOption(csharpConfig: WorkspaceConfiguration, omnisharpConfig: WorkspaceConfiguration): string | null {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -120,7 +120,7 @@ export class Options {
     }
 
     public static getExcludedPaths(vscode: vscode, includeSearchExcludes: boolean = false): string[] {
-        let workspaceConfig = vscode.workspace.getConfiguration();
+        let workspaceConfig = vscode.workspace.getConfiguration(undefined, null);
         if (!workspaceConfig) {
             return [];
         }

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -31,9 +31,8 @@ export class Options {
         public defaultLaunchSolution?: string,
         public monoPath?: string,
         public excludePaths?: string[],
-        public maxProjectFileCountForDiagnosticAnalysis?: number | null) 
-        {    
-        }
+        public maxProjectFileCountForDiagnosticAnalysis?: number | null) {
+    }
 
     public static Read(vscode: vscode): Options {
         // Extra effort is taken below to ensure that legacy versions of options
@@ -65,7 +64,7 @@ export class Options {
         const maxProjectResults = omnisharpConfig.get<number>('maxProjectResults', 250);
         const defaultLaunchSolution = omnisharpConfig.get<string>('defaultLaunchSolution', undefined);
         const useEditorFormattingSettings = omnisharpConfig.get<boolean>('useEditorFormattingSettings', true);
-        
+
         const enableRoslynAnalyzers = omnisharpConfig.get<boolean>('enableRoslynAnalyzers', false);
         const enableEditorConfigSupport = omnisharpConfig.get<boolean>('enableEditorConfigSupport', false);
 
@@ -89,21 +88,7 @@ export class Options {
 
         const maxProjectFileCountForDiagnosticAnalysis = csharpConfig.get<number | null>('maxProjectFileCountForDiagnosticAnalysis', 1000);
 
-        let workspaceConfig = vscode.workspace.getConfiguration();
-        let excludePaths = [];
-        if (workspaceConfig)
-        {
-            let excludeFilesOption = workspaceConfig.get<{ [i: string]: boolean }>('files.exclude');
-            if (excludeFilesOption)
-            {
-                for (let field in excludeFilesOption) {
-                    if (excludeFilesOption[field]) {
-                        excludePaths.push(field);
-                    }
-                }
-            }
-        }
-        
+        const excludePaths = this.getExcludedPaths(vscode);
 
         return new Options(
             path,
@@ -132,6 +117,28 @@ export class Options {
             excludePaths,
             maxProjectFileCountForDiagnosticAnalysis
         );
+    }
+
+    public static getExcludedPaths(vscode: vscode): string[] {
+        let excludePaths: string[] = [];
+
+        let workspaceConfig = vscode.workspace.getConfiguration();
+        if (!workspaceConfig) {
+            return excludePaths;
+        }
+
+        let excludeFilesOption = workspaceConfig.get<{ [i: string]: boolean }>('files.exclude');
+        if (!excludeFilesOption) {
+            return excludePaths;
+        }
+
+        for (let field in excludeFilesOption) {
+            if (excludeFilesOption[field]) {
+                excludePaths.push(field);
+            }
+        }
+
+        return excludePaths;
     }
 
     private static readPathOption(csharpConfig: WorkspaceConfiguration, omnisharpConfig: WorkspaceConfiguration): string | null {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -179,7 +179,7 @@ function isBlazorWebAssemblyHosted(project: protocol.MSBuildProject, isProjectBl
 async function isBlazorWebAssemblyProject(project: MSBuildProject): Promise<boolean> {
     const projectDirectory = path.dirname(project.Path);
     const launchSettingsPattern = new vscode.RelativePattern(projectDirectory, '**/launchSettings.json');
-    const excludedPathPattern = `{${Options.getExcludedPaths(vscode).join(',')}}`;
+    const excludedPathPattern = `{${Options.getExcludedPaths(vscode, true).join(',')}}`;
 
     const launchSettings = await vscode.workspace.findFiles(launchSettingsPattern, excludedPathPattern);
     if (!launchSettings) {

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -10,8 +10,7 @@ import { getVSCodeWithConfig, updateConfig } from './testAssets/Fakes';
 suite("Options tests", () => {
     suiteSetup(() => should());
 
-    test('Verify defaults', () =>
-    {
+    test('Verify defaults', () => {
         const vscode = getVSCodeWithConfig();
         const options = Options.Read(vscode);
         expect(options.path).to.be.null;
@@ -36,8 +35,23 @@ suite("Options tests", () => {
         expect(options.defaultLaunchSolution).to.be.undefined;
     });
 
-    test('BACK-COMPAT: "omnisharp.loggingLevel": "verbose" == "omnisharp.loggingLevel": "debug"', () =>
-    {
+    test('Verify return no excluded paths when empty', () => {
+        const vscode = getVSCodeWithConfig();
+        updateConfig(vscode, null, 'files.exclude', {});
+
+        const excludedPaths = Options.getExcludedPaths(vscode);
+        expect(excludedPaths).to.be.empty;
+    });
+
+    test('Verify return excluded paths', () => {
+        const vscode = getVSCodeWithConfig();
+        updateConfig(vscode, null, 'files.exclude', { "**/node_modules": true, "**/assets": false });
+
+        const excludedPaths = Options.getExcludedPaths(vscode);
+        expect(excludedPaths).to.equalTo(["**/node_modules"]);
+    });
+
+    test('BACK-COMPAT: "omnisharp.loggingLevel": "verbose" == "omnisharp.loggingLevel": "debug"', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'omnisharp', 'loggingLevel', "verbose");
 
@@ -46,28 +60,25 @@ suite("Options tests", () => {
         options.loggingLevel.should.equal("debug");
     });
 
-    test('BACK-COMPAT: "omnisharp.useMono": true == "omnisharp.useGlobalMono": "always"', () =>
-    {   
+    test('BACK-COMPAT: "omnisharp.useMono": true == "omnisharp.useGlobalMono": "always"', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'omnisharp', 'useMono', true);
-        
+
         const options = Options.Read(vscode);
 
         options.useGlobalMono.should.equal("always");
     });
 
-    test('BACK-COMPAT: "omnisharp.useMono": false == "omnisharp.useGlobalMono": "auto"', () =>
-    {
+    test('BACK-COMPAT: "omnisharp.useMono": false == "omnisharp.useGlobalMono": "auto"', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'omnisharp', 'useMono', false);
-    
+
         const options = Options.Read(vscode);
 
         options.useGlobalMono.should.equal("auto");
     });
 
-    test('BACK-COMPAT: "csharp.omnisharpUsesMono": true == "omnisharp.useGlobalMono": "always"', () =>
-    {
+    test('BACK-COMPAT: "csharp.omnisharpUsesMono": true == "omnisharp.useGlobalMono": "always"', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'csharp', 'omnisharpUsesMono', true);
 
@@ -76,8 +87,7 @@ suite("Options tests", () => {
         options.useGlobalMono.should.equal("always");
     });
 
-    test('BACK-COMPAT: "csharp.omnisharpUsesMono": false == "omnisharp.useGlobalMono": "auto"', () =>
-    {
+    test('BACK-COMPAT: "csharp.omnisharpUsesMono": false == "omnisharp.useGlobalMono": "auto"', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'csharp', 'omnisharpUsesMono', false);
 
@@ -86,8 +96,7 @@ suite("Options tests", () => {
         options.useGlobalMono.should.equal("auto");
     });
 
-    test('BACK-COMPAT: "csharp.omnisharp" is used if it is set and "omnisharp.path" is not', () =>
-    {
+    test('BACK-COMPAT: "csharp.omnisharp" is used if it is set and "omnisharp.path" is not', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'csharp', 'omnisharp', 'OldPath');
 
@@ -96,8 +105,7 @@ suite("Options tests", () => {
         options.path.should.equal("OldPath");
     });
 
-    test('BACK-COMPAT: "csharp.omnisharp" is not used if "omnisharp.path" is set', () =>
-    {
+    test('BACK-COMPAT: "csharp.omnisharp" is not used if "omnisharp.path" is set', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'omnisharp', 'path', 'NewPath');
         updateConfig(vscode, 'csharp', 'omnisharp', 'OldPath');
@@ -107,8 +115,7 @@ suite("Options tests", () => {
         options.path.should.equal("NewPath");
     });
 
-    test('"omnisharp.defaultLaunchSolution" is used if set', () =>
-    {
+    test('"omnisharp.defaultLaunchSolution" is used if set', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, 'omnisharp', 'defaultLaunchSolution', 'some_valid_solution.sln');
 

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -35,7 +35,7 @@ suite("Options tests", () => {
         expect(options.defaultLaunchSolution).to.be.undefined;
     });
 
-    test('Verify return no excluded paths when empty', () => {
+    test('Verify return no excluded paths when files.exclude empty', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, null, 'files.exclude', {});
 
@@ -43,12 +43,30 @@ suite("Options tests", () => {
         expect(excludedPaths).to.be.empty;
     });
 
-    test('Verify return excluded paths', () => {
+    test('Verify return excluded paths when files.exclude populated', () => {
         const vscode = getVSCodeWithConfig();
         updateConfig(vscode, null, 'files.exclude', { "**/node_modules": true, "**/assets": false });
 
         const excludedPaths = Options.getExcludedPaths(vscode);
         expect(excludedPaths).to.equalTo(["**/node_modules"]);
+    });
+
+    test('Verify return no excluded paths when files.exclude and search.exclude empty', () => {
+        const vscode = getVSCodeWithConfig();
+        updateConfig(vscode, null, 'files.exclude', {});
+        updateConfig(vscode, null, 'search.exclude', {});
+
+        const excludedPaths = Options.getExcludedPaths(vscode, true);
+        expect(excludedPaths).to.be.empty;
+    });
+
+    test('Verify return excluded paths when files.exclude and search.exclude populated', () => {
+        const vscode = getVSCodeWithConfig();
+        updateConfig(vscode, null, 'files.exclude', { "/Library": true });
+        updateConfig(vscode, null, 'search.exclude', { "**/node_modules": true, "**/assets": false });
+
+        const excludedPaths = Options.getExcludedPaths(vscode, true);
+        expect(excludedPaths).to.be.equalTo(["/Library", "**/node_modules"]);
     });
 
     test('BACK-COMPAT: "omnisharp.loggingLevel": "verbose" == "omnisharp.loggingLevel": "debug"', () => {

--- a/test/unitTests/testAssets/Fakes.ts
+++ b/test/unitTests/testAssets/Fakes.ts
@@ -185,10 +185,15 @@ export function getWorkspaceInformationUpdated(msbuild: protocol.MsBuildWorkspac
 export function getVSCodeWithConfig() {
     const vscode = getFakeVsCode();
 
+    const _vscodeConfig = getWorkspaceConfiguration();
     const _omnisharpConfig = getWorkspaceConfiguration();
     const _csharpConfig = getWorkspaceConfiguration();
 
     vscode.workspace.getConfiguration = (section?, resource?) => {
+        if (!section) {
+            return _vscodeConfig;
+        }
+
         if (section === 'omnisharp') {
             return _omnisharpConfig;
         }


### PR DESCRIPTION
`isBlazorWebAssemblyProject` used `glob` to search for launchSettings.json files. It was being invoked 3 different times for each project within the workspace by `requestWorkspaceInformation`. 

Based on this advice:
```
	 * The workspace offers support for [listening](#workspace.createFileSystemWatcher) to fs
	 * events and for [finding](#workspace.findFiles) files. Both perform well and run _outside_
	 * the editor-process so that they should be always used instead of nodejs-equivalents.
```

Updated `isBlazorWebAssemblyProject` to use `vscode.workspace.findFiles` and also use the excluded paths defined in `files.exclude`

Potential fix for #3673