### PR TITLE
improve queues, (one effect: improve code completion)

### DIFF
--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -5,7 +5,7 @@
 
 import { BaseLoggerObserver } from "./BaseLoggerObserver";
 import * as os from 'os';
-import { BaseEvent, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerRequestCanceled, OmnisharpServerVerboseMessage, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived } from "../omnisharp/loggingEvents";
+import { BaseEvent, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerRequestCancelled, OmnisharpServerVerboseMessage, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived } from "../omnisharp/loggingEvents";
 import { EventType } from "../omnisharp/EventType";
 
 export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
@@ -20,8 +20,8 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
             case EventType.OmnisharpServerDequeueRequest:
                 this.handleOmnisharpServerDequeueRequest(<OmnisharpServerDequeueRequest>event);
                 break;
-            case EventType.OmnisharpServerRequestCanceled:
-                this.handleOmnisharpServerRequestCanceled(<OmnisharpServerRequestCanceled>event);
+            case EventType.OmnisharpServerRequestCancelled:
+                this.handleOmnisharpServerRequestCancelled(<OmnisharpServerRequestCancelled>event);
                 break;
                 case EventType.OmnisharpServerProcessRequestStart:
                 this.handleOmnisharpProcessRequestStart(<OmnisharpServerProcessRequestStart>event);
@@ -47,17 +47,17 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpServerEnqueueRequest(event: OmnisharpServerEnqueueRequest) {
-        this.logger.appendLine(`Enqueue ${event.name} request for ${event.command}.`);
+        this.logger.appendLine(`Enqueue to ${event.queueName} request for ${event.command}.`);
         this.logger.appendLine();
     }
 
     private handleOmnisharpServerDequeueRequest(event: OmnisharpServerDequeueRequest) {
-        this.logger.appendLine(`Dequeue ${event.name} request for ${event.command} (${event.id}).`);
+        this.logger.appendLine(`Dequeue from ${event.queueName} with status ${event.queueStatus} request for ${event.command}${event.id? ` (${event.id})`: ''}.`);
         this.logger.appendLine();
     }
 
