### PR TITLE
Support auto doc comment generation

### DIFF
--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -88,7 +88,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables.add(vscode.languages.registerRenameProvider(documentSelector, new RenameProvider(server, languageMiddlewareFeature)));
         if (options.useFormatting) {
             localDisposables.add(vscode.languages.registerDocumentRangeFormattingEditProvider(documentSelector, new FormatProvider(server, languageMiddlewareFeature)));
-            localDisposables.add(vscode.languages.registerOnTypeFormattingEditProvider(documentSelector, new FormatProvider(server, languageMiddlewareFeature), '}', ';'));
+            localDisposables.add(vscode.languages.registerOnTypeFormattingEditProvider(documentSelector, new FormatProvider(server, languageMiddlewareFeature), '}', '/', '\n', ';'));
         }
         localDisposables.add(vscode.languages.registerCompletionItemProvider(documentSelector, new CompletionProvider(server, languageMiddlewareFeature), '.', ' '));
         localDisposables.add(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(server, optionProvider, languageMiddlewareFeature)));

--- a/test/integrationTests/documentationCommentAutoFormatting.integration.test.ts
+++ b/test/integrationTests/documentationCommentAutoFormatting.integration.test.ts
@@ -1,0 +1,61 @@
+import { expect, should } from 'chai';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { isRazorWorkspace } from './integrationHelpers';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+import { skip } from 'rxjs/operators';
+
+const onTypeFormatProviderCommand = 'vscode.executeFormatOnTypeProvider';
+
+function normalizeNewlines(original: string): string {
+    while (original.indexOf('\r\n') != -1) {
+        original = original.replace('\r\n', '\n');
+    }
+
+    return original;
+}
+
+suite(`Documentation Comment Auto Formatting: ${testAssetWorkspace.description}`, function () {
+    let fileUri: vscode.Uri;
+
+    suiteSetup(async function () {
+        should();
+
+        if (isRazorWorkspace(vscode.workspace)) {
+            // The format-on-type provider does not run for razor files.
+            this.skip();
+        }
+
+        const projectDirectory = testAssetWorkspace.projects[0].projectDirectoryPath;
+        const filePath = path.join(projectDirectory, 'DocComments.cs');
+        fileUri = vscode.Uri.file(filePath);
+
+        await vscode.commands.executeCommand('vscode.open', fileUri);
+    });
+
+    suiteTeardown(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test('Triple slash inserts doc comment snippet', async () => {
+        const commentPosition = new vscode.Position(2, 7);
+        const formatEdits = <vscode.TextEdit[]>(await vscode.commands.executeCommand(onTypeFormatProviderCommand, fileUri, commentPosition, '/'));
+        expect(formatEdits).ofSize(1);
+        expect(normalizeNewlines(formatEdits[0].newText)).eq(" <summary>\n    /// \n    /// </summary>\n    /// <param name=\"param1\"></param>\n    /// <param name=\"param2\"></param>\n    /// <returns></returns>");
+        expect(formatEdits[0].range.start.line).eq(commentPosition.line);
+        expect(formatEdits[0].range.start.character).eq(commentPosition.character);
+        expect(formatEdits[0].range.end.line).eq(commentPosition.line);
+        expect(formatEdits[0].range.end.character).eq(commentPosition.character);
+    });
+
+    test('Enter in comment inserts triple-slashes preceding', async () => {
+        const commentPosition = new vscode.Position(9, 0);
+        const formatEdits = <vscode.TextEdit[]>(await vscode.commands.executeCommand(onTypeFormatProviderCommand, fileUri, commentPosition, '\n'));
+        expect(formatEdits).ofSize(1);
+        expect(formatEdits[0].newText).eq("    /// ");
+        expect(formatEdits[0].range.start.line).eq(commentPosition.line);
+        expect(formatEdits[0].range.start.character).eq(commentPosition.character);
+        expect(formatEdits[0].range.end.line).eq(commentPosition.line);
+        expect(formatEdits[0].range.end.character).eq(commentPosition.character);
+    });
+});

--- a/test/integrationTests/documentationCommentAutoFormatting.integration.test.ts
+++ b/test/integrationTests/documentationCommentAutoFormatting.integration.test.ts
@@ -1,9 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
 import { expect, should } from 'chai';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { isRazorWorkspace } from './integrationHelpers';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
-import { skip } from 'rxjs/operators';
 
 const onTypeFormatProviderCommand = 'vscode.executeFormatOnTypeProvider';
 

--- a/test/integrationTests/testAssets/singleCsproj/DocComments.cs
+++ b/test/integrationTests/testAssets/singleCsproj/DocComments.cs
@@ -1,0 +1,13 @@
+class DocComments
+{
+    ///
+    string M(int param1, string param2)
+    {
+        return null;
+    }
+
+    /// <summary>
+
+    /// </summary>
+    void M2() {}
+}

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/DocComments.cs
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/DocComments.cs
@@ -1,0 +1,13 @@
+class DocComments
+{
+    ///
+    string M(int param1, string param2)
+    {
+        return null;
+    }
+
+    /// <summary>
+
+    /// </summary>
+    void M2() {}
+}


### PR DESCRIPTION
Adds '\n' and '/' to the on-type format list, enabling vscode support for the newly-added omnisharp feature of auto-generating documentation comments. Closes https://github.com/OmniSharp/omnisharp-vscode/issues/8.
