### PR TITLE
Add option to organize imports during document formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -820,6 +820,11 @@
           "default": false,
           "description": "Enables support for showing unimported types and unimported extension methods in completion lists. When committed, the appropriate using directive will be added at the top of the current file. This option can have a negative impact on initial completion responsiveness, particularly for the first few completion sessions after opening a solution."
         },
+        "omnisharp.organizeImportsOnFormat": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether 'using' directives should be grouped and sorted during document formatting."
+        },
         "razor.plugin.path": {
           "type": [
             "string",

--- a/src/observers/OptionChangeObserver.ts
+++ b/src/observers/OptionChangeObserver.ts
@@ -20,7 +20,8 @@ const omniSharpOptions: ReadonlyArray<OptionsKey> = [
     "loggingLevel",
     "enableEditorConfigSupport",
     "enableDecompilationSupport",
-    "enableImportCompletion"
+    "enableImportCompletion",
+    "organizeImportsOnFormat",
 ];
 
 function OmniSharpOptionChangeObservable(optionObservable: Observable<Options>): Observable<Options> {

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -16,6 +16,7 @@ export class Options {
         public maxProjectResults: number,
         public useEditorFormattingSettings: boolean,
         public useFormatting: boolean,
+        public organizeImportsOnFormat: boolean,
         public showReferencesCodeLens: boolean,
         public showTestsCodeLens: boolean,
         public disableCodeActions: boolean,
@@ -74,6 +75,7 @@ export class Options {
         const enableImportCompletion = omnisharpConfig.get<boolean>('enableImportCompletion', false);
 
         const useFormatting = csharpConfig.get<boolean>('format.enable', true);
+        const organizeImportsOnFormat = omnisharpConfig.get<boolean>('organizeImportsOnFormat', false);
 
         const showReferencesCodeLens = csharpConfig.get<boolean>('referencesCodeLens.enabled', true);
         const showTestsCodeLens = csharpConfig.get<boolean>('testsCodeLens.enabled', true);
@@ -107,6 +109,7 @@ export class Options {
             maxProjectResults,
             useEditorFormattingSettings,
             useFormatting,
+            organizeImportsOnFormat,
             showReferencesCodeLens,
             showTestsCodeLens,
             disableCodeActions,

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -354,6 +354,10 @@ export class OmniSharpServer {
             args.push('FormattingOptions:EnableEditorConfigSupport=true');
         }
 
+        if (options.organizeImportsOnFormat === true) {
+            args.push('FormattingOptions:OrganizeImports=true');
+        }
+
         if (this.decompilationAuthorized && options.enableDecompilationSupport === true) {
             args.push('RoslynExtensionsOptions:EnableDecompilationSupport=true');
         }

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, 0, 0, false, false, false, false, false, false, false, undefined, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, false, 0, 0, false, false, false, false, false, false, false, undefined, "", "");
 }


### PR DESCRIPTION
This flag was added to OmniSharp a while back but we never introduced a VS Code setting.