### PR TITLE
Update Razor to version 6.0.0-alpha.1.20529.17.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 * For Mono-based development (e.g. Unity) that requires full .NET framework, you need to set `"omnisharp.useGlobalMono": "always"`. The current value of "auto" will remain "never" until Mono [upgrades their bundled MSBuild version](https://github.com/mono/mono/issues/20250).
 * Known limitations with the preview Razor (cshtml) language service to be addressed in a future release:
   * Only ASP.NET Core projects are supported (no support for ASP.NET projects)
-  * Limited support for formatting
   * Error squiggles misaligned for expressions near the start of a new line
   * Emmet based abbreviation expansion is not yet supported (See note in readme for how to enable through your settings.json)
 * There currently is no completion support for package references in csproj files. ([#1156](https://github.com/OmniSharp/omnisharp-vscode/issues/1156))
@@ -15,7 +14,7 @@
 * Set meaning of UseGlobalMono "auto" to "never" since Mono 6.12.0 still ships with MSBuild 16.7 (PR: [#4130](https://github.com/OmniSharp/omnisharp-vscode/pull/4130))
 * Ensure that the rename identifier and run code action providers do not apply changes twice (PR: [#4133](https://github.com/OmniSharp/omnisharp-vscode/pull/4133))
 * Do not send file changed events for .cs files (PR: [#4141](https://github.com/OmniSharp/omnisharp-vscode/pull/4141), [#4143](https://github.com/OmniSharp/omnisharp-vscode/pull/4143))
-* Update Razor to 6.0.0-alpha1.20521.3:
+* Update Razor to 6.0.0-alpha.1.20529.17:
   * Improvements to HTML colorization for non-C# portions of the document.
   * Bug fix - the `razor.format.enable` option is honored again
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6183,8 +6183,8 @@
             }
         },
         "microsoft.aspnetcore.razor.vscode": {
-            "version": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/4e36e947303ca50c2545ca954ce9ca5f/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20526.2.tgz",
-            "integrity": "sha512-MQworzXrEMs5ELU0J004+xirCcI1Dbt4XjhQoRl6cAp6xJLGmBOZy0OA5E+OU/Yn8fMTumyaHYAmWSDBQXeB7A==",
+            "version": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/312cddba1ed0acdae0fd9ec3f44026b2/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20529.17.tgz",
+            "integrity": "sha512-y6+yOK3771skw9rCrA4/V3Rnu8wK06zJH1m6tixB6lUbGrSydGpcWSYCIhtDo8FxwPS7d327kWtwUNn+0eqtHw==",
             "requires": {
                 "ps-list": "^7.0.0",
                 "vscode-html-languageservice": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "defaults": {
     "omniSharp": "1.37.3",
-    "razor": "6.0.0-alpha.1.20526.2"
+    "razor": "6.0.0-alpha.1.20529.17"
   },
   "main": "./dist/extension",
   "scripts": {
@@ -79,7 +79,7 @@
     "http-proxy-agent": "2.1.0",
     "https-proxy-agent": "^3.0.1",
     "jsonc-parser": "2.0.3",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/4e36e947303ca50c2545ca954ce9ca5f/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20526.2.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/312cddba1ed0acdae0fd9ec3f44026b2/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.20529.17.tgz",
     "mkdirp": "^1.0.3",
     "node-filter-async": "1.1.1",
     "node-machine-id": "1.1.12",
@@ -342,8 +342,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/e4ce80c5603158444269e4705b854a1a/razorlanguageserver-win-x64-6.0.0-alpha.1.20526.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-6.0.0-alpha.1.20526.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/f625585b30d205e6cde18ee709b1b604/razorlanguageserver-win-x64-6.0.0-alpha.1.20529.17.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x64-6.0.0-alpha.1.20529.17.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -355,8 +355,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/cf7261f0a6d04fbbc296519d70920da6/razorlanguageserver-win-x86-6.0.0-alpha.1.20526.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-6.0.0-alpha.1.20526.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/d57034073eed8eb2e42632aea36dc248/razorlanguageserver-win-x86-6.0.0-alpha.1.20529.17.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-win-x86-6.0.0-alpha.1.20529.17.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -368,8 +368,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/66be7969db9f484d79aaf402a0f2e1bf/razorlanguageserver-linux-x64-6.0.0-alpha.1.20526.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-6.0.0-alpha.1.20526.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/9ab0011c8228eb201b9968cbaf9c6a97/razorlanguageserver-linux-x64-6.0.0-alpha.1.20529.17.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-linux-x64-6.0.0-alpha.1.20529.17.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -384,8 +384,8 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/843455c8-a9cb-4fc9-9a5b-257eaa054edc/0d9c73274c48948c450dc203def34055/razorlanguageserver-osx-x64-6.0.0-alpha.1.20526.2.zip",
-      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-6.0.0-alpha.1.20526.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/813d0878-1f3c-41ad-909f-3a79032f77bd/b8b48fb221f4ec148ad3f698f96ca7aa/razorlanguageserver-osx-x64-6.0.0-alpha.1.20529.17.zip",
+      "fallbackUrl": "https://razorvscodetest.blob.core.windows.net/languageserver/RazorLanguageServer-osx-x64-6.0.0-alpha.1.20529.17.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"


### PR DESCRIPTION
- Includes a fix for the Razor server ready check.