### PR TITLE
Support TextEdit in completion responses

### DIFF
--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -523,6 +523,7 @@ export interface OmnisharpCompletionItem {
     FilterText?: string;
     InsertText?: string;
     InsertTextFormat?: InsertTextFormat;
+    TextEdit?: LinePositionSpanTextChange;
     CommitCharacters?: string[];
     AdditionalTextEdits?: LinePositionSpanTextChange[];
     Data: any;


### PR DESCRIPTION
This is the vscode side of https://github.com/OmniSharp/omnisharp-roslyn/pull/1941. This is written in such a fashion as to be mergeable now, as it will fall back to InsertText if TextEdit is not present in the completion response. After some appropriate period of time, we can remove the InsertText component.
