### PR TITLE
Prompt user to install Blazor WASM companion extension if needed

### DIFF
--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -240,6 +240,19 @@ async function isBlazorWebAssemblyProject(project: MSBuildProject): Promise<bool
 }
 
 function hasBlazorWebAssemblyDebugPrerequisites() {
+    const companionExtension = vscode.extensions.getExtension('ms-dotnettools.blazorwasm-companion');
+    if (!companionExtension) {
+        const msg = 'The Blazor WASM Debugging Extension is required to debug Blazor WASM apps in VS Code.';
+        vscode.window.showInformationMessage(msg, 'Install Extension', 'Close')
+            .then(async result => {
+                if (result === 'Install Extension') {
+                    const uriToOpen = vscode.Uri.parse('vscode:extension/ms-dotnettools.blazorwasm-companion');
+                    await vscode.commands.executeCommand('vscode.open', uriToOpen);
+                }
+            });
+        return false;
+    }
+
     const debugJavaScriptConfigSection = vscode.workspace.getConfiguration('debug.javascript');
     const usePreviewValue = debugJavaScriptConfigSection.get('usePreview');
     if (usePreviewValue) {

--- a/test-plan.md
+++ b/test-plan.md
@@ -236,6 +236,12 @@ To setup a test project to verify on you can do:
 
 ##### Debugging with blazorwasm debug adapter
 
+**Note:** On a VS Code installation with no extensions, you should recieve an alert like the following:
+
+> The Blazor WASM Debugging Extension is required to debug Blazor WASM apps in VS Code.
+
+Press "Install Extension" before step 2 in each of the test scenarios below.
+
 ###### Standalone app
 
 To set up a test project to verify on, create a new Blazor WebAssembly application using the dotnet CLI.


### PR DESCRIPTION
Detects if the companion extension is installed if the user is editing a Blazor WASM project and prompts them to install it if not.﻿

The companion extension is a new requirement for debugging Blazor WASM on VS Code to allow for:

- support for remote debugging
- faster launching for debugging sessions
- ability to debug on apps with windows auth configured
