### PR TITLE
Fadeout unused variable names

### DIFF
--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -169,7 +169,7 @@ class DiagnosticsProvider extends AbstractSupport {
             vscode.workspace.onDidChangeTextDocument(event => this._onDocumentOpenOrChange(event.document), this),
             vscode.workspace.onDidCloseTextDocument(this._onDocumentClose, this),
             vscode.window.onDidChangeActiveTextEditor(event => this._onDidChangeActiveTextEditor(event), this),
-            vscode.window.onDidChangeWindowState(event => this._OnDidChangeWindowState(event), this,),
+            vscode.window.onDidChangeWindowState(event => this._OnDidChangeWindowState(event), this),
         );
     }
 
@@ -252,8 +252,7 @@ class DiagnosticsProvider extends AbstractSupport {
                 }
 
                 // No problems published for virtual files
-                if(isVirtualCSharpDocument(document))
-                {
+                if (isVirtualCSharpDocument(document)) {
                     return;
                 }
 
@@ -346,17 +345,18 @@ class DiagnosticsProvider extends AbstractSupport {
         return { diagnostic: diagnostic, fileName: quickFix.FileName };
     }
 
-    private _getDiagnosticDisplay(quickFix: protocol.QuickFix, severity: vscode.DiagnosticSeverity | "hidden"): { severity: vscode.DiagnosticSeverity | "hidden", isFadeout: boolean }
-    {
-        // CS0162 & CS8019 => Unnused using and unreachable code.
-        // These hard coded values bring some goodnes of fading even when analyzers are disabled.
-        let isFadeout = (quickFix.Tags && !!quickFix.Tags.find(x => x.toLowerCase() == 'unnecessary')) || quickFix.Id == "CS0162" || quickFix.Id == "CS8019";
+    private _getDiagnosticDisplay(quickFix: protocol.QuickFix, severity: vscode.DiagnosticSeverity | "hidden"): { severity: vscode.DiagnosticSeverity | "hidden", isFadeout: boolean } {
+        // These hard coded values bring the goodness of fading even when analyzers are disabled.
+        let isFadeout = (quickFix.Tags && !!quickFix.Tags.find(x => x.toLowerCase() == 'unnecessary'))
+            || quickFix.Id == "CS0162"  // CS0162: Unreachable code
+            || quickFix.Id == "CS0219"  // CS0219: Unused variable
+            || quickFix.Id == "CS8019"; // CS8019: Unnecessary using
 
         if (isFadeout && quickFix.LogLevel.toLowerCase() === 'hidden' || quickFix.LogLevel.toLowerCase() === 'none') {
             // Theres no such thing as hidden severity in VSCode,
             // however roslyn uses commonly analyzer with hidden to fade out things.
             // Without this any of those doesn't fade anything in vscode.
-            return { severity: vscode.DiagnosticSeverity.Hint , isFadeout };
+            return { severity: vscode.DiagnosticSeverity.Hint, isFadeout };
         }
 
         return { severity: severity, isFadeout };

--- a/test/integrationTests/diagnostics.integration.test.ts
+++ b/test/integrationTests/diagnostics.integration.test.ts
@@ -98,6 +98,14 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
                 res => expect(res.length).to.be.greaterThan(0));
         });
 
+        test("Return fadeout diagnostic in case of unused variable", async function () {
+            let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15 * 1000, 500);
+
+            let cs0219 = result.find(x => x.code === "CS0219");
+            expect(cs0219).to.not.be.undefined;
+            expect(cs0219.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+        });
+
         test("Return unnecessary tag in case of unnesessary using", async function () {
             let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15 * 1000, 500);
 
@@ -110,6 +118,7 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
             let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 20 * 1000, 500, result => result.find(x => x.code === "IDE0059") != undefined);
 
             let ide0059 = result.find(x => x.code === "IDE0059");
+            expect(ide0059).to.not.be.undefined;
             expect(ide0059.tags).to.include(vscode.DiagnosticTag.Unnecessary);
         });
 

--- a/test/integrationTests/diagnostics.integration.test.ts
+++ b/test/integrationTests/diagnostics.integration.test.ts
@@ -94,12 +94,19 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
         });
 
         test("Returns any diagnostics from file", async function () {
-            await assertWithPoll(() => vscode.languages.getDiagnostics(fileUri), 10 * 1000, 500,
+            await assertWithPoll(
+                () => vscode.languages.getDiagnostics(fileUri),
+                /*duration*/ 10 * 1000,
+                /*step*/ 500,
                 res => expect(res.length).to.be.greaterThan(0));
         });
 
-        test("Return fadeout diagnostic in case of unused variable", async function () {
-            let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15 * 1000, 500);
+        test("Return unnecessary tag in case of unused variable", async function () {
+            let result = await poll(
+                () => vscode.languages.getDiagnostics(fileUri),
+                /*duration*/ 15 * 1000,
+                /*step*/ 500,
+                result => result.find(x => x.code === "CS0219") != undefined);
 
             let cs0219 = result.find(x => x.code === "CS0219");
             expect(cs0219).to.not.be.undefined;
@@ -107,7 +114,11 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
         });
 
         test("Return unnecessary tag in case of unnesessary using", async function () {
-            let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 15 * 1000, 500);
+            let result = await poll(
+                () => vscode.languages.getDiagnostics(fileUri),
+                /*duration*/ 15 * 1000,
+                /*step*/ 500,
+                result => result.find(x => x.code === "CS8019") != undefined);
 
             let cs8019 = result.find(x => x.code === "CS8019");
             expect(cs8019).to.not.be.undefined;
@@ -115,7 +126,11 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
         });
 
         test("Return fadeout diagnostics like unused variables based on roslyn analyzers", async function () {
-            let result = await poll(() => vscode.languages.getDiagnostics(fileUri), 20 * 1000, 500, result => result.find(x => x.code === "IDE0059") != undefined);
+            let result = await poll(
+                () => vscode.languages.getDiagnostics(fileUri),
+                /*duration*/ 20 * 1000,
+                /*step*/ 500,
+                result => result.find(x => x.code === "IDE0059") != undefined);
 
             let ide0059 = result.find(x => x.code === "IDE0059");
             expect(ide0059).to.not.be.undefined;


### PR DESCRIPTION
Currently unused variables are only faded out when `omnisharp.enableRoslynAnalyzers` is enabled. This change adds it to the list of compiler diagnostics we fadeout even when analyzers are disabled.

fixes #1324