### PR TITLE
Update to OmniSharp 1.37.3 and revert useGlobalMono meaning.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -139,8 +139,8 @@
                 "updatePackageDependencies"
             ],
             "env": {
-                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/503ebd3f8f242394cebd496b76e726c7/omnisharp-linux-x64-1.37.2.zip,https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/4cf34bc86b969db7a466d4cdd00c1d7b/omnisharp-linux-x86-1.37.2.zip,https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/f57fe2aed239711c69cda6c82ee7a2bf/omnisharp-osx-1.37.2.zip,https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/97dcfcf480bf1bd5c8bb0a10ac3e5782/omnisharp-win-x64-1.37.2.zip,https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/2b796a0bb27b816d543577d519b6a5a2/omnisharp-win-x86-1.37.2.zip",
-                "NEW_DEPS_VERSION": "1.37.2"
+                "NEW_DEPS_URLS": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/4d682ee649bcf084eee3d6b675157541/omnisharp-linux-x64-1.37.3.zip,https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/d86b6a136dd8b420d101bcc5bfed442d/omnisharp-linux-x86-1.37.3.zip,https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/0b3f4fd3384777867ebe50923b6dee90/omnisharp-osx-1.37.3.zip,https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/fd2b97e2a06208d965a3abeb19d87e47/omnisharp-win-x64-1.37.3.zip,https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/a1bbd300586e592052207344cc47073d/omnisharp-win-x86-1.37.3.zip",
+                "NEW_DEPS_VERSION": "1.37.3"
             },
             "cwd": "${workspaceFolder}"
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
-## Known Issues in 1.23.3
+## Known Issues in 1.23.4
 
