### PR TITLE
Add vscode implemention of the 'RunTestsInContext' and `DebugTestsInContext' commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -911,7 +911,7 @@
       {
         "command": "dotnet.test.debugTestsInContext",
         "key": "ctrl+r ctrl+t",
-        "mac": "cmd+r ctrl+t",
+        "mac": "cmd+r cmd+t",
         "when": "editorLangId == csharp && editorTextFocus"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -3272,6 +3272,18 @@
           "when": "resourceLangId == aspnetcorerazor"
         }
       ],
+      "editor/context": [
+        {
+          "command": "dotnet.test.runTestsInContext",
+          "when": "editorLangId == csharp",
+          "group": "2_dotnet@1"
+        },
+        {
+          "command": "dotnet.test.debugTestsInContext",
+          "when": "editorLangId == csharp",
+          "group": "2_dotnet@2"
+        }
+      ],
       "commandPalette": [
         {
           "command": "dotnet.test.runTestsInContext",

--- a/package.json
+++ b/package.json
@@ -884,6 +884,16 @@
         "command": "razor.reportIssue",
         "title": "Report a Razor issue",
         "category": "Razor"
+      },
+      {
+        "command": "dotnet.test.runTestsInContext",
+        "title": "Run Tests in Context",
+        "category": ".NET"
+      },
+      {
+        "command": "dotnet.test.debugTestsInContext",
+        "title": "Debug Tests in Context",
+        "category": ".NET"
       }
     ],
     "keybindings": [
@@ -891,6 +901,18 @@
         "command": "o.showOutput",
         "key": "Ctrl+Shift+F9",
         "mac": "Cmd+Shift+F9"
+      },
+      {
+        "command": "dotnet.test.runTestsInContext",
+        "key": "ctrl+r t",
+        "mac": "cmd+r t",
+        "when": "editorLangId == csharp && editorTextFocus"
+      },
+      {
+        "command": "dotnet.test.debugTestsInContext",
+        "key": "ctrl+r ctrl+t",
+        "mac": "cmd+r ctrl+t",
+        "when": "editorLangId == csharp && editorTextFocus"
       }
     ],
     "snippets": [
@@ -3058,6 +3080,16 @@
         {
           "command": "razor.reportIssue",
           "when": "resourceLangId == aspnetcorerazor"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "dotnet.test.runTestsInContext",
+          "when": "editorLangId == csharp"
+        },
+        {
+          "command": "dotnet.test.debugTestsInContext",
+          "when": "editorLangId == csharp"
         }
       ]
     }

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -130,7 +130,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
             const quickFixes = result.QuickFixes;
             const count = quickFixes.length;
             const locations = quickFixes.map(toLocation);
-            
+
             // Allow language middlewares to re-map its edits if necessary.
             const remappedLocations = await this._languageMiddlewareFeature.remap("remapLocations", locations, token);
 
@@ -166,9 +166,8 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         catch (error) {
             return undefined;
         }
-            
-        // We do not support running all tests on legacy projects.
-        if (projectInfo.MsBuildProject && !projectInfo.DotNetProject) {
+
+        if (projectInfo.MsBuildProject) {
             codeLens.command = {
                 title: pluralTitle,
                 command: pluralCommandName,

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -57,20 +57,12 @@ export class Advisor {
     }
 
     private _addOrUpdateProjectFileCount(info: protocol.ProjectInformationResponse): void {
-        if (info.DotNetProject && info.DotNetProject.SourceFiles) {
-            this._updateProjectFileCount(info.DotNetProject.Path, info.DotNetProject.SourceFiles.length);
-        }
-
         if (info.MsBuildProject && info.MsBuildProject.SourceFiles) {
             this._updateProjectFileCount(info.MsBuildProject.Path, info.MsBuildProject.SourceFiles.length);
         }
     }
 
     private _removeProjectFileCount(info: protocol.ProjectInformationResponse): void {
-        if (info.DotNetProject && info.DotNetProject.SourceFiles) {
-            delete this._projectSourceFileCounts[info.DotNetProject.Path];
-        }
-
         if (info.MsBuildProject && info.MsBuildProject.SourceFiles) {
             delete this._projectSourceFileCounts[info.MsBuildProject.Path];
         }

--- a/src/observers/DotnetTestChannelObserver.ts
+++ b/src/observers/DotnetTestChannelObserver.ts
@@ -15,6 +15,8 @@ export default class DotnetTestChannelObserver extends BaseChannelObserver {
             case EventType.DotNetTestsInClassRunStart:
             case EventType.DotNetTestDebugStart:
             case EventType.DotNetTestsInClassDebugStart:
+            case EventType.DotNetTestRunInContextStart:
+            case EventType.DotNetTestDebugInContextStart:
                 this.showChannel(true);
                 break;
         }

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -73,12 +73,12 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleDotnetTestsRunInContextStart(event: DotNetTestRunInContextStart) {
-        this.logger.appendLine(`----- Running test(s) in context "${event.fileName} ${event.line}:${event.column}" -----`);
+        this.logger.appendLine(`----- Running test(s) in context "${event.fileName} ${event.line + 1}:${event.column + 1}" -----`);
         this.logger.appendLine('');
     }
 
     private handleDotnetTestsDebugInContextStart(event: DotNetTestDebugInContextStart) {
-        this.logger.appendLine(`----- Debugging test(s) in context "${event.fileName} ${event.line}:${event.column}" -----`);
+        this.logger.appendLine(`----- Debugging test(s) in context "${event.fileName} ${event.line + 1}:${event.column + 1}" -----`);
         this.logger.appendLine('');
     }
 

--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseEvent, DotNetTestRunStart, DotNetTestMessage, ReportDotNetTestResults, DotNetTestDebugStart, DotNetTestDebugWarning, DotNetTestDebugProcessStart, DotNetTestsInClassDebugStart, DotNetTestsInClassRunStart } from "../omnisharp/loggingEvents";
+import { BaseEvent, DotNetTestRunStart, DotNetTestMessage, ReportDotNetTestResults, DotNetTestDebugStart, DotNetTestDebugWarning, DotNetTestDebugProcessStart, DotNetTestsInClassDebugStart, DotNetTestsInClassRunStart, DotNetTestRunInContextStart, DotNetTestDebugInContextStart } from "../omnisharp/loggingEvents";
 import { BaseLoggerObserver } from "./BaseLoggerObserver";
 import * as protocol from '../omnisharp/protocol';
 import { EventType } from "../omnisharp/EventType";
@@ -39,6 +39,12 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
             case EventType.DotNetTestsInClassRunStart:
                 this.handleDotnetTestsInClassRunStart(<DotNetTestsInClassRunStart>event);
                 break;
+            case EventType.DotNetTestRunInContextStart:
+                this.handleDotnetTestsRunInContextStart(<DotNetTestRunInContextStart>event);
+                break;
+            case EventType.DotNetTestDebugInContextStart:
+                this.handleDotnetTestsDebugInContextStart(<DotNetTestDebugInContextStart>event);
+                break;
         }
     }
 
@@ -63,6 +69,16 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
 
     private handleDotnetTestsInClassRunStart(event: DotNetTestsInClassRunStart): any {
         this.logger.appendLine(`----- Running tests in class "${event.className}" -----`);
+        this.logger.appendLine('');
+    }
+
+    private handleDotnetTestsRunInContextStart(event: DotNetTestRunInContextStart) {
+        this.logger.appendLine(`----- Running test(s) in context "${event.fileName} ${event.line}:${event.column}" -----`);
+        this.logger.appendLine('');
+    }
+
+    private handleDotnetTestsDebugInContextStart(event: DotNetTestDebugInContextStart) {
+        this.logger.appendLine(`----- Debugging test(s) in context "${event.fileName} ${event.line}:${event.column}" -----`);
         this.logger.appendLine('');
     }
 

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -79,7 +79,9 @@ export enum EventType {
     OmnisharpServerOnStart = 72,
     OmnisharpOnBeforeServerInstall = 73,
     ProjectConfigurationReceived = 74,
-    ProjectDiagnosticStatus = 75
+    ProjectDiagnosticStatus = 75,
+    DotNetTestRunInContextStart = 76,
+    DotNetTestDebugInContextStart = 77,
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -202,6 +202,16 @@ export class DotNetTestsInClassDebugStart implements BaseEvent {
     constructor(public className: string) { }
 }
 
+export class DotNetTestRunInContextStart implements BaseEvent {
+    type = EventType.DotNetTestRunInContextStart;
+    constructor(public fileName: string, public line: number, public column: number) { }
+}
+
+export class DotNetTestDebugInContextStart implements BaseEvent {
+    type = EventType.DotNetTestDebugInContextStart;
+    constructor(public fileName: string, public line: number, public column: number) { }
+}
+
 export class DocumentSynchronizationFailure implements BaseEvent {
     type = EventType.DocumentSynchronizationFailure;
     constructor(public documentPath: string, public errorMessage: string) { }

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -284,7 +284,6 @@ export interface AutoCompleteResponse {
 
 export interface ProjectInformationResponse {
     MsBuildProject: MSBuildProject;
-    DotNetProject: DotNetProject;
 }
 
 export enum DiagnosticStatus {
@@ -477,8 +476,10 @@ export namespace V2 {
         export const GetTestStartInfo = '/v2/getteststartinfo';
         export const RunTest = '/v2/runtest';
         export const RunAllTestsInClass = "/v2/runtestsinclass";
+        export const RunTestsInContext = "/v2/runtestsincontext";
         export const DebugTestGetStartInfo = '/v2/debugtest/getstartinfo';
         export const DebugTestsInClassGetStartInfo = '/v2/debugtestsinclass/getstartinfo';
+        export const DebugTestsInContextGetStartInfo = '/v2/debugtestsincontext/getstartinfo';
         export const DebugTestLaunch = '/v2/debugtest/launch';
         export const DebugTestStop = '/v2/debugtest/stop';
         export const BlockStructure = '/v2/blockstructure';
@@ -572,6 +573,11 @@ export namespace V2 {
         TargetFrameworkVersion: string;
     }
 
+    interface TestsInContextRequest extends Request {
+        RunSettings?: string;
+        TargetFrameworkVersion?: string;
+    }
+
     export interface DebugTestGetStartInfoRequest extends SingleTestRequest {
     }
 
@@ -583,6 +589,9 @@ export namespace V2 {
         Arguments: string;
         WorkingDirectory: string;
         EnvironmentVariables: Map<string, string>;
+        Succeeded: boolean;
+        ContextHadNoTests: boolean;
+        FailureReason?: string;
     }
 
     export interface DebugTestLaunchRequest extends Request {
@@ -613,6 +622,12 @@ export namespace V2 {
     export interface RunTestsInClassRequest extends MultiTestRequest {
     }
 
+    export interface RunTestsInContextRequest extends TestsInContextRequest {
+    }
+
+    export interface DebugTestsInContextGetStartInfoRequest extends TestsInContextRequest {
+    }
+
     export module TestOutcomes {
         export const None = 'none';
         export const Passed = 'passed';
@@ -634,6 +649,7 @@ export namespace V2 {
         Failure: string;
         Pass: boolean;
         Results: DotNetTestResult[];
+        ContextHadNoTests: boolean;
     }
 
     export interface TestMessageEvent {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -135,12 +135,20 @@ export async function runTestsInClass(server: OmniSharpServer, request: protocol
     return server.makeRequest<protocol.V2.RunTestResponse>(protocol.V2.Requests.RunAllTestsInClass, request);
 }
 
+export async function runTestsInContext(server: OmniSharpServer, request: protocol.V2.RunTestsInContextRequest) {
+    return server.makeRequest<protocol.V2.RunTestResponse>(protocol.V2.Requests.RunTestsInContext, request);
+}
+
 export async function debugTestGetStartInfo(server: OmniSharpServer, request: protocol.V2.DebugTestGetStartInfoRequest) {
     return server.makeRequest<protocol.V2.DebugTestGetStartInfoResponse>(protocol.V2.Requests.DebugTestGetStartInfo, request);
 }
 
 export async function debugTestClassGetStartInfo(server: OmniSharpServer, request: protocol.V2.DebugTestClassGetStartInfoRequest) {
     return server.makeRequest<protocol.V2.DebugTestGetStartInfoResponse>(protocol.V2.Requests.DebugTestsInClassGetStartInfo, request);
+}
+
+export async function debugTestsInContextGetStartInfo(server: OmniSharpServer, request: protocol.V2.DebugTestsInContextGetStartInfoRequest) {
+    return server.makeRequest<protocol.V2.DebugTestGetStartInfoResponse>(protocol.V2.Requests.DebugTestsInContextGetStartInfo, request);
 }
 
 export async function debugTestLaunch(server: OmniSharpServer, request: protocol.V2.DebugTestLaunchRequest) {

--- a/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
+++ b/test/unitTests/logging/DotnetTestLoggerObserver.test.ts
@@ -5,7 +5,7 @@
 
 import * as chai from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
-import { EventWithMessage, DotNetTestDebugWarning, DotNetTestDebugStart, BaseEvent, DotNetTestRunStart, DotNetTestDebugProcessStart, DotNetTestMessage, DotNetTestDebugComplete, ReportDotNetTestResults, DotNetTestsInClassDebugStart, DotNetTestsInClassRunStart } from '../../../src/omnisharp/loggingEvents';
+import { EventWithMessage, DotNetTestDebugWarning, DotNetTestDebugStart, BaseEvent, DotNetTestRunStart, DotNetTestDebugProcessStart, DotNetTestMessage, DotNetTestDebugComplete, ReportDotNetTestResults, DotNetTestsInClassDebugStart, DotNetTestsInClassRunStart, DotNetTestRunInContextStart, DotNetTestDebugInContextStart } from '../../../src/omnisharp/loggingEvents';
 import DotNetTestLoggerObserver from '../../../src/observers/DotnetTestLoggerObserver';
 import * as protocol from '../../../src/omnisharp/protocol';
 
@@ -52,6 +52,17 @@ suite(`${DotNetTestLoggerObserver.name}`, () => {
             expect(appendedMessage).to.be.empty;
             observer.post(event);
             expect(appendedMessage).to.contain("foo");
+        });
+    });
+
+    [
+        new DotNetTestRunInContextStart("foo", 1, 2),
+        new DotNetTestDebugInContextStart("foo", 1, 2)
+    ].forEach((event: BaseEvent) => {
+        test(`${event.constructor.name}: File name and line/column are logged`, () => {
+            expect(appendedMessage).to.be.empty;
+            observer.post(event);
+            expect(appendedMessage).to.contain("foo").and.contain("2").and.contain("3");
         });
     });
 


### PR DESCRIPTION
This is the omnisharp-vsocde side of https://github.com/OmniSharp/omnisharp-roslyn/pull/1782. I've implemented support for both of those commands, and bound them to the same default shortcuts as in VS proper. These commands can also be invoked from the command palette.

I've also done a small bit of refactoring to remove references to legacy project.json support. There is no support for loading this project type in Omnisharp anymore, so this was cruft that was unnecessary at this point.
