### PR TITLE
Add schema support for global.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -896,6 +896,10 @@
       {
         "fileMatch": "omnisharp.json",
         "url": "http://json.schemastore.org/omnisharp"
+      },
+      {
+        "fileMatch": "global.json",
+        "url": "http://json.schemastore.org/global"
       }
     ],
     "commands": [


### PR DESCRIPTION
This will be handy as I frequently forget the values for `rollForward`.