### PR TITLE
Make "Run/debug tests in context" position a link

### DIFF
--- a/src/observers/DotnetTestLoggerObserver.ts
+++ b/src/observers/DotnetTestLoggerObserver.ts
@@ -73,12 +73,12 @@ export default class DotNetTestLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleDotnetTestsRunInContextStart(event: DotNetTestRunInContextStart) {
-        this.logger.appendLine(`----- Running test(s) in context "${event.fileName} ${event.line + 1}:${event.column + 1}" -----`);
+        this.logger.appendLine(`----- Running test(s) in context "${event.fileName}(${event.line + 1},${event.column + 1})" -----`);
         this.logger.appendLine('');
     }
 
     private handleDotnetTestsDebugInContextStart(event: DotNetTestDebugInContextStart) {
-        this.logger.appendLine(`----- Debugging test(s) in context "${event.fileName} ${event.line + 1}:${event.column + 1}" -----`);
+        this.logger.appendLine(`----- Debugging test(s) in context "${event.fileName}(${event.line + 1},${event.column + 1})" -----`);
         this.logger.appendLine('');
     }
 


### PR DESCRIPTION
This modifies the format for the context position so that it formats as a link in VS Code. This is handy when you are reviewing the test output logs and you want to get back to the context position for some tests that you ran previously.

This imitates the formatting for positions used when the compiler reports diagnostics and in stack traces at runtime.

Before: `src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs 3015:15`
After: `src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs(3015,15)`

You can actually try just including these strings in a terminal command and you will see that the former does not parse as a link but the latter does.

/cc @333fred @JoeRobich