### PR TITLE
Only skip file changed events when open

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -54,21 +54,23 @@ function forwardFileChanges(server: OmniSharpServer): IDisposable {
                 return;
             }
 
-            const docs = workspace.textDocuments.filter(doc => doc.uri.fsPath === uri.fsPath);
-            if (Array.isArray(docs) && docs.some(doc => !doc.isClosed)) {
-                // When a file changes on disk a FileSystemEvent is generated as well as a
-                // DidChangeTextDocumentEvent.The ordering of these is:
-                //  1. This method is called back. vscode's TextDocument has not yet been reloaded, so it has
-                //     the version from before the changes are applied.
-                //  2. vscode reloads the file, and fires onDidChangeTextDocument. The document has been updated,
-                //     and the changes have the delta.
-                // If we send this change to the server, then it will reload from the disk, which means it will
-                // be synchronized to the version after the changes. Then, onDidChangeTextDocument will fire and
-                // send the delta changes, which will cause the server to apply those exact changes. The results
-                // being that the file is now in an inconsistent state.
-                // If the document is closed, however, it will no longer be synchronized, so the text change will
-                // not be triggered and we should tell the server to reread from the disk.
-                return;
+            if (changeType === FileChangeType.Change) {
+                const docs = workspace.textDocuments.filter(doc => doc.uri.fsPath === uri.fsPath);
+                if (Array.isArray(docs) && docs.some(doc => !doc.isClosed)) {
+                    // When a file changes on disk a FileSystemEvent is generated as well as a
+                    // DidChangeTextDocumentEvent.The ordering of these is:
+                    //  1. This method is called back. vscode's TextDocument has not yet been reloaded, so it has
+                    //     the version from before the changes are applied.
+                    //  2. vscode reloads the file, and fires onDidChangeTextDocument. The document has been updated,
+                    //     and the changes have the delta.
+                    // If we send this change to the server, then it will reload from the disk, which means it will
+                    // be synchronized to the version after the changes. Then, onDidChangeTextDocument will fire and
+                    // send the delta changes, which will cause the server to apply those exact changes. The results
+                    // being that the file is now in an inconsistent state.
+                    // If the document is closed, however, it will no longer be synchronized, so the text change will
+                    // not be triggered and we should tell the server to reread from the disk.
+                    return;
+                }
             }
 
             const req = { FileName: uri.fsPath, changeType };


### PR DESCRIPTION
File creation/deletion/directorydeletion events still need to be forwarded to the server, we only need to skip forwarding events if the buffer is actually changed on disk and reloaded by the editor. Fixes https://github.com/OmniSharp/omnisharp-vscode/issues/4174.
