### PR TITLE
Add setting to control whether to show the OmniSharp log on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -702,6 +702,11 @@
           "description": "Enable/disable Semantic Highlighting for C# files (Razor files currently unsupported). Defaults to false. Close open files for changes to take effect.",
           "scope": "window"
         },
+        "csharp.showOmnisharpLogOnError": {
+          "type": "boolean",
+          "default": true,
+          "description": "Shows the OmniSharp log in the Output pane when OmniSharp reports an error."
+        },
         "omnisharp.path": {
           "type": [
             "string",

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CSharp
 
     let omnisharpChannel = vscode.window.createOutputChannel('OmniSharp Log');
     let omnisharpLogObserver = new OmnisharpLoggerObserver(omnisharpChannel);
-    let omnisharpChannelObserver = new OmnisharpChannelObserver(omnisharpChannel);
+    let omnisharpChannelObserver = new OmnisharpChannelObserver(omnisharpChannel, vscode);
     eventStream.subscribe(omnisharpLogObserver.post);
     eventStream.subscribe(omnisharpChannelObserver.post);
 

--- a/src/observers/OmnisharpChannelObserver.ts
+++ b/src/observers/OmnisharpChannelObserver.ts
@@ -4,21 +4,34 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BaseChannelObserver } from "./BaseChannelObserver";
-import { BaseEvent } from '../omnisharp/loggingEvents';
+import { vscode, OutputChannel } from '../vscodeAdapter';
+import { BaseEvent, OmnisharpServerOnStdErr } from '../omnisharp/loggingEvents';
 import { EventType } from "../omnisharp/EventType";
 
 export class OmnisharpChannelObserver extends BaseChannelObserver {
+    constructor(channel: OutputChannel, private vscode: vscode) {
+        super(channel);
+    }
 
     public post = (event: BaseEvent) => {
         switch (event.type) {
             case EventType.ShowOmniSharpChannel:
             case EventType.OmnisharpFailure:
-            case EventType.OmnisharpServerOnStdErr:
                 this.showChannel(true);
+                break;
+            case EventType.OmnisharpServerOnStdErr:
+                this.handleOmnisharpServerOnStdErr(<OmnisharpServerOnStdErr>event);
                 break;
             case EventType.OmnisharpRestart:
                 this.clearChannel();
                 break;
+        }
+    }
+
+    private async handleOmnisharpServerOnStdErr(event: OmnisharpServerOnStdErr) {
+        let csharpConfig = this.vscode.workspace.getConfiguration('csharp');
+        if (csharpConfig.get<boolean>('showOmnisharpLogOnError')) {
+            this.showChannel(true);
         }
     }
 }

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -21,6 +21,7 @@ export class Options {
         public showTestsCodeLens: boolean,
         public disableCodeActions: boolean,
         public disableMSBuildDiagnosticWarning: boolean,
+        public showOmnisharpLogOnError: boolean,
         public minFindSymbolsFilterLength: number,
         public maxFindSymbolsItems: number,
         public razorDisabled: boolean,
@@ -86,6 +87,8 @@ export class Options {
 
         const disableMSBuildDiagnosticWarning = omnisharpConfig.get<boolean>('disableMSBuildDiagnosticWarning', false);
 
+        const showOmnisharpLogOnError = csharpConfig.get<boolean>('showOmnisharpLogOnError', true);
+
         const minFindSymbolsFilterLength = omnisharpConfig.get<number>('minFindSymbolsFilterLength', 0);
         const maxFindSymbolsItems = omnisharpConfig.get<number>('maxFindSymbolsItems', 1000);   // The limit is applied only when this setting is set to a number greater than zero
 
@@ -114,6 +117,7 @@ export class Options {
             showTestsCodeLens,
             disableCodeActions,
             disableMSBuildDiagnosticWarning,
+            showOmnisharpLogOnError,
             minFindSymbolsFilterLength,
             maxFindSymbolsItems,
             razorDisabled,

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, false, 0, 0, false, false, false, false, false, false, false, undefined, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, false, false, false, 0, 0, false, false, false, false, false, false, false, undefined, "", "");
 }

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -26,7 +26,7 @@ suite("Options tests", () => {
         options.showReferencesCodeLens.should.equal(true);
         options.showTestsCodeLens.should.equal(true);
         options.disableCodeActions.should.equal(false);
-        options.disableCodeActions.should.equal(false);
+        options.showOmnisharpLogOnError.should.equal(true);
         options.minFindSymbolsFilterLength.should.equal(0);
         options.maxFindSymbolsItems.should.equal(1000);
         options.enableMsBuildLoadProjectsOnDemand.should.equal(false);


### PR DESCRIPTION
Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/4102 & https://github.com/OmniSharp/omnisharp-vscode/issues/4330

By default, the C# extension will continue to show the OmniSharp log when errors are encountered. This PR provides a setting so users can disable this behavior.