### PR TITLE
Revert "Make updateBuffer use incremental updates"

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -6,7 +6,7 @@
 import { Uri, workspace } from 'vscode';
 import { OmniSharpServer } from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
-import { FileChangeType, LinePositionSpanTextChange } from '../omnisharp/protocol';
+import { FileChangeType } from '../omnisharp/protocol';
 import { IDisposable } from '../Disposable';
 import CompositeDisposable from '../CompositeDisposable';
 
@@ -23,18 +23,7 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
             return;
         }
 
-        const lineChanges = event.contentChanges.map(function (change): LinePositionSpanTextChange {
-            const range = change.range;
-            return {
-                NewText: change.text,
-                StartLine: range.start.line + 1,
-                StartColumn: range.start.character + 1,
-                EndLine: range.end.line + 1,
-                EndColumn: range.end.character + 1
-            };
-        });
-
-        serverUtils.updateBuffer(server, { Changes: lineChanges, FileName: document.fileName }).catch(err => {
+        serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName }).catch(err => {
             console.error(err);
             return err;
         });


### PR DESCRIPTION
Reverts OmniSharp/omnisharp-vscode#3931

OmniSharp server did not handle these changes as expected. This broke keeping the documents coordinated between client and server in some scenarios (Refactor Rename, Multiple Cursor Mode, etc...)