### PR TITLE
Suppress codelens for IEnumerable.GetEnumerator

### DIFF
--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -242,7 +242,8 @@ const filteredSymbolNames: { [name: string]: boolean } = {
     'Finalize': true,
     'GetHashCode': true,
     'ToString': true,
-    'Dispose': true
+    'Dispose': true,
+    'GetEnumerator': true,
 };
 
 function isValidElementForReferencesCodeLens(element: Structure.CodeElement): boolean {


### PR DESCRIPTION
Fixes #4245 

I hope that suppressing codelens in general for `GetEnumerator` is an accepted solution.