-    private handleOmnisharpServerRequestCanceled(event: OmnisharpServerRequestCanceled) {
-        this.logger.appendLine(`Canceled request for ${event.command} (${event.id}).`);
+    private handleOmnisharpServerRequestCancelled(event: OmnisharpServerRequestCancelled) {
+        this.logger.appendLine(`Cancelled request for ${event.command} (${event.id}).`);
         this.logger.appendLine();
     }
 

--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -5,7 +5,7 @@
 
 import { BaseLoggerObserver } from "./BaseLoggerObserver";
 import * as os from 'os';
-import { BaseEvent, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerVerboseMessage, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived } from "../omnisharp/loggingEvents";
+import { BaseEvent, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerRequestCanceled, OmnisharpServerVerboseMessage, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived } from "../omnisharp/loggingEvents";
 import { EventType } from "../omnisharp/EventType";
 
 export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
@@ -20,7 +20,10 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
             case EventType.OmnisharpServerDequeueRequest:
                 this.handleOmnisharpServerDequeueRequest(<OmnisharpServerDequeueRequest>event);
                 break;
-            case EventType.OmnisharpServerProcessRequestStart:
+            case EventType.OmnisharpServerRequestCanceled:
+                this.handleOmnisharpServerRequestCanceled(<OmnisharpServerRequestCanceled>event);
+                break;
+                case EventType.OmnisharpServerProcessRequestStart:
                 this.handleOmnisharpProcessRequestStart(<OmnisharpServerProcessRequestStart>event);
                 break;
             case EventType.OmnisharpServerProcessRequestComplete:
@@ -50,6 +53,11 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
 
     private handleOmnisharpServerDequeueRequest(event: OmnisharpServerDequeueRequest) {
         this.logger.appendLine(`Dequeue ${event.name} request for ${event.command} (${event.id}).`);
+        this.logger.appendLine();
+    }
+
+    private handleOmnisharpServerRequestCanceled(event: OmnisharpServerRequestCanceled) {
+        this.logger.appendLine(`Canceled request for ${event.command} (${event.id}).`);
         this.logger.appendLine();
     }
 

--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -62,7 +62,7 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpProcessRequestStart(event: OmnisharpServerProcessRequestStart) {
-        this.logger.appendLine(`Processing ${event.name} queue, empty slots ${event.slots}`);
+        this.logger.appendLine(`Processing ${event.name} queue, available slots ${event.availableRequestSlots}`);
         this.logger.increaseIndent();
     }
 

--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -62,7 +62,7 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpProcessRequestStart(event: OmnisharpServerProcessRequestStart) {
-        this.logger.appendLine(`Processing ${event.name} queue`);
+        this.logger.appendLine(`Processing ${event.name} queue, empty slots ${event.slots}`);
         this.logger.increaseIndent();
     }
 

--- a/src/observers/OmnisharpDebugModeLoggerObserver.ts
+++ b/src/observers/OmnisharpDebugModeLoggerObserver.ts
@@ -23,7 +23,7 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
             case EventType.OmnisharpServerRequestCancelled:
                 this.handleOmnisharpServerRequestCancelled(<OmnisharpServerRequestCancelled>event);
                 break;
-                case EventType.OmnisharpServerProcessRequestStart:
+            case EventType.OmnisharpServerProcessRequestStart:
                 this.handleOmnisharpProcessRequestStart(<OmnisharpServerProcessRequestStart>event);
                 break;
             case EventType.OmnisharpServerProcessRequestComplete:
@@ -52,7 +52,7 @@ export class OmnisharpDebugModeLoggerObserver extends BaseLoggerObserver {
     }
 
     private handleOmnisharpServerDequeueRequest(event: OmnisharpServerDequeueRequest) {
-        this.logger.appendLine(`Dequeue from ${event.queueName} with status ${event.queueStatus} request for ${event.command}${event.id? ` (${event.id})`: ''}.`);
+        this.logger.appendLine(`Dequeue from ${event.queueName} with status ${event.queueStatus} request for ${event.command}${event.id ? ` (${event.id})` : ''}.`);
         this.logger.appendLine();
     }
 

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -83,7 +83,7 @@ export enum EventType {
     DotNetTestRunInContextStart = 76,
     DotNetTestDebugInContextStart = 77,
     TelemetryErrorEvent = 78,
-    OmnisharpServerRequestCanceled = 79
+    OmnisharpServerRequestCancelled = 79
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -83,7 +83,7 @@ export enum EventType {
     DotNetTestRunInContextStart = 76,
     DotNetTestDebugInContextStart = 77,
     TelemetryErrorEvent = 78,
-    OmnisharpServerRequestCancelled = 79
+    OmnisharpServerRequestCancelled = 79,
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -82,7 +82,8 @@ export enum EventType {
     ProjectDiagnosticStatus = 75,
     DotNetTestRunInContextStart = 76,
     DotNetTestDebugInContextStart = 77,
-    TelemetryErrorEvent = 78
+    TelemetryErrorEvent = 78,
+    OmnisharpServerRequestCanceled = 79
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -115,16 +115,16 @@ export class OmnisharpServerUnresolvedDependencies implements BaseEvent {
 
 export class OmnisharpServerEnqueueRequest implements BaseEvent {
     type = EventType.OmnisharpServerEnqueueRequest;
-    constructor(public name: string, public command: string) { }
+    constructor(public queueName: string, public command: string) { }
 }
 
 export class OmnisharpServerDequeueRequest implements BaseEvent {
     type = EventType.OmnisharpServerDequeueRequest;
-    constructor(public name: string, public command: string, public id: number) { }
+    constructor(public queueName: string, public queueStatus: string, public command: string, public id?: number) { }
 }
 
-export class OmnisharpServerRequestCanceled implements BaseEvent {
-    type = EventType.OmnisharpServerRequestCanceled;
+export class OmnisharpServerRequestCancelled implements BaseEvent {
+    type = EventType.OmnisharpServerRequestCancelled;
     constructor(public command: string, public id: number) { }
 }
 

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -123,6 +123,11 @@ export class OmnisharpServerDequeueRequest implements BaseEvent {
     constructor(public name: string, public command: string, public id: number) { }
 }
 
+export class OmnisharpServerRequestCanceled implements BaseEvent {
+    type = EventType.OmnisharpServerRequestCanceled;
+    constructor(public command: string, public id: number) { }
+}
+
 export class OmnisharpServerProcessRequestStart implements BaseEvent {
     type = EventType.OmnisharpServerProcessRequestStart;
     constructor(public name: string) { }

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -130,7 +130,7 @@ export class OmnisharpServerRequestCancelled implements BaseEvent {
 
 export class OmnisharpServerProcessRequestStart implements BaseEvent {
     type = EventType.OmnisharpServerProcessRequestStart;
-    constructor(public name: string, public slots: number) { }
+    constructor(public name: string, public availableRequestSlots: number) { }
 }
 
 export class OmnisharpEventPacketReceived implements BaseEvent {

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -130,7 +130,7 @@ export class OmnisharpServerRequestCanceled implements BaseEvent {
 
 export class OmnisharpServerProcessRequestStart implements BaseEvent {
     type = EventType.OmnisharpServerProcessRequestStart;
-    constructor(public name: string) { }
+    constructor(public name: string, public slots: number) { }
 }
 
 export class OmnisharpEventPacketReceived implements BaseEvent {

--- a/src/omnisharp/prioritization.ts
+++ b/src/omnisharp/prioritization.ts
@@ -15,7 +15,6 @@ const priorityCommands = [
 const normalCommands = [
     protocol.Requests.Completion,
     protocol.Requests.CompletionResolve,
-    protocol.Requests.AutoComplete,
     protocol.Requests.FilesChanged,
     protocol.Requests.FindSymbols,
     protocol.Requests.FindUsages,

--- a/src/omnisharp/prioritization.ts
+++ b/src/omnisharp/prioritization.ts
@@ -13,6 +13,8 @@ const priorityCommands = [
 ];
 
 const normalCommands = [
+    protocol.Requests.Completion,
+    protocol.Requests.CompletionResolve,
     protocol.Requests.AutoComplete,
     protocol.Requests.FilesChanged,
     protocol.Requests.FindSymbols,

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -8,7 +8,6 @@ import { CompletionTriggerKind, CompletionItemKind, CompletionItemTag, InsertTex
 
 export module Requests {
     export const AddToProject = '/addtoproject';
-    export const AutoComplete = '/autocomplete';
     export const CodeCheck = '/codecheck';
     export const CodeFormat = '/codeformat';
     export const ChangeBuffer = '/changebuffer';

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -14,6 +14,7 @@ export interface Request {
     onError(err: any): void;
     startTime?: number;
     endTime?: number;
+    id?: number;
 }
 
 /**
@@ -62,7 +63,11 @@ class RequestQueue {
             request.onError(new Error(`Pending request cancelled: ${request.command}`));
         }
 
-        // TODO: Handle cancellation of a request already waiting on the OmniSharp server.
+        console.log(`canceling waiting request ${request.command} ${request.id}`);
+        if (request.id){
+            console.log(`dequeueing request ${request.command} with id ${request.id}`);
+            this.dequeue(request.id);
+        }
     }
 
     /**
@@ -84,18 +89,21 @@ class RequestQueue {
      */
     public processPending() {
         if (this._pending.length === 0) {
+            console.log("non pending: break");
             return;
         }
 
         this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name));
 
         const slots = this._maxSize - this._waiting.size;
+        console.log(`slots available: ${slots}`);
 
         for (let i = 0; i < slots && this._pending.length > 0; i++) {
             const item = this._pending.shift();
             item.startTime = Date.now();
 
             const id = this._makeRequest(item);
+            console.log(`requested: ${item.command}, id: ${id}`);
             this._waiting.set(id, item);
 
             if (this.isFull()) {
@@ -159,30 +167,36 @@ export class RequestQueueCollection {
 
     public drain() {
         if (this._isProcessing) {
+            console.log("is processing: break");
             return false;
         }
 
         if (this._priorityQueue.isFull()) {
+            console.log("priority queue is full: break");
             return false;
         }
 
         if (this._normalQueue.isFull() && this._deferredQueue.isFull()) {
+            console.log("other queues are full: break");
             return false;
         }
 
         this._isProcessing = true;
 
         if (this._priorityQueue.hasPending()) {
+            console.log("processing priority queue");
             this._priorityQueue.processPending();
             this._isProcessing = false;
             return;
         }
 
         if (this._normalQueue.hasPending()) {
+            console.log("processing normal queue");
             this._normalQueue.processPending();
         }
 
         if (this._deferredQueue.hasPending()) {
+            console.log("processing deferred queue");
             this._deferredQueue.processPending();
         }
 

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -63,9 +63,7 @@ class RequestQueue {
             request.onError(new Error(`Pending request cancelled: ${request.command}`));
         }
 
-        console.log(`canceling waiting request ${request.command} ${request.id}`);
         if (request.id){
-            console.log(`dequeueing request ${request.command} with id ${request.id}`);
             this.dequeue(request.id);
         }
     }
@@ -89,21 +87,18 @@ class RequestQueue {
      */
     public processPending() {
         if (this._pending.length === 0) {
-            console.log("non pending: break");
             return;
         }
 
         this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name));
 
         const slots = this._maxSize - this._waiting.size;
-        console.log(`slots available: ${slots}`);
 
         for (let i = 0; i < slots && this._pending.length > 0; i++) {
             const item = this._pending.shift();
             item.startTime = Date.now();
 
             const id = this._makeRequest(item);
-            console.log(`requested: ${item.command}, id: ${id}`);
             this._waiting.set(id, item);
 
             if (this.isFull()) {
@@ -167,36 +162,30 @@ export class RequestQueueCollection {
 
     public drain() {
         if (this._isProcessing) {
-            console.log("is processing: break");
             return false;
         }
 
         if (this._priorityQueue.isFull()) {
-            console.log("priority queue is full: break");
             return false;
         }
 
         if (this._normalQueue.isFull() && this._deferredQueue.isFull()) {
-            console.log("other queues are full: break");
             return false;
         }
 
         this._isProcessing = true;
 
         if (this._priorityQueue.hasPending()) {
-            console.log("processing priority queue");
             this._priorityQueue.processPending();
             this._isProcessing = false;
             return;
         }
 
         if (this._normalQueue.hasPending()) {
-            console.log("processing normal queue");
             this._normalQueue.processPending();
         }
 
         if (this._deferredQueue.hasPending()) {
-            console.log("processing deferred queue");
             this._deferredQueue.processPending();
         }
 

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -88,10 +88,10 @@ class RequestQueue {
             return;
         }
 
-        const slots = this._maxSize - this._waiting.size;
-        this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name, slots));
+        const availableRequestSlots = this._maxSize - this._waiting.size;
+        this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name, availableRequestSlots));
 
-        for (let i = 0; i < slots && this._pending.length > 0; i++) {
+        for (let i = 0; i < availableRequestSlots && this._pending.length > 0; i++) {
             const item = this._pending.shift();
             item.startTime = Date.now();
 

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -89,7 +89,6 @@ class RequestQueue {
         }
 
         const slots = this._maxSize - this._waiting.size;
-        
         this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name, slots));
 
         for (let i = 0; i < slots && this._pending.length > 0; i++) {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -572,6 +572,7 @@ export class OmniSharpServer {
 
         if (token) {
             token.onCancellationRequested(() => {
+                this.eventStream.post(new ObservableEvents.OmnisharpServerRequestCanceled(request.command, request.id));
                 this._requestQueue.cancelRequest(request);
             });
         }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -709,7 +709,7 @@ export class OmniSharpServer {
     private _makeRequest(request: Request) {
         const id = OmniSharpServer._nextId++;
         request.id = id;
-        
+
         const requestPacket: protocol.WireProtocol.RequestPacket = {
             Type: 'request',
             Seq: id,

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -572,8 +572,10 @@ export class OmniSharpServer {
 
         if (token) {
             token.onCancellationRequested(() => {
-                this.eventStream.post(new ObservableEvents.OmnisharpServerRequestCanceled(request.command, request.id));
+                this.eventStream.post(new ObservableEvents.OmnisharpServerRequestCancelled(request.command, request.id));
                 this._requestQueue.cancelRequest(request);
+                // Note: This calls reject() on the promise returned by OmniSharpServer.makeRequest
+                request.onError(new Error(`Request ${request.command} cancelled, id: ${request.id}`));
             });
         }
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -705,7 +705,8 @@ export class OmniSharpServer {
 
     private _makeRequest(request: Request) {
         const id = OmniSharpServer._nextId++;
-
+        request.id = id;
+        
         const requestPacket: protocol.WireProtocol.RequestPacket = {
             Type: 'request',
             Seq: id,

--- a/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { use, should, expect } from 'chai';
 import { getNullChannel } from '../testAssets/Fakes';
-import { OmnisharpServerVerboseMessage, EventWithMessage, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived, OmnisharpServerProcessRequestComplete } from '../../../src/omnisharp/loggingEvents';
+import { OmnisharpServerVerboseMessage, EventWithMessage, OmnisharpRequestMessage, OmnisharpServerEnqueueRequest, OmnisharpServerDequeueRequest, OmnisharpServerProcessRequestStart, OmnisharpEventPacketReceived, OmnisharpServerProcessRequestComplete, OmnisharpServerRequestCancelled } from '../../../src/omnisharp/loggingEvents';
 import { OmnisharpDebugModeLoggerObserver } from '../../../src/observers/OmnisharpDebugModeLoggerObserver';
 
 use(require("chai-string"));
@@ -33,23 +33,31 @@ suite("OmnisharpDebugModeLoggerObserver", () => {
     test(`OmnisharpServerEnqueueRequest: Name and Command is logged`, () => {
         let event = new OmnisharpServerEnqueueRequest("foo", "someCommand");
         observer.post(event);
-        expect(logOutput).to.contain(event.name);
+        expect(logOutput).to.contain(event.queueName);
         expect(logOutput).to.contain(event.command);
     });
 
-    test(`OmnisharpServerDequeueRequest: Name and Command is logged`, () => {
-        let event = new OmnisharpServerDequeueRequest("foo", "someCommand", 1);
+    test(`OmnisharpServerDequeueRequest: QueueName, QueueStatus, Command and Id is logged`, () => {
+        let event = new OmnisharpServerDequeueRequest("foo", "pending", "someCommand", 1);
         observer.post(event);
-        expect(logOutput).to.contain(event.name);
+        expect(logOutput).to.contain(event.queueName);
+        expect(logOutput).to.contain(event.queueStatus);
         expect(logOutput).to.contain(event.command);
         expect(logOutput).to.contain(event.id);
     });
 
-    test(`OmnisharpProcessRequestStart: Name is logged`, () => {
+    test(`OmnisharpProcessRequestStart: Name and slots is logged`, () => {
         let event = new OmnisharpServerProcessRequestStart("foobar", 2);
         observer.post(event);
         expect(logOutput).to.contain(event.name);
         expect(logOutput).to.contain(event.slots);
+    });
+
+    test(`OmnisharpServerRequestCancelled: Name and Id is logged`, () => {
+        let event = new OmnisharpServerRequestCancelled("foobar", 23);
+        observer.post(event);
+        expect(logOutput).to.contain(event.command);
+        expect(logOutput).to.contain(event.id);
     });
 
     test(`OmnisharpServer messages increase and decrease indent`, () => {

--- a/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
@@ -46,14 +46,15 @@ suite("OmnisharpDebugModeLoggerObserver", () => {
     });
 
     test(`OmnisharpProcessRequestStart: Name is logged`, () => {
-        let event = new OmnisharpServerProcessRequestStart("foobar");
+        let event = new OmnisharpServerProcessRequestStart("foobar", 2);
         observer.post(event);
         expect(logOutput).to.contain(event.name);
+        expect(logOutput).to.contain(event.slots);
     });
 
     test(`OmnisharpServer messages increase and decrease indent`, () => {
         observer.post(new OmnisharpServerVerboseMessage("!indented_1"));
-        observer.post(new OmnisharpServerProcessRequestStart("name"));
+        observer.post(new OmnisharpServerProcessRequestStart("name", 2));
         observer.post(new OmnisharpServerVerboseMessage("indented"));
         observer.post(new OmnisharpServerProcessRequestComplete());
         observer.post(new OmnisharpServerVerboseMessage("!indented_2"));

--- a/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpDebugModeLoggerObserver.test.ts
@@ -50,7 +50,7 @@ suite("OmnisharpDebugModeLoggerObserver", () => {
         let event = new OmnisharpServerProcessRequestStart("foobar", 2);
         observer.post(event);
         expect(logOutput).to.contain(event.name);
-        expect(logOutput).to.contain(event.slots);
+        expect(logOutput).to.contain(event.availableRequestSlots);
     });
 
     test(`OmnisharpServerRequestCancelled: Name and Id is logged`, () => {


### PR DESCRIPTION
After updating to the recent 1.23.x versions I had severe performance issues on code completion. 

I investigated that and made the following changes: 
* Completion, CompletionResolve, and AutoComplete should be equally prioritized (add to normal queue)
* remove request from _waiting queue when cancelRequest is called and call onError on the request to reject() any awaited promises.
* add logging (debugMode=true in main.ts) for canceled requests and add logging details to RequestQueue internals.

The second bullet point addresses a deferred queue that stays always full when requests are cancelled. A symptom for that are many log entries of the kind: 
``` 
Problem invoking 'GetCodeActions' on OmniSharp server: Error: Pending request cancelled: /v2/getcodeactions
```