### PR TITLE
Update to use zero based indexes

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -32,10 +32,10 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
             const range = change.range;
             return {
                 NewText: change.text,
-                StartLine: range.start.line + 1,
-                StartColumn: range.start.character + 1,
-                EndLine: range.end.line + 1,
-                EndColumn: range.end.character + 1
+                StartLine: range.start.line,
+                StartColumn: range.start.character,
+                EndLine: range.end.line,
+                EndColumn: range.end.character
             };
         });
 

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -43,8 +43,8 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
                 // The editor does not have a selection. Use the active position of the selection (i.e. the caret).
                 let active = editor.selection.active;
 
-                line = active.line + 1;
-                column = active.character + 1;
+                line = active.line;
+                column = active.character;
             }
             else {
                 // The editor has a selection. Use it.
@@ -52,16 +52,16 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
                 let end = editor.selection.end;
 
                 selection = {
-                    Start: { Line: start.line + 1, Column: start.character + 1 },
-                    End: { Line: end.line + 1, Column: end.character + 1 }
+                    Start: { Line: start.line, Column: start.character },
+                    End: { Line: end.line, Column: end.character }
                 };
             }
         }
         else {
             // We couldn't find the editor, so just use the range we were provided.
             selection = {
-                Start: { Line: range.start.line + 1, Column: range.start.character + 1 },
-                End: { Line: range.end.line + 1, Column: range.end.character + 1 }
+                Start: { Line: range.start.line, Column: range.start.character },
+                End: { Line: range.end.line, Column: range.end.character }
             };
         }
 

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -25,7 +25,7 @@ abstract class OmniSharpCodeLens extends vscode.CodeLens {
         public fileName: string) {
 
         super(new vscode.Range(
-            range.Start.Line - 1, range.Start.Column - 1, range.End.Line - 1, range.End.Column - 1
+            range.Start.Line, range.Start.Column, range.End.Line, range.End.Column
         ));
     }
 }
@@ -115,8 +115,8 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
     private async resolveReferencesCodeLens(codeLens: ReferencesCodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens> {
         const request: protocol.FindUsagesRequest = {
             FileName: codeLens.fileName,
-            Line: codeLens.range.start.line + 1, // OmniSharp is 1-based
-            Column: codeLens.range.start.character + 1, // OmniSharp is 1-based
+            Line: codeLens.range.start.line,
+            Column: codeLens.range.start.character,
             OnlyThisFile: false,
             ExcludeDefinition: true
         };

--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -63,8 +63,8 @@ export default class OmnisharpCompletionProvider extends AbstractProvider implem
         const docs: MarkdownString | undefined = omnisharpCompletion.Documentation ? new MarkdownString(omnisharpCompletion.Documentation, false) : undefined;
 
         const mapRange = function (edit: protocol.LinePositionSpanTextChange): Range {
-            const newStart = new Position(edit.StartLine - 1, edit.StartColumn - 1);
-            const newEnd = new Position(edit.EndLine - 1, edit.EndColumn - 1);
+            const newStart = new Position(edit.StartLine, edit.StartColumn);
+            const newEnd = new Position(edit.EndLine, edit.EndColumn);
             return new Range(newStart, newEnd);
         };
 

--- a/src/features/definitionProvider.ts
+++ b/src/features/definitionProvider.ts
@@ -60,7 +60,7 @@ export default class CSharpDefinitionProvider extends AbstractSupport implements
                 }
 
                 const uri: Uri = this._definitionMetadataDocumentProvider.addMetadataResponse(metadataResponse);
-                location = new Location(uri, new Position(gotoDefinitionResponse.Line - 1, gotoDefinitionResponse.Column - 1));
+                location = new Location(uri, new Position(gotoDefinitionResponse.Line, gotoDefinitionResponse.Column));
             }
 
             // Allow language middlewares to re-map its edits if necessary.

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -273,8 +273,8 @@ export default class TestManager extends AbstractProvider {
 
         const request: protocol.V2.RunTestsInContextRequest = {
             FileName: fileName,
-            Line: active.line + 1,
-            Column: active.character + 1,
+            Line: active.line,
+            Column: active.character,
             RunSettings: runSettings,
             TargetFrameworkVersion: targetFrameworkVersion
         };
@@ -504,8 +504,8 @@ export default class TestManager extends AbstractProvider {
 
         const request: protocol.V2.DebugTestsInContextGetStartInfoRequest = {
             FileName: fileName,
-            Line: line + 1,
-            Column: column + 1,
+            Line: line,
+            Column: column,
             RunSettings: runSettings,
             TargetFrameworkVersion: targetFrameworkVersion
         };

--- a/src/features/formattingEditProvider.ts
+++ b/src/features/formattingEditProvider.ts
@@ -14,10 +14,10 @@ export default class FormattingSupport extends AbstractSupport implements Docume
 
         let request = <protocol.FormatRangeRequest>{
             FileName: document.fileName,
-            Line: range.start.line + 1,
-            Column: range.start.character + 1,
-            EndLine: range.end.line + 1,
-            EndColumn: range.end.character + 1
+            Line: range.start.line,
+            Column: range.start.character,
+            EndLine: range.end.line,
+            EndColumn: range.end.character
         };
 
         try {
@@ -35,8 +35,8 @@ export default class FormattingSupport extends AbstractSupport implements Docume
 
         let request = <protocol.FormatAfterKeystrokeRequest>{
             FileName: document.fileName,
-            Line: position.line + 1,
-            Column: position.character + 1,
+            Line: position.line,
+            Column: position.character,
             Character: ch
         };
 
@@ -53,7 +53,7 @@ export default class FormattingSupport extends AbstractSupport implements Docume
 
     private static _asEditOptionation(change: protocol.TextChange): TextEdit {
         return new TextEdit(
-            new Range(change.StartLine - 1, change.StartColumn - 1, change.EndLine - 1, change.EndColumn - 1),
+            new Range(change.StartLine, change.StartColumn, change.EndLine, change.EndColumn),
             change.NewText);
     }
 }

--- a/src/features/renameProvider.ts
+++ b/src/features/renameProvider.ts
@@ -31,7 +31,7 @@ export default class OmnisharpRenameProvider extends AbstractSupport implements 
 
                 change.Changes.forEach(change => {
                     edit.replace(uri,
-                        new Range(change.StartLine - 1, change.StartColumn - 1, change.EndLine - 1, change.EndColumn - 1),
+                        new Range(change.StartLine, change.StartColumn, change.EndLine, change.EndColumn),
                         change.NewText);
                 });
             });

