### PR TITLE
Set IsWebProject property before it is used

### DIFF
--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -77,10 +77,11 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
         let blazorWebAssemblyProjectFound = false;
 
         for (const project of response.MsBuild.Projects) {
+            project.IsWebProject = isWebProject(project);
+
             const isProjectBlazorWebAssemblyProject = await isBlazorWebAssemblyProject(project);
             const isProjectBlazorWebAssemblyHosted = isBlazorWebAssemblyHosted(project, isProjectBlazorWebAssemblyProject);
 
-            project.IsWebProject = isWebProject(project);
             project.IsBlazorWebAssemblyHosted = blazorDetectionEnabled && isProjectBlazorWebAssemblyHosted;
             project.IsBlazorWebAssemblyStandalone = blazorDetectionEnabled && isProjectBlazorWebAssemblyProject && !project.IsBlazorWebAssemblyHosted;
 


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/22151.

The `IsWebProject` property is used inside the `isBlazorWebAssemblyHosted` function before it is set. As a result, this causes the `isBlazorWebAssemblyHosted` to incorrectly not identify hosted Blazor apps.

To fix this, we set the `IsWebProject` property before it is used.