### PR TITLE
Fix CI by specifying version of dotnet sdk to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - sudo dpkg -i packages-microsoft-prod.deb
   - sudo apt-get install apt-transport-https
   - sudo apt-get update
-  - sudo apt-get install dotnet-sdk-3.1
+  - sudo apt-get install dotnet-sdk-3.1=3.1.302-1
   - sudo apt install xvfb
 
 addons:


### PR DESCRIPTION
dotnet sdk 3.1.401 doesn't work with OmniSharp's included version of Mono.