--- a/src/features/structureProvider.ts
+++ b/src/features/structureProvider.ts
@@ -18,7 +18,7 @@ export class StructureProvider extends AbstractSupport implements FoldingRangePr
             let response = await blockStructure(this._server, request, token);
             let ranges: FoldingRange[] = [];
             for (let member of response.Spans) {
-                ranges.push(new FoldingRange(member.Range.Start.Line - 1, member.Range.End.Line - 1, this.GetType(member.Kind)));
+                ranges.push(new FoldingRange(member.Range.Start.Line, member.Range.End.Line, this.GetType(member.Kind)));
             }
 
             return ranges;

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -314,6 +314,7 @@ export class OmniSharpServer {
         const cwd = path.dirname(solutionPath);
 
         let args = [
+            '-z',
             '-s', solutionPath,
             '--hostPID', process.pid.toString(),
             'DotNet:enablePackageRestore=false',

--- a/src/omnisharp/typeConversion.ts
+++ b/src/omnisharp/typeConversion.ts
@@ -12,13 +12,13 @@ export function toLocation(location: protocol.ResourceLocation | protocol.QuickF
 }
 
 export function toLocationFromUri(uri: vscode.Uri, location: protocol.ResourceLocation | protocol.QuickFix): vscode.Location {
-    const position = new vscode.Position(location.Line - 1, location.Column - 1);
+    const position = new vscode.Position(location.Line, location.Column);
 
     const endLine = (<protocol.QuickFix>location).EndLine;
     const endColumn = (<protocol.QuickFix>location).EndColumn;
 
     if (endLine !== undefined && endColumn !== undefined) {
-        const endPosition = new vscode.Position(endLine - 1, endColumn - 1);
+        const endPosition = new vscode.Position(endLine, endColumn);
         return new vscode.Location(uri, new vscode.Range(position, endPosition));
     }
 
@@ -40,7 +40,7 @@ export function toRange3(range: protocol.V2.Range): vscode.Range {
 }
 
 export function toVSCodeRange(StartLine: number, StartColumn: number, EndLine: number, EndColumn: number): vscode.Range {
-    return new vscode.Range(StartLine - 1, StartColumn - 1, EndLine - 1, EndColumn - 1);
+    return new vscode.Range(StartLine, StartColumn, EndLine, EndColumn);
 }
 
 export function createRequest<T extends protocol.Request>(document: vscode.TextDocument, where: vscode.Position | vscode.Range, includeBuffer: boolean = false): T {
@@ -48,11 +48,11 @@ export function createRequest<T extends protocol.Request>(document: vscode.TextD
     let Line: number, Column: number;
 
     if (where instanceof vscode.Position) {
-        Line = where.line + 1;
-        Column = where.character + 1;
+        Line = where.line;
+        Column = where.character;
     } else if (where instanceof vscode.Range) {
-        Line = where.start.line + 1;
-        Column = where.start.character + 1;
+        Line = where.start.line;
+        Column = where.start.character;
     }
 
     // for metadata sources, we need to remove the [metadata] from the filename, and prepend the $metadata$ authority


### PR DESCRIPTION
I'm moving forward with the lsp changes, but I figured this should land before that.

OmniSharp has a flag that tells the serializer to serialize with or without zero based indexes.  Internally OmniSharp works purely on zero-based indexes because it makes interacting with Roslyn easier.  However for backward compatibility externally we surface one-based indexes, the `-z` flag tells OmniSharp to return zero-based indexes instead of one based.

