### PR TITLE
Make updateBuffer use incremental updates

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -6,7 +6,7 @@
 import { Uri, workspace } from 'vscode';
 import { OmniSharpServer } from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
-import { FileChangeType } from '../omnisharp/protocol';
+import { FileChangeType, LinePositionSpanTextChange } from '../omnisharp/protocol';
 import { IDisposable } from '../Disposable';
 import CompositeDisposable from '../CompositeDisposable';
 
@@ -23,7 +23,18 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
             return;
         }
 
-        serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName }).catch(err => {
+        const lineChanges = event.contentChanges.map(function (change): LinePositionSpanTextChange {
+            const range = change.range;
+            return {
+                NewText: change.text,
+                StartLine: range.start.line + 1,
+                StartColumn: range.start.character + 1,
+                EndLine: range.end.line + 1,
+                EndColumn: range.end.character + 1
+            };
+        });
+
+        serverUtils.updateBuffer(server, { Changes: lineChanges, FileName: document.fileName }).catch(err => {
             console.error(err);
             return err;
         });


### PR DESCRIPTION
Today, VSCode serializes the entire file whenever it sends a file update request. This can be very costly, particularly for files like Roslyn's NullableReferenceTypeTests.cs, which is 5+ MB. This causes large allocations in both vscode itself and in omnisharp, slowing down typing responsiveness. This commit moves the vscode extension to use the per-line changes that the omnisharp-roslyn host already supports. Editing experience in the afformentioned file is noticeably smoother. Completions are still somewhat slow and work needs to be done on that front, but this makes it possible to actually edit the file with vscode still being responsive.
