### PR TITLE
Update remoteProcessPickerScript windows ssh exit

### DIFF
--- a/scripts/remoteProcessPickerScript
+++ b/scripts/remoteProcessPickerScript
@@ -1,1 +1,1 @@
-uname && if [ "$(uname)" = "Linux" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= ; elif [ "$(uname)" = "Darwin" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= -c; fi
+uname && if [ "$(uname)" = "Linux" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= ; exit; elif [ "$(uname)" = "Darwin" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= -c; fi


### PR DESCRIPTION
On windows vscode using the openssh client the command does not exit by default which does not allow vscode to prompt available processes to the user. This continues to work on linux despite redundant exit command.