### PR TITLE
Fix typo in import path

### DIFF
--- a/test/unitTests/logging/OmnisharpChannelObserver.test.ts
+++ b/test/unitTests/logging/OmnisharpChannelObserver.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from 'chai';
-import { vscode } from '.,/../../src/vscodeAdapter';
+import { vscode } from '../../../src/vscodeAdapter';
 import { getNullChannel, updateConfig, getVSCodeWithConfig } from '../testAssets/Fakes';
 import { OmnisharpChannelObserver } from '../../../src/observers/OmnisharpChannelObserver';
 import { OmnisharpFailure, ShowOmniSharpChannel, BaseEvent, OmnisharpRestart, OmnisharpServerOnStdErr } from '../../../src/omnisharp/loggingEvents';


### PR DESCRIPTION
It was working because of a TypeScript [bug](https://github.com/microsoft/TypeScript/issues/43342).