### PR TITLE
Move CodeActions to LSP to resolve cancellations

### DIFF
--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -100,7 +100,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
 
     private async _runCodeAction(req: protocol.V2.RunCodeActionRequest, token: vscode.CancellationToken): Promise<boolean | string | {}> {
 
-        return serverUtils.runCodeAction(this._server, req).then(response => {
+        return serverUtils.runCodeAction(this._server, req).then(async response => {
             if (response) {
                 return buildEditForResponse(response.Changes, this._languageMiddlewareFeature, token);
             }

--- a/src/omnisharp/engines/LspEngine.ts
+++ b/src/omnisharp/engines/LspEngine.ts
@@ -30,14 +30,12 @@ import {
     DocumentHighlightRequest,
     DocumentSymbolRequest,
     WorkspaceSymbolRequest,
-    CodeActionRequest,
     CodeLensRequest,
     DocumentFormattingRequest,
     DocumentRangeFormattingRequest,
     DocumentOnTypeFormattingRequest,
     RenameRequest,
     DocumentLinkRequest,
-    ExecuteCommandRequest,
 } from 'vscode-languageclient';
 import {
     ExtensionContext,
@@ -211,14 +209,12 @@ export class LspEngine implements IEngine {
         disableFeature(DocumentHighlightRequest);
         disableFeature(DocumentSymbolRequest);
         disableFeature(WorkspaceSymbolRequest);
-        disableFeature(CodeActionRequest);
         disableFeature(CodeLensRequest);
         disableFeature(DocumentFormattingRequest);
         disableFeature(DocumentRangeFormattingRequest);
         disableFeature(DocumentOnTypeFormattingRequest);
         disableFeature(RenameRequest);
         disableFeature(DocumentLinkRequest);
-        disableFeature(ExecuteCommandRequest);
         disableFeature(TypeDefinitionFeature);
         disableFeature(SelectionRangeFeature);
         disableFeature(ImplementationFeature);

--- a/src/omnisharp/engines/LspEngine.ts
+++ b/src/omnisharp/engines/LspEngine.ts
@@ -254,7 +254,9 @@ export class LspEngine implements IEngine {
         data?: any,
         token?: CancellationToken
     ): Promise<TResponse> {
-        if (data?.Buffer) delete data.Buffer;
+        if (data?.Buffer) {
+            delete data.Buffer;
+        }
         let tries = 0;
         while (tries < 5) {
             try {

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -93,11 +93,6 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables.add(vscode.languages.registerCompletionItemProvider(documentSelector, new CompletionProvider(server, languageMiddlewareFeature), '.', ' '));
         localDisposables.add(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(server, optionProvider, languageMiddlewareFeature)));
         localDisposables.add(vscode.languages.registerSignatureHelpProvider(documentSelector, new SignatureHelpProvider(server, languageMiddlewareFeature), '(', ','));
-        // Since the CodeActionProvider registers its own commands, we must instantiate it and add it to the localDisposables
-        // so that it will be cleaned up if OmniSharp is restarted.
-        const codeActionProvider = new CodeActionProvider(server, optionProvider, languageMiddlewareFeature);
-        localDisposables.add(codeActionProvider);
-        localDisposables.add(vscode.languages.registerCodeActionsProvider(documentSelector, codeActionProvider));
         // Since the FixAllProviders registers its own commands, we must instantiate it and add it to the localDisposables
         // so that it will be cleaned up if OmniSharp is restarted.
         const fixAllProvider = new FixAllProvider(server, languageMiddlewareFeature);
@@ -106,6 +101,11 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables.add(reportDiagnostics(server, advisor, languageMiddlewareFeature, optionProvider));
         if (!options.enableLspDriver) {
             localDisposables.add(forwardChanges(server));
+            // Since the CodeActionProvider registers its own commands, we must instantiate it and add it to the localDisposables
+            // so that it will be cleaned up if OmniSharp is restarted.
+            const codeActionProvider = new CodeActionProvider(server, optionProvider, languageMiddlewareFeature);
+            localDisposables.add(codeActionProvider);
+            localDisposables.add(vscode.languages.registerCodeActionsProvider(documentSelector, codeActionProvider));
         }
         localDisposables.add(trackVirtualDocuments(server, eventStream));
         localDisposables.add(vscode.languages.registerFoldingRangeProvider(documentSelector, new StructureProvider(server, languageMiddlewareFeature)));

--- a/tasks/testTasks.ts
+++ b/tasks/testTasks.ts
@@ -44,8 +44,8 @@ const projectNames = [
 ];
 
 for (const projectName of projectNames) {
-    gulp.task(`test:integration:${projectName}:stdio`, () => runIntegrationTest(projectName, 'stdio'));
-    gulp.task(`test:integration:${projectName}:lsp`, () => runIntegrationTest(projectName, 'lsp'));
+    gulp.task(`test:integration:${projectName}:stdio`, async () => runIntegrationTest(projectName, 'stdio'));
+    gulp.task(`test:integration:${projectName}:lsp`, async () => runIntegrationTest(projectName, 'lsp'));
     gulp.task(`test:integration:${projectName}`, gulp.series(`test:integration:${projectName}:stdio`, `test:integration:${projectName}:lsp`));
 }
 

--- a/test/integrationTests/diagnostics.integration.test.ts
+++ b/test/integrationTests/diagnostics.integration.test.ts
@@ -188,6 +188,10 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
         });
 
         test("When workspace is count as 'large', then only show/fetch diagnostics from open documents", async function () {
+            if (process.env.OMNISHARP_DRIVER === 'lsp') {
+                // lsp does pull-based diagnostics. If you ask for a file specifically, you'll get it.
+                this.skip()
+            }
 
             // This is to trigger manual cleanup for diagnostics before test because we modify max project file count on fly.
             await vscode.commands.executeCommand("vscode.open", secondaryFileUri);

--- a/test/integrationTests/diagnostics.integration.test.ts
+++ b/test/integrationTests/diagnostics.integration.test.ts
@@ -119,8 +119,9 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
 
             let cs0219 = result.find(x => x.code === "CS0219");
             expect(cs0219).to.not.be.undefined;
-            if (cs0219.tags) // not currently making it through lsp 100% of the time
-            expect(cs0219.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            if (cs0219.tags) { // not currently making it through lsp 100% of the time
+                expect(cs0219.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            }
         });
 
         test("Return unnecessary tag in case of unnesessary using", async function () {
@@ -136,8 +137,9 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
 
             let cs8019 = result.find(x => x.code === "CS8019");
             expect(cs8019).to.not.be.undefined;
-            if (cs8019.tags) // not currently making it through lsp 100% of the time
-            expect(cs8019.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            if (cs8019.tags) { // not currently making it through lsp 100% of the time
+                expect(cs8019.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            }
         });
 
         test("Return fadeout diagnostics like unused variables based on roslyn analyzers", async function () {
@@ -153,8 +155,9 @@ suite(`DiagnosticProvider: ${testAssetWorkspace.description}`, function () {
 
             let ide0059 = result.find(x => x.code === "IDE0059");
             expect(ide0059).to.not.be.undefined;
-            if (ide0059.tags) // not currently making it through lsp 100% of the time
-            expect(ide0059.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            if (ide0059.tags) { // not currently making it through lsp 100% of the time
+                expect(ide0059.tags).to.include(vscode.DiagnosticTag.Unnecessary);
+            }
         });
 
         test("On small workspaces also show/fetch closed document analysis results", async function () {


### PR DESCRIPTION
The tests were failing because the legacy O# routing is timing out when executing code actions. By moving code actions to LSP, it resolves the issue. Also depends on the changes https://github.com/OmniSharp/omnisharp-roslyn/pull/2072 for a fully green run.