### PR TITLE
Update Razor to 6.0.0-alpha.1.20418.9.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6183,8 +6183,8 @@
             }
         },
         "microsoft.aspnetcore.razor.vscode": {
-            "version": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/708c4ce219111a3bdf62fc29b5cd3768/microsoft.aspnetcore.razor.vscode-5.0.0-rc.1.20417.4.tgz",
-            "integrity": "sha512-Ut3D4NXF/RLyHaVJidBc2KUBjYo6MF2K9U7wS3mISTfFybsW1AZDqqWhaM8sKjeNH6xaYuRAFSXSS/CsN5zQpQ==",
+            "version": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/cdad169d976850542ede3d3b8c7cb58f/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20418.9.tgz",
+            "integrity": "sha512-S3mPhFlNIo4DG2DrP0JC+2DbWqKXXa3FecZCAK1zkvciFWQCzudP1V73NPbuzSTSBFXnR40vsBcxsOIaqMP9hg==",
             "requires": {
                 "ps-list": "^7.0.0",
                 "vscode-html-languageservice": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "defaults": {
     "omniSharp": "1.37.0",
-    "razor": "5.0.0-rc.1.20417.4"
+    "razor": "6.0.0-alpha.1.20418.9"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -80,7 +80,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "^3.0.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/708c4ce219111a3bdf62fc29b5cd3768/microsoft.aspnetcore.razor.vscode-5.0.0-rc.1.20417.4.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/cdad169d976850542ede3d3b8c7cb58f/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20418.9.tgz",
     "mkdirp": "^1.0.3",
     "node-filter-async": "1.1.1",
     "node-machine-id": "1.1.12",
@@ -305,8 +305,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/b81c6338f89d3912d7750337398cd253/razorlanguageserver-win-x64-5.0.0-rc.1.20417.4.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-5.0.0-rc.1.20417.4.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/49aae2627ac29087608b8c8b1e5f796e/razorlanguageserver-win-x64-6.0.0-alpha.1.20418.9.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-6.0.0-alpha.1.20418.9.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -318,8 +318,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/ebc7996959de1a5be40d72dec6c1a2fb/razorlanguageserver-win-x86-5.0.0-rc.1.20417.4.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-5.0.0-rc.1.20417.4.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/898bd06092383d62a0635c0fc47bc346/razorlanguageserver-win-x86-6.0.0-alpha.1.20418.9.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-6.0.0-alpha.1.20418.9.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -331,8 +331,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/a7b2070fa56680573ad75f627b5ef6a6/razorlanguageserver-linux-x64-5.0.0-rc.1.20417.4.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-5.0.0-rc.1.20417.4.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/2b6d8eee0470acf725c1c7a09f8b6475/razorlanguageserver-linux-x64-6.0.0-alpha.1.20418.9.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-6.0.0-alpha.1.20418.9.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -347,8 +347,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/7ce7bb73-ea73-4c97-8b32-a897d45f853a/87ba98c9c045bbeb9f901af0fb2c1aeb/razorlanguageserver-osx-x64-5.0.0-rc.1.20417.4.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-5.0.0-rc.1.20417.4.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/757f5246-2b09-43fe-9a8d-840cfd15092b/1350e896e43b4d0bc67886b27a6e44a9/razorlanguageserver-osx-x64-6.0.0-alpha.1.20418.9.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-6.0.0-alpha.1.20418.9.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- Contains the fix for Component renames not working as expected: https://github.com/dotnet/aspnetcore/issues/25018