### PR TITLE
Disable Prettier if no prettier config exists

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
+    "prettier.requireConfig": true,
 
     "files.exclude": {
         "out": true,


### PR DESCRIPTION
A lot of users of [prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) use it to format files automatically on save leading to unwanted diffs, so I've added an option to disable prettier unless there is a prettier config file.