### PR TITLE
Add properties to blazorwasm debug configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3216,54 +3216,6 @@
                 "type": "object",
                 "description": "Environment variables passed to dotnet. Only valid for hosted apps."
               },
-              "logging": {
-                "description": "Optional flags to determine what types of messages should be logged to the output window. Applicable only for the app server of hosted Blazor WASM apps.",
-                "type": "object",
-                "required": [],
-                "default": {},
-                "properties": {
-                  "exceptions": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether exception messages should be logged to the output window.",
-                    "default": true
-                  },
-                  "moduleLoad": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether module load events should be logged to the output window.",
-                    "default": true
-                  },
-                  "programOutput": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
-                    "default": true
-                  },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
-                    "default": false
-                  },
-                  "browserStdOut": {
-                    "type": "boolean",
-                    "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
-                    "default": true
-                  },
-                  "elapsedTiming": {
-                    "type": "boolean",
-                    "description": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took.",
-                    "default": false
-                  },
-                  "threadExit": {
-                    "type": "boolean",
-                    "description": "Controls if a message is logged when a thread in the target process exits. Default: `false`.",
-                    "default": false
-                  },
-                  "processExit": {
-                    "type": "boolean",
-                    "description": "Controls if a message is logged when the target process exits, or debugging is stopped. Default: `true`.",
-                    "default": true
-                  }
-                }
-              },
               "dotNetConfig": {
                 "description": "Options passed to the underlying .NET debugger. For more info, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger.md.",
                 "type": "object",
@@ -3274,6 +3226,54 @@
                     "type": "boolean",
                     "description": "Optional flag to only show user code.",
                     "default": true
+                  },
+                  "logging": {
+                    "description": "Optional flags to determine what types of messages should be logged to the output window. Applicable only for the app server of hosted Blazor WASM apps.",
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "exceptions": {
+                        "type": "boolean",
+                        "description": "Optional flag to determine whether exception messages should be logged to the output window.",
+                        "default": true
+                      },
+                      "moduleLoad": {
+                        "type": "boolean",
+                        "description": "Optional flag to determine whether module load events should be logged to the output window.",
+                        "default": true
+                      },
+                      "programOutput": {
+                        "type": "boolean",
+                        "description": "Optional flag to determine whether program output should be logged to the output window when not using an external console.",
+                        "default": true
+                      },
+                      "engineLogging": {
+                        "type": "boolean",
+                        "description": "Optional flag to determine whether diagnostic engine logs should be logged to the output window.",
+                        "default": false
+                      },
+                      "browserStdOut": {
+                        "type": "boolean",
+                        "description": "Optional flag to determine if stdout text from the launching the web browser should be logged to the output window.",
+                        "default": true
+                      },
+                      "elapsedTiming": {
+                        "type": "boolean",
+                        "description": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took.",
+                        "default": false
+                      },
+                      "threadExit": {
+                        "type": "boolean",
+                        "description": "Controls if a message is logged when a thread in the target process exits. Default: `false`.",
+                        "default": false
+                      },
+                      "processExit": {
+                        "type": "boolean",
+                        "description": "Controls if a message is logged when the target process exits, or debugging is stopped. Default: `true`.",
+                        "default": true
+                      }
+                    }
                   },
                   "sourceFileMap": {
                     "type": "object",

--- a/package.json
+++ b/package.json
@@ -3264,19 +3264,27 @@
                   }
                 }
               },
-              "justMyCode": {
-                "type": "boolean",
-                "description": "Optional flag to only show user code.",
-                "default": true
-              },
-              "sourceFileMap": {
+              "dotNetConfig": {
+                "description": "Options passed to the underlying .NET debugger. For more info, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger.md.",
                 "type": "object",
-                "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "default": {
-                  "<insert-source-path-here>": "<insert-target-path-here>"
+                "required": [],
+                "default": {},
+                "properties": {
+                  "justMyCode": {
+                    "type": "boolean",
+                    "description": "Optional flag to only show user code.",
+                    "default": true
+                  },
+                  "sourceFileMap": {
+                    "type": "object",
+                    "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "default": {
+                      "<insert-source-path-here>": "<insert-target-path-here>"
+                    }
+                  }
                 }
               },
               "browserConfig": {

--- a/package.json
+++ b/package.json
@@ -3263,6 +3263,37 @@
                     "default": true
                   }
                 }
+              },
+              "justMyCode": {
+                "type": "boolean",
+                "description": "Optional flag to only show user code.",
+                "default": true
+              },
+              "sourceFileMap": {
+                "type": "object",
+                "description": "Optional source file mappings passed to the debug engine. Example: '{ \"C:\\foo\":\"/home/user/foo\" }'",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "default": {
+                  "<insert-source-path-here>": "<insert-target-path-here>"
+                }
+              },
+              "browserConfig": {
+                "description": "Options based to the underlying JavaScript debugger. For more info, see https://github.com/microsoft/vscode-js-debug/blob/master/OPTIONS.md.",
+                "type": "object",
+                "required": [],
+                "default": {},
+                "properties": {
+                  "outputCapture": {
+                    "enum": [
+                      "console",
+                      "std"
+                    ],
+                    "description": "From where to capture output messages: the default debug API if set to `console`, or stdout/stderr streams if set to `std`.",
+                    "default": "console"
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
Fixes dotnet/aspnetcore#30977.

Property definition taken directly from https://github.com/dotnet/aspnetcore-tooling/blob/c866a4bce578412c78443988c957fccacf5494cd/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json#L68.
