### PR TITLE
Don't apply edits on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## 1.23.5 (Not yet released)
 * Set meaning of UseGlobalMono "auto" to "never" since Mono 6.12.0 still ships with MSBuild 16.7 (PR: [#4130](https://github.com/OmniSharp/omnisharp-vscode/pull/4130))
+* Ensure that the rename identifier and run code action providers do not apply changes twice PR: [4133](https://github.com/OmniSharp/omnisharp-vscode/pull/4133)
 
 ## 1.23.4 (October, 19, 2020)
 * Use incremental changes to update language server (PR: [#4088](https://github.com/OmniSharp/omnisharp-vscode/pull/4088))

--- a/src/features/fixAllProvider.ts
+++ b/src/features/fixAllProvider.ts
@@ -7,12 +7,12 @@ import * as vscode from 'vscode';
 import * as serverUtils from '../omnisharp/utils';
 import * as protocol from '../omnisharp/protocol';
 import { OmniSharpServer } from '../omnisharp/server';
-import { FixAllScope, FixAllItem, FileModificationType } from '../omnisharp/protocol';
-import { Uri } from 'vscode';
+import { FixAllScope, FixAllItem } from '../omnisharp/protocol';
 import CompositeDisposable from '../CompositeDisposable';
 import AbstractProvider from './abstractProvider';
-import { toRange2 } from '../omnisharp/typeConversion';
 import { LanguageMiddlewareFeature } from '../omnisharp/LanguageMiddlewareFeature';
+import { buildEditForResponse } from '../omnisharp/fileOperationsResponseEditBuilder';
+import { CancellationToken } from 'vscode-languageserver-protocol';
 
 export class FixAllProvider extends AbstractProvider implements vscode.CodeActionProvider {
     public constructor(private server: OmniSharpServer, languageMiddlewareFeature: LanguageMiddlewareFeature) {
@@ -80,72 +80,8 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
             ApplyChanges: false
         });
 
-        if (response && Array.isArray(response.Changes)) {
-            let edit = new vscode.WorkspaceEdit();
-
-            let fileToOpen: Uri = null;
-            let renamedFiles: Uri[] = [];
-
-            for (let change of response.Changes) {
-                if (change.ModificationType == FileModificationType.Renamed)
-                {
-                    // The file was renamed. Omnisharp has already persisted
-                    // the right changes to disk. We don't need to try to
-                    // apply text changes (and will skip this file if we see an edit)
-                    renamedFiles.push(Uri.file(change.FileName));
-                }
-            }
-
-            for (let change of response.Changes) {
-                if (change.ModificationType == FileModificationType.Opened)
-                {
-                    // The CodeAction requested that we open a file.
-                    // Record that file name and keep processing CodeActions.
-                    // If a CodeAction requests that we open multiple files
-                    // we only open the last one (what would it mean to open multiple files?)
-                    fileToOpen = vscode.Uri.file(change.FileName);
-                }
-
-                if (change.ModificationType == FileModificationType.Modified)
-                {
-                    let uri = vscode.Uri.file(change.FileName);
-                    if (renamedFiles.some(r => r == uri))
-                    {
-                        // This file got renamed. Omnisharp has already
-                        // persisted the new file with any applicable changes.
-                        continue;
-                    }
-
-                    let edits: vscode.TextEdit[] = [];
-                    for (let textChange of change.Changes) {
-                        edits.push(vscode.TextEdit.replace(toRange2(textChange), textChange.NewText));
-                    }
-
-                    edit.set(uri, edits);
-                }
-            }
-
-            let applyEditPromise = vscode.workspace.applyEdit(edit);
-
-            // Unfortunately, the textEditor.Close() API has been deprecated
-            // and replaced with a command that can only close the active editor.
-            // If files were renamed that weren't the active editor, their tabs will
-            // be left open and marked as "deleted" by VS Code
-            let next = applyEditPromise;
-            if (renamedFiles.some(r => r.fsPath == vscode.window.activeTextEditor.document.uri.fsPath))
-            {
-                next = applyEditPromise.then(_ =>
-                    {
-                        return vscode.commands.executeCommand("workbench.action.closeActiveEditor");
-                    });
-            }
-
-            return fileToOpen != null
-             ? next.then(_ =>
-                    {
-                        return vscode.commands.executeCommand("vscode.open", fileToOpen);
-                    })
-             : next;
+        if (response) {
+            return buildEditForResponse(response.Changes, this._languageMiddlewareFeature, CancellationToken.None);
         }
     }
 }

--- a/src/features/renameProvider.ts
+++ b/src/features/renameProvider.ts
@@ -16,6 +16,7 @@ export default class OmnisharpRenameProvider extends AbstractSupport implements 
         let req = createRequest<protocol.RenameRequest>(document, position);
         req.WantsTextChanges = true;
         req.RenameTo = newName;
+        req.ApplyTextChanges = false;
 
         try {
             let response = await serverUtils.rename(this._server, req, token);

--- a/src/omnisharp/fileOperationsResponseEditBuilder.ts
+++ b/src/omnisharp/fileOperationsResponseEditBuilder.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Uri } from 'vscode';
+import { LanguageMiddlewareFeature } from './LanguageMiddlewareFeature';
+import { FileModificationType, FileOperationResponse, ModifiedFileResponse, RenamedFileResponse } from "./protocol";
+import { toRange2 } from './typeConversion';
+
+export async function buildEditForResponse(changes: FileOperationResponse[], languageMiddlewareFeature: LanguageMiddlewareFeature, token: vscode.CancellationToken): Promise<boolean> {
+    let edit = new vscode.WorkspaceEdit();
+
+    let fileToOpen: Uri = null;
+
+    if (!changes || !Array.isArray(changes) || !changes.length) {
+        return true;
+    }
+
+    for (const change of changes) {
+        if (change.ModificationType == FileModificationType.Opened) {
+            // The CodeAction requested that we open a file.
+            // Record that file name and keep processing CodeActions.
+            // If a CodeAction requests that we open multiple files
+            // we only open the last one (what would it mean to open multiple files?)
+            fileToOpen = vscode.Uri.file(change.FileName);
+        }
+
+        if (change.ModificationType == FileModificationType.Modified) {
+            const modifiedChange = <ModifiedFileResponse>change;
+            const uri = vscode.Uri.file(modifiedChange.FileName);
+            let edits: vscode.TextEdit[] = [];
+            for (let textChange of modifiedChange.Changes) {
+                edits.push(vscode.TextEdit.replace(toRange2(textChange), textChange.NewText));
+            }
+
+            edit.set(uri, edits);
+        }
+    }
+
+    for (const change of changes) {
+        if (change.ModificationType == FileModificationType.Renamed) {
+            const renamedChange = <RenamedFileResponse>change;
+            edit.renameFile(vscode.Uri.file(renamedChange.FileName), vscode.Uri.file(renamedChange.NewFileName));
+        }
+    }
+
+    // Allow language middlewares to re-map its edits if necessary.
+    edit = await languageMiddlewareFeature.remap("remapWorkspaceEdit", edit, token);
+
+    const applyEditPromise = vscode.workspace.applyEdit(edit);
+
+    // Unfortunately, the textEditor.Close() API has been deprecated
+    // and replaced with a command that can only close the active editor.
+    // If files were renamed that weren't the active editor, their tabs will
+    // be left open and marked as "deleted" by VS Code
+    return fileToOpen != null
+        ? applyEditPromise.then(_ => {
+            return vscode.commands.executeCommand("vscode.open", fileToOpen);
+        })
+        : applyEditPromise;
+}

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -262,7 +262,7 @@ export interface GetCodeActionsResponse {
 
 export interface RunFixAllActionResponse {
     Text: string;
-    Changes: ModifiedFileResponse[];
+    Changes: FileOperationResponse[];
 }
 
 export interface FixAllItem {
@@ -371,13 +371,24 @@ export interface DotNetFramework {
 export interface RenameRequest extends Request {
     RenameTo: string;
     WantsTextChanges?: boolean;
+    ApplyTextChanges: boolean;
 }
 
-export interface ModifiedFileResponse {
+export interface FileOperationResponse {
     FileName: string;
+    ModificationType: FileModificationType;
+}
+
+export interface ModifiedFileResponse extends FileOperationResponse {
     Buffer: string;
     Changes: TextChange[];
-    ModificationType: FileModificationType;
+}
+
+export interface RenamedFileResponse extends FileOperationResponse {
+    NewFileName: string;
+}
+
+export interface OpenFileResponse extends FileOperationResponse {
 }
 
 export enum FileModificationType {
@@ -596,10 +607,11 @@ export namespace V2 {
         Selection?: Range;
         WantsTextChanges: boolean;
         WantsAllCodeActionOperations: boolean;
+        ApplyTextChanges: boolean;
     }
 
     export interface RunCodeActionResponse {
-        Changes: ModifiedFileResponse[];
+        Changes: FileOperationResponse[];
     }
 
     export interface MSBuildProjectDiagnostics {


### PR DESCRIPTION
The code action provider and rename provider were expecting the server to apply the file changes, which then messes up incremental buffer changes. This sends for false for these parameters, and refactors the handling of code action responses to do the renames locally. As part of that, I also refactored the protocol to accurately reflect O#'s hierarchy, and share the edit building between the fixAllProvider and the runCodeAction provider. Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4128.