### PR TITLE
Allowing arm64 macOS to debug dotnet projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,8 @@
         "darwin"
       ],
       "architectures": [
-        "x86_64"
+        "x86_64",
+        "arm64"
       ],
       "binaries": [
         "./vsdbg-ui",

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -43,6 +43,9 @@ async function checkForInvalidArchitecture(platformInformation: PlatformInformat
         else if (platformInformation.architecture !== "x86_64") {
             if (platformInformation.isWindows() && platformInformation.architecture === "x86") {
                 eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: x86 Windows is not currently supported by the .NET Core debugger. Debugging will not be available.`));
+            } else if (platformInformation.isMacOS() && platformInformation.architecture === "arm64") {
+                eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: arm64 macOS is not officially supported by the .NET Core debugger. You may experience unexpected issues when running in this configuration.`));
+                return false;
             } else {
                 eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: Processor architecture '${platformInformation.architecture}' is not currently supported by the .NET Core debugger. Debugging will not be available.`));
             }


### PR DESCRIPTION
Issue #4277

This commit removes the bit of code that was preventing the .net debugger from starting on Apple Silicon.
I've added a warning message that indicates that you might see unexpected issues when running this way.
This should start working once macOS 11.1 is released next week. (See https://github.com/dotnet/runtime/issues/44958 for more details)