### PR TITLE
Classify excluded code

### DIFF
--- a/package.json
+++ b/package.json
@@ -3088,6 +3088,10 @@
         "description": "Represents"
       },
       {
+        "id": "excludedCode",
+        "description": ""
+      },
+      {
         "id": "punctuation",
         "description": ""
       },
@@ -3179,6 +3183,9 @@
           ],
           "preprocessorText": [
             "meta.preprocessor.string.cs"
+          ],
+          "excludedCode": [
+            "support.other.excluded.cs"
           ],
           "punctuation": [
             "punctuation.cs"

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -45,6 +45,7 @@ enum CustomTokenType {
     operatorOverloaded,
     preprocessorKeyword,
     preprocessorText,
+    excludedCode,
     punctuation,
     stringVerbatim,
     stringEscapeCharacter,
@@ -261,6 +262,7 @@ tokenTypes[CustomTokenType.controlKeyword] = "controlKeyword";
 tokenTypes[CustomTokenType.operatorOverloaded] = "operatorOverloaded";
 tokenTypes[CustomTokenType.preprocessorKeyword] = "preprocessorKeyword";
 tokenTypes[CustomTokenType.preprocessorText] = "preprocessorText";
+tokenTypes[CustomTokenType.excludedCode] = "excludedCode";
 tokenTypes[CustomTokenType.punctuation] = "punctuation";
 tokenTypes[CustomTokenType.stringVerbatim] = "stringVerbatim";
 tokenTypes[CustomTokenType.stringEscapeCharacter] = "stringEscapeCharacter";
@@ -291,7 +293,7 @@ tokenModifiers[DefaultTokenModifier.readonly] = 'readonly';
 
 const tokenTypeMap: number[] = [];
 tokenTypeMap[SemanticHighlightClassification.Comment] = DefaultTokenType.comment;
-tokenTypeMap[SemanticHighlightClassification.ExcludedCode] = undefined;
+tokenTypeMap[SemanticHighlightClassification.ExcludedCode] = CustomTokenType.excludedCode;
 tokenTypeMap[SemanticHighlightClassification.Identifier] = DefaultTokenType.variable;
 tokenTypeMap[SemanticHighlightClassification.Keyword] = CustomTokenType.plainKeyword;
 tokenTypeMap[SemanticHighlightClassification.ControlKeyword] = CustomTokenType.controlKeyword;


### PR DESCRIPTION
Resolves #3788

![image](https://user-images.githubusercontent.com/611219/82103515-295fef00-96c8-11ea-97da-722112ca687b.png)

Requires a color to be specified for the "support.other.excluded" scope. Recommend using the following tweaks:

<details>
  <summary>VS2019 theme tweaks: </summary>

```json
    "editor.tokenColorCustomizations": {
        "[Default Dark+]": {
            "textMateRules": [
                {
                    "scope": "support.other.excluded",
                    "settings": {
                        "foreground": "#808080"
                    }
                },
                {
                    "scope": "keyword.preprocessor",
                    "settings": {
                        "foreground": "#808080"
                    }
                },
                {
                    "scope": "punctuation",
                    "settings": {
                        "foreground": "#D4D4D4"
                    }
                },
                {
                    "scope": "entity.name.namespace",
                    "settings": {
                        "foreground": "#D4D4D4"
                    }
                },
                {
                    "scope": "entity.name.variable.field",
                    "settings": {
                        "foreground": "#D4D4D4"
                    }
                },
                {
                    "scope": "variable.other.property",
                    "settings": {
                        "foreground": "#D4D4D4"
                    }
                },
                {
                    "scope": "variable.other.constant",
                    "settings": {
                        "foreground": "#D4D4D4",
                    }
                },
                {
                    "scope": "variable.other.enummember",
                    "settings": {
                        "foreground": "#D4D4D4"
                    }
                },
                {
                    "scope": "entity.name.type.interface",
                    "settings": {
                        "foreground": "#b8d7a3"
                    }
                },
                {
                    "scope": "entity.name.type.enum",
                    "settings": {
                        "foreground": "#b8d7a3"
                    }
                },
                {
                    "scope": "entity.name.type.parameter",
                    "settings": {
                        "foreground": "#b8d7a3"
                    }
                },
                {
                    "scope": "entity.name.type.struct",
                    "settings": {
                        "foreground": "#86C691",
                    }
                },
                {
                    "scope": "entity.name.function.extension",
                    "settings": {
                        "foreground": "#DCDCAA",
                    }
                },
                {
                    "scope": "comment.documentation",
                    "settings": {
                        "foreground": "#608B4E",
                    }
                },
                {
                    "scope": "comment.documentation.attribute",
                    "settings": {
                        "foreground": "#C8C8C8",
                    }
                },
                {
                    "scope": "comment.documentation.cdata",
                    "settings": {
                        "foreground": "#E9D585",
                    }
                },
                {
                    "scope": "comment.documentation.delimiter",
                    "settings": {
                        "foreground": "#808080",
                    }
                },
                {
                    "scope": "comment.documentation.name",
                    "settings": {
                        "foreground": "#569CD6",
                    }
                },
                {
                    "scope": "comment.regex",
                    "settings": {
                        "foreground": "#57A64A",
                    }
                },
                {
                    "scope": "constant.character.character-class.regexp",
                    "settings": {
                        "foreground": "#2EABFE",
                    }
                },
                {
                    "scope": "keyword.control.anchor.regexp",
                    "settings": {
                        "foreground": "#F979AE",
                    }
                },
                {
                    "scope": "keyword.operator.quantifier.regexp",
                    "settings": {
                        "foreground": "#F979AE",
                    }
                },
                {
                    "scope": "punctuation.definition.group.regexp",
                    "settings": {
                        "foreground": "#05C3BA",
                    }
                },
                {
                    "scope": "keyword.operator.or.regexp",
                    "settings": {
                        "foreground": "#05C3BA",
                    }
                },
                {
                    "scope": "string.regexp",
                    "settings": {
                        "foreground": "#D69D85",
                    }
                },
                {
                    "scope": "constant.character.escape.regexp",
                    "settings": {
                        "foreground": "#D69D85",
                    }
                },
                {
                    "scope": "constant.other.escape.regexp",
                    "settings": {
                        "foreground": "#FFD68F",
                    }
                },
            ]
        },
        "[Default Light+]": {
            "textMateRules": [
                {
                    "scope": "support.other.excluded",
                    "settings": {
                        "foreground": "#808080"
                    }
                },
                {
                    "scope": "keyword.preprocessor",
                    "settings": {
                        "foreground": "#808080"
                    }
                },
                {
                    "scope": "punctuation",
                    "settings": {
                        "foreground": "#222222"
                    }
                },
                {
                    "scope": "entity.name.namespace",
                    "settings": {
                        "foreground": "#222222"
                    }
                },
                {
                    "scope": "entity.name.variable.field",
                    "settings": {
                        "foreground": "#222222"
                    }
                },
                {
                    "scope": "variable.other.property",
                    "settings": {
                        "foreground": "#222222"
                    }
                },
                {
                    "scope": "variable.other.constant",
                    "settings": {
                        "foreground": "#222222",
                    }
                },
                {
                    "scope": "variable.other.enummember",
                    "settings": {
                        "foreground": "#222222"
                    }
                },
                {
                    "scope": "entity.name.type.interface",
                    "settings": {
                        "foreground": "#267f99"
                    }
                },
                {
                    "scope": "entity.name.type.enum",
                    "settings": {
                        "foreground": "#267f99"
                    }
                },
                {
                    "scope": "entity.name.type.parameter",
                    "settings": {
                        "foreground": "#267f99"
                    }
                },
                {
                    "scope": "entity.name.type.struct",
                    "settings": {
                        "foreground": "#267f99",
                    }
                },
                {
                    "scope": "entity.name.function.extension",
                    "settings": {
                        "foreground": "#795E26",
                    }
                },
                {
                    "scope": "comment.documentation",
                    "settings": {
                        "foreground": "#008000",
                    }
                },
                {
                    "scope": "comment.documentation.attribute",
                    "settings": {
                        "foreground": "#282828",
                    }
                },
                {
                    "scope": "comment.documentation.cdata",
                    "settings": {
                        "foreground": "#808080",
                    }
                },
                {
                    "scope": "comment.documentation.delimiter",
                    "settings": {
                        "foreground": "#808080",
                    }
                },
                {
                    "scope": "comment.documentation.name",
                    "settings": {
                        "foreground": "#808080",
                    }
                }
            ]
        }
    },
```
</details>