### PR TITLE
Add support for building NET 5.0 launch.json

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -161,8 +161,8 @@ export class AssetGenerator {
         const startupProjectDir = path.dirname(this.startupProject.Path);
         const relativeProjectDir = path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, startupProjectDir));
         const configurationName = 'Debug';
-        const targetFramework = protocol.findNetCoreAppTargetFramework(this.startupProject).ShortName;
-        const result = path.join(relativeProjectDir, `bin/${configurationName}/${targetFramework}/${this.startupProject.AssemblyName}.dll`);
+        const targetFramework = protocol.findNetCoreAppTargetFramework(this.startupProject) ?? protocol.findNet5TargetFramework(this.startupProject);
+        const result = path.join(relativeProjectDir, `bin/${configurationName}/${targetFramework.ShortName}/${this.startupProject.AssemblyName}.dll`);
         return result;
     }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -287,8 +287,7 @@ export interface ProjectInformationResponse {
     DotNetProject: DotNetProject;
 }
 
-export enum DiagnosticStatus
-{
+export enum DiagnosticStatus {
     Processing = 0,
     Ready = 1
 }
@@ -740,6 +739,16 @@ export function findNetFrameworkTargetFramework(project: MSBuildProject): Target
     return project.TargetFrameworks.find(tf => regexp.test(tf.ShortName));
 }
 
+export function findNet5TargetFramework(project: MSBuildProject): TargetFramework {
+    const targetFramework = project.TargetFrameworks.find(tf => tf.ShortName.startsWith('net5'));
+    // Temprorary workaround until changes to support the net5.0 TFM is settled. Some NuGet
+    // builds report the shortname as net50.
+    if (targetFramework !== undefined) {
+        targetFramework.ShortName = "net5.0";
+    }
+    return targetFramework;
+}
+
 export function findNetCoreAppTargetFramework(project: MSBuildProject): TargetFramework {
     return project.TargetFrameworks.find(tf => tf.ShortName.startsWith('netcoreapp'));
 }
@@ -749,7 +758,8 @@ export function findNetStandardTargetFramework(project: MSBuildProject): TargetF
 }
 
 export function isDotNetCoreProject(project: MSBuildProject): Boolean {
-    return findNetCoreAppTargetFramework(project) !== undefined ||
+    return findNet5TargetFramework(project) !== undefined ||
+        findNetCoreAppTargetFramework(project) !== undefined ||
         findNetStandardTargetFramework(project) !== undefined ||
         findNetFrameworkTargetFramework(project) !== undefined;
 }
@@ -792,7 +802,11 @@ export function findExecutableMSBuildProjects(projects: MSBuildProject[]) {
     let result: MSBuildProject[] = [];
 
     projects.forEach(project => {
-        if (project.IsExe && (findNetCoreAppTargetFramework(project) !== undefined || project.IsBlazorWebAssemblyStandalone)) {
+        const projectIsNotNetFramework = findNetCoreAppTargetFramework(project) !== undefined
+            || findNet5TargetFramework(project) !== undefined
+            || project.IsBlazorWebAssemblyStandalone;
+
+        if (project.IsExe && projectIsNotNetFramework) {
             result.push(project);
         }
     });

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -44,7 +44,7 @@ suite("Asset generation: csproj", () => {
         generator.setStartupProject(0);
         let tasksJson = generator.createTasksConfiguration();
 
-        tasksJson.tasks.forEach(task=> task.args.should.contain("/consoleloggerparameters:NoSummary"));
+        tasksJson.tasks.forEach(task => task.args.should.contain("/consoleloggerparameters:NoSummary"));
     });
 
     test("Create tasks.json for nested project opened in workspace", () => {
@@ -71,6 +71,19 @@ suite("Asset generation: csproj", () => {
         // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
         let segments = programPath.split(path.posix.sep);
         segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
+    });
+
+    test("Create launch.json for NET 5 project opened in workspace", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'net5.0', /*isExe*/ true);
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
+        let programPath = launchJson[0].program;
+
+        // ${workspaceFolder}/bin/Debug/net5.0/testApp.dll
+        let segments = programPath.split(path.posix.sep);
+        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'net5.0', 'testApp.dll']);
     });
 
     test("Create launch.json for nested project opened in workspace", () => {


### PR DESCRIPTION
While investigating https://github.com/OmniSharp/omnisharp-vscode/issues/3439, I realized we didn't support generating launch.json for .NET 5 projects.