### PR TITLE
improved documentation entry for omnisharp.path

### DIFF
--- a/package.json
+++ b/package.json
@@ -671,7 +671,7 @@
           ],
           "default": null,
           "scope": "machine",
-          "description": "Specifies the path to OmniSharp. This can be the absolute path to an OmniSharp executable, a specific version number, or \"latest\". If a version number or \"latest\" is specified, the appropriate version of OmniSharp will be downloaded on your behalf."
+          "description": "Specifies the path to OmniSharp. When left empty the OmniSharp version pinned to the C# Extension is used. This can be the absolute path to an OmniSharp executable, a specific version number, or \"latest\". If a version number or \"latest\" is specified, the appropriate version of OmniSharp will be downloaded on your behalf. Setting \"latest\" is an opt-in into latest beta releases of OmniSharp."
         },
         "omnisharp.useGlobalMono": {
           "type": "string",


### PR DESCRIPTION
At the moment it is not clear that `"omnisharp.path":"latest"` opts the user into the beta channel builds.