### PR TITLE
Revert incremental change forwarding

### DIFF
--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -6,7 +6,7 @@
 import { Uri, workspace } from 'vscode';
 import { OmniSharpServer } from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
-import { FileChangeType, LinePositionSpanTextChange } from '../omnisharp/protocol';
+import { FileChangeType } from '../omnisharp/protocol';
 import { IDisposable } from '../Disposable';
 import CompositeDisposable from '../CompositeDisposable';
 
@@ -14,13 +14,8 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
 
     return workspace.onDidChangeTextDocument(event => {
 
-        let { document, contentChanges } = event;
+        let { document } = event;
         if (document.isUntitled || document.languageId !== 'csharp' || document.uri.scheme !== 'file') {
-            return;
-        }
-
-        if (contentChanges.length === 0) {
-            // This callback fires with no changes when a document's state changes between "clean" and "dirty".
             return;
         }
 
@@ -28,18 +23,7 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
             return;
         }
 
-        const lineChanges = contentChanges.map(function (change): LinePositionSpanTextChange {
-            const range = change.range;
-            return {
-                NewText: change.text,
-                StartLine: range.start.line,
-                StartColumn: range.start.character,
-                EndLine: range.end.line,
-                EndColumn: range.end.character
-            };
-        });
-
-        serverUtils.updateBuffer(server, { Changes: lineChanges, FileName: document.fileName, ApplyChangesTogether: true }).catch(err => {
+        serverUtils.updateBuffer(server, { Buffer: document.getText(), FileName: document.fileName }).catch(err => {
             console.error(err);
             return err;
         });
@@ -54,39 +38,13 @@ function forwardFileChanges(server: OmniSharpServer): IDisposable {
                 return;
             }
 
-            if (changeType === FileChangeType.Change) {
-                const docs = workspace.textDocuments.filter(doc => doc.uri.fsPath === uri.fsPath && isCSharpCodeFile(doc.uri));
-                if (Array.isArray(docs) && docs.some(doc => !doc.isClosed)) {
-                    // When a file changes on disk a FileSystemEvent is generated as well as a
-                    // DidChangeTextDocumentEvent.The ordering of these is:
-                    //  1. This method is called back. vscode's TextDocument has not yet been reloaded, so it has
-                    //     the version from before the changes are applied.
-                    //  2. vscode reloads the file, and fires onDidChangeTextDocument. The document has been updated,
-                    //     and the changes have the delta.
-                    // If we send this change to the server, then it will reload from the disk, which means it will
-                    // be synchronized to the version after the changes. Then, onDidChangeTextDocument will fire and
-                    // send the delta changes, which will cause the server to apply those exact changes. The results
-                    // being that the file is now in an inconsistent state.
-                    // If the document is closed, however, it will no longer be synchronized, so the text change will
-                    // not be triggered and we should tell the server to reread from the disk.
-                    // This applies to C# code files only, not other files significant for OmniSharp
-                    // e.g. csproj or editorconfig files
-                    return;
-                }
-            }
-
-            const req = { FileName: uri.fsPath, changeType };
+            let req = { FileName: uri.fsPath, changeType };
 
             serverUtils.filesChanged(server, [req]).catch(err => {
                 console.warn(`[o] failed to forward file change event for ${uri.fsPath}`, err);
                 return err;
             });
         };
-    }
-
-    function isCSharpCodeFile(uri: Uri) : Boolean {
-        const normalized = uri.path.toLocaleLowerCase();
-        return normalized.endsWith(".cs") || normalized.endsWith(".csx") || normalized.endsWith(".cake");
     }
 
     function onFolderEvent(changeType: FileChangeType): (uri: Uri) => void {
@@ -96,7 +54,7 @@ function forwardFileChanges(server: OmniSharpServer): IDisposable {
             }
 
             if (changeType === FileChangeType.Delete) {
-                const requests = [{ FileName: uri.fsPath, changeType: FileChangeType.DirectoryDelete }];
+                let requests = [{ FileName: uri.fsPath, changeType: FileChangeType.DirectoryDelete }];
 
                 serverUtils.filesChanged(server, requests).catch(err => {
                     console.warn(`[o] failed to forward file change event for ${uri.fsPath}`, err);

--- a/src/features/changeForwarding.ts
+++ b/src/features/changeForwarding.ts
@@ -14,8 +14,8 @@ function forwardDocumentChanges(server: OmniSharpServer): IDisposable {
 
     return workspace.onDidChangeTextDocument(event => {
 
-        let { document } = event;
-        if (document.isUntitled || document.languageId !== 'csharp' || document.uri.scheme !== 'file') {
+        let { document, contentChanges } = event;
+        if (document.isUntitled || document.languageId !== 'csharp' || document.uri.scheme !== 'file' || contentChanges.length === 0) {
             return;
         }
 


### PR DESCRIPTION
While I made this change with good intentions (and the perf benefit when working in Roslyn has been very real), this has proven to be more trouble than it's worth. LSP will be the way to get the perf benefits of incremental changes and should prove to be far more robust. This is a checkout of changeForwarding.ts to d26e995342b8df02135a5cbf0d385a2c02a6dd5b. The only other commits to this file since then have been about 0-based indexes, which no longer matters with this revert.
