### PR TITLE
Add setting for enabling go to decompilation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -748,6 +748,12 @@
           "default": false,
           "description": "Enables support for reading code style, naming convention and analyzer settings from .editorconfig."
         },
+        "omnisharp.enableDecompilationSupport": {
+          "type": "boolean",
+          "default": false,
+          "scope": "machine",
+          "description": "Enables support for decompiling external references instead of viewing metadata."
+        },
         "razor.plugin.path": {
           "type": [
             "string",
@@ -868,6 +874,11 @@
       {
         "command": "csharp.reportIssue",
         "title": "Report an issue",
+        "category": "CSharp"
+      },
+      {
+        "command": "csharp.showDecompilationTerms",
+        "title": "Show the decompiler terms agreement",
         "category": "CSharp"
       },
       {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import IInstallDependencies from './packageManager/IInstallDependencies';
 import { installRuntimeDependencies } from './InstallRuntimeDependencies';
 import { isValidDownload } from './packageManager/isValidDownload';
 import { BackgroundWorkStatusBarObserver } from './observers/BackgroundWorkStatusBarObserver';
+import { getDecompilationAuthorization } from './omnisharp/decompilationPrompt';
 
 export async function activate(context: vscode.ExtensionContext): Promise<CSharpExtensionExports> {
 
@@ -153,6 +154,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
     let networkSettingsProvider = vscodeNetworkSettingsProvider(vscode);
     let installDependencies: IInstallDependencies = async (dependencies: AbsolutePathPackage[]) => downloadAndInstallPackages(dependencies, networkSettingsProvider, eventStream, isValidDownload);
     let runtimeDependenciesExist = await ensureRuntimeDependencies(extension, eventStream, platformInfo, installDependencies);
+
+    // Prompt to authorize decompilation in this workspace
+    await getDecompilationAuthorization(context, optionProvider);
 
     // activate language services
     let langServicePromise = OmniSharp.activate(context, extension.packageJSON, platformInfo, networkSettingsProvider, eventStream, optionProvider, extension.extensionPath);

--- a/src/observers/OptionChangeObserver.ts
+++ b/src/observers/OptionChangeObserver.ts
@@ -10,29 +10,35 @@ import { Observable } from "rxjs";
 import Disposable from "../Disposable";
 import { filter } from 'rxjs/operators';
 
-function ConfigChangeObservable(optionObservable: Observable<Options>): Observable<Options> {
+type OptionsKey = keyof Options;
+
+const omniSharpOptions: ReadonlyArray<OptionsKey> = [
+    "path",
+    "useGlobalMono",
+    "enableMsBuildLoadProjectsOnDemand",
+    "waitForDebugger",
+    "loggingLevel",
+    "enableEditorConfigSupport",
+    "enableDecompilationSupport"
+];
+
+function OmniSharpOptionChangeObservable(optionObservable: Observable<Options>): Observable<Options> {
     let options: Options;
-    return optionObservable.pipe(filter(newOptions => {
-        let changed = (options && hasChanged(options, newOptions));
-        options = newOptions;
-        return changed;
-    }));
+    return optionObservable.pipe(
+        filter(newOptions => {
+            const changed = options && omniSharpOptions.some(key => options[key] !== newOptions[key]);
+            options = newOptions;
+            return changed;
+        })
+    );
 }
 
 export function ShowOmniSharpConfigChangePrompt(optionObservable: Observable<Options>, vscode: vscode): Disposable {
-    let subscription = ConfigChangeObservable(optionObservable)
+    const subscription = OmniSharpOptionChangeObservable(optionObservable)
         .subscribe(_ => {
             let message = "OmniSharp configuration has changed. Would you like to relaunch the OmniSharp server with your changes?";
             ShowInformationMessage(vscode, message, { title: "Restart OmniSharp", command: 'o.restart' });
         });
 
     return new Disposable(subscription);
-}
-
-function hasChanged(oldOptions: Options, newOptions: Options): boolean {
-    return (oldOptions.path != newOptions.path ||
-        oldOptions.useGlobalMono != newOptions.useGlobalMono ||
-        oldOptions.enableMsBuildLoadProjectsOnDemand != newOptions.enableMsBuildLoadProjectsOnDemand ||
-        oldOptions.waitForDebugger != newOptions.waitForDebugger ||
-        oldOptions.loggingLevel != newOptions.loggingLevel);
 }

--- a/src/omnisharp/decompilationPrompt.ts
+++ b/src/omnisharp/decompilationPrompt.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import OptionProvider from "../observers/OptionProvider";
+
+export async function getDecompilationAuthorization(context: vscode.ExtensionContext, optionProvider: OptionProvider) {
+    // If decompilation is disabled the return false
+    const options = optionProvider.GetLatestOptions();
+    if (options.enableDecompilationSupport === false) {
+        return false;
+    }
+
+    // If the terms have been acknowledged for this workspace then return.
+    let decompilationAutorized = context.workspaceState.get<boolean | undefined>("decompilationAuthorized");
+    if (decompilationAutorized !== undefined) {
+        return decompilationAutorized;
+    }
+
+    const result = await promptToAcceptDecompilationTerms();
+    decompilationAutorized = result === PromptResult.Yes;
+
+    await context.workspaceState.update("decompilationAuthorized", decompilationAutorized);
+
+    return decompilationAutorized;
+}
+
+enum PromptResult {
+    Dismissed,
+    Yes,
+    No
+}
+
+interface PromptItem extends vscode.MessageItem {
+    result: PromptResult;
+}
+
+async function promptToAcceptDecompilationTerms() {
+    return new Promise<PromptResult>((resolve, reject) => {
+        const message = `IMPORTANT: C# extension includes decompiling functionality (“Decompiler”) that enables reproducing source code from binary code. By accessing and using the Decompiler, you agree to the terms for the Decompiler below. If you do not agree with these terms, do not access or use the Decompiler.
+
+You acknowledge that binary code and source code might be protected by copyright and trademark laws.  Before using the Decompiler on any binary code, you need to first:
+
+(i) confirm that the license terms governing your use of the binary code do not contain a provision which prohibits you from decompiling the software; or
+
+(ii) obtain permission to decompile the binary code from the owner of the software.
+
+Your use of the Decompiler is optional.  Microsoft is not responsible and disclaims all liability for your use of the Decompiler that violates any laws or any software license terms which prohibit decompiling of the software.
+
+I agree to all of the foregoing:`;
+
+        const messageOptions: vscode.MessageOptions = { modal: true };
+
+        const yesItem: PromptItem = { title: 'Yes', result: PromptResult.Yes };
+        const noItem: PromptItem = { title: 'No', result: PromptResult.No, isCloseAffordance: true };
+
+        vscode.window.showWarningMessage(message, messageOptions, noItem, yesItem)
+            .then(selection => resolve(selection?.result ?? PromptResult.Dismissed));
+    });
+}

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -52,7 +52,8 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
 
     const options = optionProvider.GetLatestOptions();
     let omnisharpMonoResolver = new OmniSharpMonoResolver(getMonoVersion);
-    const server = new OmniSharpServer(vscode, provider, packageJSON, platformInfo, eventStream, optionProvider, extensionPath, omnisharpMonoResolver);
+    const decompilationAuthorized = context.workspaceState.get<boolean | undefined>("decompilationAuthorized") ?? false;
+    const server = new OmniSharpServer(vscode, provider, packageJSON, platformInfo, eventStream, optionProvider, extensionPath, omnisharpMonoResolver, decompilationAuthorized);
     const advisor = new Advisor(server, optionProvider); // create before server is started
     const disposables = new CompositeDisposable();
     const languageMiddlewareFeature = new LanguageMiddlewareFeature();
@@ -102,7 +103,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables = null;
     }));
 
-    disposables.add(registerCommands(server, platformInfo, eventStream, optionProvider, omnisharpMonoResolver, packageJSON, extensionPath));
+    disposables.add(registerCommands(context, server, platformInfo, eventStream, optionProvider, omnisharpMonoResolver, packageJSON, extensionPath));
 
     if (!context.workspaceState.get<boolean>('assetPromptDisabled')) {
         disposables.add(server.onServerStart(() => {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -27,6 +27,7 @@ export class Options {
         public enableMsBuildLoadProjectsOnDemand: boolean,
         public enableRoslynAnalyzers: boolean,
         public enableEditorConfigSupport: boolean,
+        public enableDecompilationSupport: boolean,
         public razorPluginPath?: string,
         public defaultLaunchSolution?: string,
         public monoPath?: string,
@@ -67,6 +68,7 @@ export class Options {
 
         const enableRoslynAnalyzers = omnisharpConfig.get<boolean>('enableRoslynAnalyzers', false);
         const enableEditorConfigSupport = omnisharpConfig.get<boolean>('enableEditorConfigSupport', false);
+        const enableDecompilationSupport = omnisharpConfig.get<boolean>('enableDecompilationSupport', false);
 
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
 
@@ -111,6 +113,7 @@ export class Options {
             enableMsBuildLoadProjectsOnDemand,
             enableRoslynAnalyzers,
             enableEditorConfigSupport,
+            enableDecompilationSupport,
             razorPluginPath,
             defaultLaunchSolution,
             monoPath,

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -98,7 +98,7 @@ export class OmniSharpServer {
     private updateProjectDebouncer = new Subject<ObservableEvents.ProjectModified>();
     private firstUpdateProject: boolean;
 
-    constructor(private vscode: vscode, networkSettingsProvider: NetworkSettingsProvider, private packageJSON: any, private platformInfo: PlatformInformation, private eventStream: EventStream, private optionProvider: OptionProvider, private extensionPath: string, private monoResolver: IMonoResolver) {
+    constructor(private vscode: vscode, networkSettingsProvider: NetworkSettingsProvider, private packageJSON: any, private platformInfo: PlatformInformation, private eventStream: EventStream, private optionProvider: OptionProvider, private extensionPath: string, private monoResolver: IMonoResolver, public decompilationAuthorized: boolean) {
         this._requestQueue = new RequestQueueCollection(this.eventStream, 8, request => this._makeRequest(request));
         let downloader = new OmnisharpDownloader(networkSettingsProvider, this.eventStream, this.packageJSON, platformInfo, extensionPath);
         this._omnisharpManager = new OmnisharpManager(downloader, platformInfo);
@@ -347,6 +347,10 @@ export class OmniSharpServer {
 
         if (options.enableEditorConfigSupport === true) {
             args.push('FormattingOptions:EnableEditorConfigSupport=true');
+        }
+
+        if (this.decompilationAuthorized && options.enableDecompilationSupport === true) {
+            args.push('RoslynExtensionsOptions:EnableDecompilationSupport=true');
         }
 
         let launchInfo: LaunchInfo;

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, false, false, undefined, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, false, false, false, undefined, "", "");
 }

--- a/test/unitTests/optionStream.test.ts
+++ b/test/unitTests/optionStream.test.ts
@@ -53,6 +53,7 @@ suite('OptionStream', () => {
             options.enableMsBuildLoadProjectsOnDemand.should.equal(false);
             options.enableRoslynAnalyzers.should.equal(false);
             options.enableEditorConfigSupport.should.equal(false);
+            options.enableDecompilationSupport.should.equal(false);
             expect(options.defaultLaunchSolution).to.be.undefined;
         });
 

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -32,6 +32,7 @@ suite("Options tests", () => {
         options.enableMsBuildLoadProjectsOnDemand.should.equal(false);
         options.enableRoslynAnalyzers.should.equal(false);
         options.enableEditorConfigSupport.should.equal(false);
+        options.enableDecompilationSupport.should.equal(false);
         expect(options.defaultLaunchSolution).to.be.undefined;
     });
 


### PR DESCRIPTION
This option works just like the Visual Studio counterpart.

There is a single application wide setting to enable decompilation support (`'omnisharp.enableDecompilationSupport'`). Then for each workspace you access there is a terms agreement which must be acknowledged. This acknowledgement will persist between sessions for the workspace. If there is need to change how the terms were acknowledged, a command is added to display the decompilation terms prompt (`'csharp.showDecompilationTerms'`) for the open workspace.

![image](https://user-images.githubusercontent.com/611219/81522297-e9cb8880-92fe-11ea-95f6-5dfca1ddc1fd.png)