-* For Mono-based development (e.g. Unity) that requires full .NET framework, you need to set `"omnisharp.useGlobalMono": "always"`. This is needed until Mono [upgrades their bundled MSBuild version](https://github.com/mono/mono/issues/20250)
 * Known limitations with the preview Razor (cshtml) language service to be addressed in a future release:
   * Only ASP.NET Core projects are supported (no support for ASP.NET projects)
   * Limited support for formatting
@@ -11,7 +10,15 @@
 * Renaming symbol fails within a file that had recently been renamed without saving changes.
   * As a workaround, make an edit within the file before using Rename Symbol.
 
-## 1.23.3 (Not yet released)
+## 1.23.4 (Not yet released)
+* Use incremental changes to update language server (PR: [#4088](https://github.com/OmniSharp/omnisharp-vscode/pull/4088))
+* Set meaning of UseGlobalMono "auto" to "always" now that Mono 6.12.0 ships with MSBuild 16.8 (PR: [#4115](https://github.com/OmniSharp/omnisharp-vscode/pull/4115))
+* Updated OmniSharp to 1.37.3
+  * Fixed a bug when the server wouldn't start on MacOS/Linux when a username contained a space (PR: [omnisharp-roslyn/#1979](https://github.com/OmniSharp/omnisharp-roslyn/pull/1979))
+  * Update to Mono 6.12.0 (PR: [omnisharp-roslyn/#1981](https://github.com/OmniSharp/omnisharp-roslyn/pull/1981))
+  * Fix responsiveness regression with targeted DiagnosticWorker revert ([omnisharp-roslyn/#1982](https://github.com/OmniSharp/omnisharp-roslyn/issues/1982), [omnisharp-roslyn/#1983](https://github.com/OmniSharp/omnisharp-roslyn/issues/1983), PR: [omnisharp-roslyn/#1984](https://github.com/OmniSharp/omnisharp-roslyn/pull/1984))
+
+## 1.23.3 (October 12, 2020)
 * Fix ps call for Alpine images ([#4023](https://github.com/OmniSharp/omnisharp-vscode/issues/4023), PR: [#4097](https://github.com/OmniSharp/omnisharp-vscode/pull/4097))
 * Support TextEdit in completion responses (PR: [@4073](https://github.com/OmniSharp/omnisharp-vscode/pull/4073))
 * Updated Razor support

--- a/README.md
+++ b/README.md
@@ -20,10 +20,20 @@ The C# extension is powered by [OmniSharp](https://github.com/OmniSharp/omnishar
 -   [Documentation](https://code.visualstudio.com/docs/languages/csharp)
 -   [Video Tutorial compiling with .NET Core](https://channel9.msdn.com/Blogs/dotnet/Get-started-VSCode-Csharp-NET-Core-Windows)
 
-## Note about using .NET Core 3.1.401 or .NET 5 Preview 8 SDKs on Mono platforms
+## Note about using .NET 5 SDKs
 
-Because of the new minimum MSBuild version requirement of these new SDKs, it will be necessary to use the Mono packaged with the C# extension. The meaning of "omnisharp.useGlobalMono" has change to "never", this forces the use of the included Mono. To use your system
-install of Mono set the value to "always" although it may not be compatible with newer SDKs.
+The .NET 5 SDK requires version 16.8 of MSBuild.
+
+For Windows users who have Visual Studio installed, this means you will need to be on the latest Visual Studio 16.8 Preview.
+For MacOS and Linux users who have Mono installed, this means you will need to be on the latest stable Mono (6.12.0).
+
+## What's new in 1.23.4
+-   Use incremental changes to update language server (PR: [#4088](https://github.com/OmniSharp/omnisharp-vscode/pull/4088))
+-   Set meaning of UseGlobalMono "auto" to "always" now that Mono 6.12.0 ships with MSBuild 16.8 (PR: [#4115](https://github.com/OmniSharp/omnisharp-vscode/pull/4115))
+-   Updated OmniSharp to 1.37.3
+    -   Fixed a bug when the server wouldn't start on MacOS/Linux when a username contained a space (PR: [omnisharp-roslyn/#1979](https://github.com/OmniSharp/omnisharp-roslyn/pull/1979))
+    -   Update to Mono 6.12.0 (PR: [omnisharp-roslyn/#1981](https://github.com/OmniSharp/omnisharp-roslyn/pull/1981))
+    -   Fix responsiveness regression with targeted DiagnosticWorker revert ([omnisharp-roslyn/#1982](https://github.com/OmniSharp/omnisharp-roslyn/issues/1982), [omnisharp-roslyn/#1983](https://github.com/OmniSharp/omnisharp-roslyn/issues/1983), PR: [omnisharp-roslyn/#1984](https://github.com/OmniSharp/omnisharp-roslyn/pull/1984))
 
 ## What's new in 1.23.3
 -   Fix ps call for Alpine images ([#4023](https://github.com/OmniSharp/omnisharp-vscode/issues/4023), PR: [#4097](https://github.com/OmniSharp/omnisharp-vscode/pull/4097))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "csharp",
-    "version": "1.23.3",
+    "version": "1.23.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp",
   "publisher": "ms-dotnettools",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "description": "C# for Visual Studio Code (powered by OmniSharp).",
   "displayName": "C#",
   "author": "Microsoft Corporation",
@@ -29,7 +29,7 @@
     "dotnet"
   ],
   "defaults": {
-    "omniSharp": "1.37.2",
+    "omniSharp": "1.37.3",
     "razor": "6.0.0-alpha.1.20479.2"
   },
   "main": "./dist/extension",
@@ -161,41 +161,41 @@
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/2b796a0bb27b816d543577d519b6a5a2/omnisharp-win-x86-1.37.2.zip",
-      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-win-x86-1.37.2.zip",
-      "installPath": ".omnisharp/1.37.2",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/a1bbd300586e592052207344cc47073d/omnisharp-win-x86-1.37.3.zip",
+      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.3/omnisharp-win-x86-1.37.3.zip",
+      "installPath": ".omnisharp/1.37.3",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86"
       ],
-      "installTestPath": "./.omnisharp/1.37.2/OmniSharp.exe",
+      "installTestPath": "./.omnisharp/1.37.3/OmniSharp.exe",
       "platformId": "win-x86",
-      "integrity": "1AE479E04E1C73A5991FAB22FD1110DE614E7182FA3B65940DD0995CD113E2EA"
+      "integrity": "AA2544E73A17760BF6699A7C0580610FC610D63A434CEB3CCF307A772AA365C6"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Windows (.NET 4.6 / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/97dcfcf480bf1bd5c8bb0a10ac3e5782/omnisharp-win-x64-1.37.2.zip",
-      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-win-x64-1.37.2.zip",
-      "installPath": ".omnisharp/1.37.2",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/fd2b97e2a06208d965a3abeb19d87e47/omnisharp-win-x64-1.37.3.zip",
+      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.3/omnisharp-win-x64-1.37.3.zip",
+      "installPath": ".omnisharp/1.37.3",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86_64"
       ],
-      "installTestPath": "./.omnisharp/1.37.2/OmniSharp.exe",
+      "installTestPath": "./.omnisharp/1.37.3/OmniSharp.exe",
       "platformId": "win-x64",
-      "integrity": "E06C415107A8874A323C1B9779F699A2143EB2D3B4B84B8E765120BC921105C7"
+      "integrity": "542841E6ECCAA3FF545BFA8778CB0CC4F4BEB5A6D2E55D5A9972E02DAB5ED993"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for OSX",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/f57fe2aed239711c69cda6c82ee7a2bf/omnisharp-osx-1.37.2.zip",
-      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-osx-1.37.2.zip",
-      "installPath": ".omnisharp/1.37.2",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/0b3f4fd3384777867ebe50923b6dee90/omnisharp-osx-1.37.3.zip",
+      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.3/omnisharp-osx-1.37.3.zip",
+      "installPath": ".omnisharp/1.37.3",
       "platforms": [
         "darwin"
       ],
@@ -203,16 +203,16 @@
         "./mono.osx",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.37.2/run",
+      "installTestPath": "./.omnisharp/1.37.3/run",
       "platformId": "osx",
-      "integrity": "94CAF422B6FA516BE4DCAA2BBBBB6D657CAC957B134FD5AF614FA58665E1A9A7"
+      "integrity": "A146279775CCFE4CFF45964DB83CF293BD9F0C0E9FD11A517E912A5EC1B20BC9"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Linux (x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/4cf34bc86b969db7a466d4cdd00c1d7b/omnisharp-linux-x86-1.37.2.zip",
-      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-linux-x86-1.37.2.zip",
-      "installPath": ".omnisharp/1.37.2",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/d86b6a136dd8b420d101bcc5bfed442d/omnisharp-linux-x86-1.37.3.zip",
+      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.3/omnisharp-linux-x86-1.37.3.zip",
+      "installPath": ".omnisharp/1.37.3",
       "platforms": [
         "linux"
       ],
@@ -224,16 +224,16 @@
         "./mono.linux-x86",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.37.2/run",
+      "installTestPath": "./.omnisharp/1.37.3/run",
       "platformId": "linux-x86",
-      "integrity": "7813A9F3DD5E32EAE106F9172BB39EB7F441AA2A32B81709A454DCBE5A347B45"
+      "integrity": "BBA9D8B8D894D50E3B191D7980680A93D1A493EDD77BB09A82093742AC56BFD4"
     },
     {
       "id": "OmniSharp",
       "description": "OmniSharp for Linux (x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/503ebd3f8f242394cebd496b76e726c7/omnisharp-linux-x64-1.37.2.zip",
-      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-linux-x64-1.37.2.zip",
-      "installPath": ".omnisharp/1.37.2",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/53b6d57a-1e5c-46bd-a64f-35011a3a2180/4d682ee649bcf084eee3d6b675157541/omnisharp-linux-x64-1.37.3.zip",
+      "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.3/omnisharp-linux-x64-1.37.3.zip",
+      "installPath": ".omnisharp/1.37.3",
       "platforms": [
         "linux"
       ],
@@ -244,9 +244,9 @@
         "./mono.linux-x86_64",
         "./run"
       ],
-      "installTestPath": "./.omnisharp/1.37.2/run",
+      "installTestPath": "./.omnisharp/1.37.3/run",
       "platformId": "linux-x64",
-      "integrity": "41A1111915AA66224174B561FA70B1C88340AA5D9FEBC8B8583B19B68F8A4F00"
+      "integrity": "DAB96800C45650A7BBEE1E6EDC1A96CD71B4D2C9BACED4E126A45101D30CA8E8"
     },
     {
       "id": "Debugger",

--- a/src/omnisharp/OmniSharpMonoResolver.ts
+++ b/src/omnisharp/OmniSharpMonoResolver.ts
@@ -45,13 +45,9 @@ export class OmniSharpMonoResolver implements IMonoResolver {
 
             return monoInfo;
         }
-
-        // While wwaiting for Mono to ship with a MSBuild version 16.7 or higher, we will treat "auto"
-        // as "Use included Mono".
-
-        // else if (options.useGlobalMono === "auto" && isValid) {
-        //     return monoInfo;
-        //}
+        else if (options.useGlobalMono === "auto" && isValid) {
+            return monoInfo;
+        }
 
         return undefined;
     }

--- a/test/unitTests/omnisharp/OmniSharpMonoResolver.test.ts
+++ b/test/unitTests/omnisharp/OmniSharpMonoResolver.test.ts
@@ -24,7 +24,7 @@ suite(`${OmniSharpMonoResolver.name}`, () => {
     const higherMonoVersion = "6.6.0";
 
     // Sets the meaning of UseGlobalMono "auto". When false, "auto" means "never".
-    const autoMeansAlways = false;
+    const autoMeansAlways = true;
 
     const getMono = (version: string) => async (env: NodeJS.ProcessEnv) => {
         getMonoCalled = true;


### PR DESCRIPTION
Due to a performance regression in OmniSharp 1.37.2, we need to update and publish an updated C# extension build. This PR also reverts the meaning of useGlobalMono to "always" since Mono 6.12.0 is stable and shipping with MSBuild 16.8.

CC: @nohwnd, @vzarytovskii 