### PR TITLE
Re-enable razor tests

### DIFF
--- a/tasks/testTasks.ts
+++ b/tasks/testTasks.ts
@@ -40,7 +40,7 @@ gulp.task("test:unit", async () => {
 const projectNames = [
     "singleCsproj",
     "slnWithCsproj",
-    // "BasicRazorApp2_1" // Fix: No .NET Core projects found
+    "BasicRazorApp2_1"
 ];
 
 for (const projectName of projectNames) {

--- a/test/integrationTests/testAssets/BasicRazorApp2_1/BasicRazorApp2_1.csproj
+++ b/test/integrationTests/testAssets/BasicRazorApp2_1/BasicRazorApp2_1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Re-enabled the razor tests and moved the TFM back. Not sure why the razor error is causing the SDK fail to execute Compile/CoreCompile, but that's unrelated to LSP so reverting for now.