### PR TITLE
Clean up Blazor WebAssembly notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -835,6 +835,11 @@
           "scope": "window",
           "default": true,
           "description": "Enable/disable default Razor formatter."
+        },
+        "razor.disableBlazorDebugPrompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable Blazor WebAssembly's debug requirements notification."
         }
       }
     },


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/23832

- Removes unnecessary check for nightly JS debugging extension
- Adds "Don't ask again" option to Blazor WASM debugging notification