### PR TITLE
Fixes to asset generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,16 +4,17 @@ node_modules
 out
 .omnisharp/
 .omnisharp-*/
-.debugger
-.razor
-.vscode-test
-.razor
+.vs/
+.debugger/
+.razor/
+.vscode-test/
 dist/
 *.razor.json
 
 install.*
 
 *.vsix
+*.map
 
 
 test/**/.vscode/launch.json

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -179,6 +179,25 @@ export class AssetGenerator {
         return path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, startupProjectDir));
     }
 
+    public createLaunchJsonConfigurationsArray(programLaunchType: ProgramLaunchType): vscode.DebugConfiguration[] {
+        const launchJson: string = this.createLaunchJsonConfigurations(programLaunchType);
+
+        const configurationArray: vscode.DebugConfiguration[] = JSON.parse(launchJson);
+
+        // Remove comments
+        configurationArray.forEach((configuration) => {
+            for (const key in configuration) {
+                if (Object.prototype.hasOwnProperty.call(configuration, key)) {
+                    if (key.startsWith("OS-COMMENT")) {
+                        delete configuration[key];
+                    }
+                }
+            }
+        });
+
+        return configurationArray;
+    }
+
     public createLaunchJsonConfigurations(programLaunchType: ProgramLaunchType): string {
         switch (programLaunchType) {
             case ProgramLaunchType.Console: {
@@ -305,7 +324,7 @@ export function createWebLaunchConfiguration(programPath: string, workingDirecto
         "OS-COMMENT5": "Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser",
         "serverReadyAction": {
             "action": "openExternally",
-            "pattern": "\\\\bNow listening on:\\\\s+(https?://\\\\S+)"
+            "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
         },
         "env": {
             "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -95,10 +95,9 @@ export class CSharpConfigurationProvider implements vscode.DebugConfigurationPro
                 await addTasksJsonIfNecessary(generator, buildOperations);
 
                 const programLaunchType = generator.computeProgramLaunchType();
-                const launchJson: string = generator.createLaunchJsonConfigurations(programLaunchType);
+                const launchJson: vscode.DebugConfiguration[] = generator.createLaunchJsonConfigurationsArray(programLaunchType);
 
-                // jsonc-parser's parse function parses a JSON string with comments into a JSON object. However, this removes the comments.
-                return parse(launchJson);
+                return launchJson;
 
             } else {
                 // Error to be caught in the .catch() below to write default C# configurations

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -282,6 +282,24 @@ suite("Asset generation: csproj", () => {
         lines[4].trim().should.equal('// This is a dotnet build command');
         lines[5].trim().should.equal('// this is the default command.');
     });
+
+    test("createLaunchJsonConfigurationsArray removes comments", () => {
+        let rootPath = path.resolve('testRoot');
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let launchConfigurations: vscode.DebugConfiguration[] = generator.createLaunchJsonConfigurationsArray(ProgramLaunchType.Web);
+
+        launchConfigurations.should.have.lengthOf(2);
+
+        launchConfigurations[0].type.should.equal("coreclr");
+        launchConfigurations[0].request.should.equal("launch");
+
+        launchConfigurations[1].type.should.equal("coreclr");
+        launchConfigurations[1].request.should.equal("attach");
+
+        JSON.stringify(launchConfigurations).indexOf("OS-COMMENT").should.lessThan(0);
+    });
 });
 
 function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {


### PR DESCRIPTION
This addresses two issues created by #4241.
1. Comments were left in when the launch.json content was returned through the configuration provider.
2. The search pattern for launching the browser was double-escaped, causing #4375 

This also makes some tweaks to our .gitignore to ignore some of the files that can be generated in this repo.