### PR TITLE
Move omnisharp vscode to the new hover implementation

### DIFF
--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -7,26 +7,44 @@ import AbstractSupport from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
 import { createRequest } from '../omnisharp/typeConversion';
-import { HoverProvider, Hover, TextDocument, CancellationToken, Position } from 'vscode';
-import { GetDocumentationString } from './documentation';
+import { HoverProvider, Hover, TextDocument, CancellationToken, Position, MarkdownString } from 'vscode';
 
 export default class OmniSharpHoverProvider extends AbstractSupport implements HoverProvider {
 
     public async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
-
-        let req = createRequest<protocol.TypeLookupRequest>(document, position);
-        req.IncludeDocumentation = true;
-
+        let request = createRequest<protocol.V2.QuickInfoRequest>(document, position);
         try {
-            let value = await serverUtils.typeLookup(this._server, req, token);
-            if (value && value.Type) {
-                let documentation = GetDocumentationString(value.StructuredDocumentation);
-                let contents = [{ language: 'csharp', value: value.Type }, documentation];
-                return new Hover(contents);
+            const response = await serverUtils.getQuickInfo(this._server, request, token);
+            if (!response.Description && !response.RemainingSections && !response.Summary) {
+                return undefined;
             }
+
+            let markdownString = new MarkdownString;
+            const language = "csharp";
+            if (response.Description) {
+                markdownString.appendCodeblock(response.Description, language);
+            }
+
+            if (response.Summary) {
+                markdownString.appendMarkdown(response.Summary);
+            }
+
+            if (response.RemainingSections) {
+                for (const section of response.RemainingSections) {
+                    if (section.IsCSharpCode) {
+                        markdownString.appendCodeblock(section.Text, language);
+                    }
+                    else {
+                        markdownString.appendText("\n");
+                        markdownString.appendMarkdown(section.Text);
+                    }
+                }
+            }
+
+            return new Hover(markdownString);
         }
         catch (error) {
-            return undefined; //No hover result could be obtained
+            return undefined;
         }
     }
 }

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -12,32 +12,22 @@ import { HoverProvider, Hover, TextDocument, CancellationToken, Position, Markdo
 export default class OmniSharpHoverProvider extends AbstractSupport implements HoverProvider {
 
     public async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
-        let request = createRequest<protocol.V2.QuickInfoRequest>(document, position);
+        let request = createRequest<protocol.QuickInfoRequest>(document, position);
         try {
             const response = await serverUtils.getQuickInfo(this._server, request, token);
-            if (!response.Description && !response.RemainingSections && !response.Summary) {
+            if (!response || !response.Sections) {
                 return undefined;
             }
 
             let markdownString = new MarkdownString;
             const language = "csharp";
-            if (response.Description) {
-                markdownString.appendCodeblock(response.Description, language);
-            }
-
-            if (response.Summary) {
-                markdownString.appendMarkdown(response.Summary);
-            }
-
-            if (response.RemainingSections) {
-                for (const section of response.RemainingSections) {
-                    if (section.IsCSharpCode) {
-                        markdownString.appendCodeblock(section.Text, language);
-                    }
-                    else {
-                        markdownString.appendText("\n");
-                        markdownString.appendMarkdown(section.Text);
-                    }
+            for (const section of response.Sections) {
+                if (section.IsCSharpCode) {
+                    markdownString.appendCodeblock(section.Text, language);
+                }
+                else {
+                    markdownString.appendText("\n");
+                    markdownString.appendMarkdown(section.Text);
                 }
             }
 

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -15,21 +15,12 @@ export default class OmniSharpHoverProvider extends AbstractSupport implements H
         let request = createRequest<protocol.QuickInfoRequest>(document, position);
         try {
             const response = await serverUtils.getQuickInfo(this._server, request, token);
-            if (!response || !response.Sections) {
+            if (!response || !response.Markdown) {
                 return undefined;
             }
 
-            let markdownString = new MarkdownString;
-            const language = "csharp";
-            for (const section of response.Sections) {
-                if (section.IsCSharpCode) {
-                    markdownString.appendCodeblock(section.Text, language);
-                }
-                else {
-                    markdownString.appendText("\n");
-                    markdownString.appendMarkdown(section.Text);
-                }
-            }
+            const markdownString = new MarkdownString;
+            markdownString.appendMarkdown(response.Markdown);
 
             return new Hover(markdownString);
         }

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -478,14 +478,8 @@ export interface QuickInfoRequest extends Request {
 }
 
 export interface QuickInfoResponse {
-    Sections?: QuickInfoResponseSection[];
+    Markdown?: string;
 }
-
-export interface QuickInfoResponseSection {
-    IsCSharpCode: boolean;
-    Text: string;
-}
-
 
 export namespace V2 {
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -29,6 +29,7 @@ export module Requests {
     export const UpdateBuffer = '/updatebuffer';
     export const Metadata = '/metadata';
     export const ReAnalyze = '/reanalyze';
+    export const QuickInfo = '/quickinfo';
 }
 
 export namespace WireProtocol {
@@ -473,6 +474,19 @@ export enum FileChangeType {
     DirectoryDelete = "DirectoryDelete"
 }
 
+export interface QuickInfoRequest extends Request {
+}
+
+export interface QuickInfoResponse {
+    Sections?: QuickInfoResponseSection[];
+}
+
+export interface QuickInfoResponseSection {
+    IsCSharpCode: boolean;
+    Text: string;
+}
+
+
 export namespace V2 {
 
     export module Requests {
@@ -491,7 +505,6 @@ export namespace V2 {
         export const BlockStructure = '/v2/blockstructure';
         export const CodeStructure = '/v2/codestructure';
         export const Highlight = '/v2/highlight';
-        export const QuickInfo = '/v2/quickinfo';
     }
 
     export interface SemanticHighlightSpan {
@@ -710,20 +723,6 @@ export namespace V2 {
     export interface CodeFoldingBlock {
         Range: Range;
         Kind: string;
-    }
-
-    export interface QuickInfoRequest extends Request {
-    }
-
-    export interface QuickInfoResponse {
-        Description?: string;
-        Summary?: string;
-        RemainingSections?: QuickInfoResponseSection[];
-    }
-
-    export interface QuickInfoResponseSection {
-        IsCSharpCode: boolean;
-        Text: string;
     }
 
     export module SymbolKinds {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -491,6 +491,7 @@ export namespace V2 {
         export const BlockStructure = '/v2/blockstructure';
         export const CodeStructure = '/v2/codestructure';
         export const Highlight = '/v2/highlight';
+        export const QuickInfo = '/v2/quickinfo';
     }
 
     export interface SemanticHighlightSpan {
@@ -709,6 +710,20 @@ export namespace V2 {
     export interface CodeFoldingBlock {
         Range: Range;
         Kind: string;
+    }
+
+    export interface QuickInfoRequest extends Request {
+    }
+
+    export interface QuickInfoResponse {
+        Description?: string;
+        Summary?: string;
+        RemainingSections?: QuickInfoResponseSection[];
+    }
+
+    export interface QuickInfoResponseSection {
+        IsCSharpCode: boolean;
+        Text: string;
     }
 
     export module SymbolKinds {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -169,8 +169,8 @@ export async function getSemanticHighlights(server: OmniSharpServer, request: pr
     return server.makeRequest<protocol.V2.SemanticHighlightResponse>(protocol.V2.Requests.Highlight, request);
 }
 
-export async function getQuickInfo(server: OmniSharpServer, request: protocol.V2.QuickInfoRequest, token: CancellationToken) {
-    return server.makeRequest<protocol.V2.QuickInfoResponse>(protocol.V2.Requests.QuickInfo, request, token);
+export async function getQuickInfo(server: OmniSharpServer, request: protocol.QuickInfoRequest, token: CancellationToken) {
+    return server.makeRequest<protocol.QuickInfoResponse>(protocol.Requests.QuickInfo, request, token);
 }
 
 export async function isNetCoreProject(project: protocol.MSBuildProject) {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as protocol from './protocol';
 import * as vscode from 'vscode';
 import { MSBuildProject } from './protocol';
+import { CancellationToken } from 'vscode-languageserver-protocol';
 
 export async function autoComplete(server: OmniSharpServer, request: protocol.AutoCompleteRequest, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.AutoCompleteResponse[]>(protocol.Requests.AutoComplete, request, token);
@@ -166,6 +167,10 @@ export async function debugTestStop(server: OmniSharpServer, request: protocol.V
 
 export async function getSemanticHighlights(server: OmniSharpServer, request: protocol.V2.SemanticHighlightRequest) {
     return server.makeRequest<protocol.V2.SemanticHighlightResponse>(protocol.V2.Requests.Highlight, request);
+}
+
+export async function getQuickInfo(server: OmniSharpServer, request: protocol.V2.QuickInfoRequest, token: CancellationToken) {
+    return server.makeRequest<protocol.V2.QuickInfoResponse>(protocol.V2.Requests.QuickInfo, request, token);
 }
 
 export async function isNetCoreProject(project: protocol.MSBuildProject) {

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -42,7 +42,7 @@ suite(`Hover Provider: ${testAssetWorkspace.description}`, function () {
         await vscode.commands.executeCommand("vscode.open", fileUri);
         let c = <vscode.Hover[]>(await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri, new vscode.Position(10, 29)));
         let answer: string =
-            "```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag.\n\nReturns:\n\n  Returns true if object is tagged with tag.";
+            "```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag\\.\n\nReturns:\n\n  Returns true if object is tagged with tag\\.";
 
         expect((<{ language: string; value: string }>c[0].contents[0]).value).to.equal(answer);
     });

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -10,6 +10,8 @@ import { should, expect } from 'chai';
 import { activateCSharpExtension, isRazorWorkspace } from './integrationHelpers';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 
+export type Test = 'a' | 'b' | ['c', any];
+
 const chai = require('chai');
 chai.use(require('chai-arrays'));
 chai.use(require('chai-fs'));

--- a/test/integrationTests/hoverProvider.integration.test.ts
+++ b/test/integrationTests/hoverProvider.integration.test.ts
@@ -40,8 +40,8 @@ suite(`Hover Provider: ${testAssetWorkspace.description}`, function () {
         await vscode.commands.executeCommand("vscode.open", fileUri);
         let c = <vscode.Hover[]>(await vscode.commands.executeCommand("vscode.executeHoverProvider", fileUri, new vscode.Position(10, 29)));
         let answer: string =
-            `Checks if object is tagged with the tag.`;
+            "```csharp\nbool testissue.Compare(int gameObject, string tagName)\n```\n\nChecks if object is tagged with the tag.\n\nReturns:\n\n  Returns true if object is tagged with tag.";
 
-        expect((<{ language: string; value: string }>c[0].contents[1]).value).to.equal(answer);
+        expect((<{ language: string; value: string }>c[0].contents[0]).value).to.equal(answer);
     });
 });


### PR DESCRIPTION
Hover implemention is in PR here: https://github.com/OmniSharp/omnisharp-roslyn/pull/1860.

Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/3652