### PR TITLE
Handle ProcessPicker via resolveDebugConfiguration

### DIFF
--- a/debugger.md
+++ b/debugger.md
@@ -77,7 +77,7 @@ The C# debugger supports attaching to processes. To do this, switch to the Debug
 
 ![Debug launch configuration drop down](https://raw.githubusercontent.com/wiki/OmniSharp/omnisharp-vscode/images/debug-launch-configurations.png)
 
-Select the '.NET Core Attach' configuration. Clicking the play button (or pressing <kbd>F5</kbd>) will then try to attach. In launch.json, if `processId` is set to `"${command:pickProcess}"` this will provide UI to select which process to attach to.
+Select the '.NET Core Attach' configuration. Clicking the play button (or pressing <kbd>F5</kbd>) will then try to attach. In launch.json, if `processId` is set to `""` this will provide UI to select which process to attach to.
 
 #### Remote Debugging
 

--- a/package.json
+++ b/package.json
@@ -2061,8 +2061,7 @@
             "body": {
               "name": ".NET Core Attach",
               "type": "coreclr",
-              "request": "attach",
-              "processId": ""
+              "request": "attach"
             }
           },
           {
@@ -2117,7 +2116,6 @@
               "name": ".NET Core Attach",
               "type": "coreclr",
               "request": "attach",
-              "processId": "",
               "pipeTransport": {
                 "pipeCwd": "^\"\\${workspaceFolder}\"",
                 "pipeProgram": "^\"${1:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",

--- a/package.json
+++ b/package.json
@@ -1624,12 +1624,12 @@
                 "anyOf": [
                   {
                     "type": "string",
-                    "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
-                    "default": "${command:pickProcess}"
+                    "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                    "default": ""
                   },
                   {
                     "type": "integer",
-                    "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                    "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
                     "default": 0
                   }
                 ]
@@ -2062,7 +2062,7 @@
               "name": ".NET Core Attach",
               "type": "coreclr",
               "request": "attach",
-              "processId": "^\"\\${command:pickProcess}\""
+              "processId": ""
             }
           },
           {
@@ -2117,7 +2117,7 @@
               "name": ".NET Core Attach",
               "type": "coreclr",
               "request": "attach",
-              "processId": "^\"\\${command:pickRemoteProcess}\"",
+              "processId": "",
               "pipeTransport": {
                 "pipeCwd": "^\"\\${workspaceFolder}\"",
                 "pipeProgram": "^\"${1:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
@@ -2725,12 +2725,12 @@
                 "anyOf": [
                   {
                     "type": "string",
-                    "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
-                    "default": "${command:pickProcess}"
+                    "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                    "default": ""
                   },
                   {
                     "type": "integer",
-                    "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+                    "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
                     "default": 0
                   }
                 ]

--- a/scripts/remoteProcessPickerScript
+++ b/scripts/remoteProcessPickerScript
@@ -1,1 +1,1 @@
-uname && if [ "$(uname)" = "Linux" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= ; exit; elif [ "$(uname)" = "Darwin" ] ; then ps -axww -o pid=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= -c; fi
+uname && if [ "$(uname)" = "Linux" ] ; then ps -axww -o pid=,flags=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= ; exit; elif [ "$(uname)" = "Darwin" ] ; then ps -axww -o pid=,flags=,comm=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,args= -c; fi

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -421,7 +421,7 @@ export function createAttachConfiguration(): string {
         "name": ".NET Core Attach",
         "type": "coreclr",
         "request": "attach",
-        "processId": "\${command:pickProcess}"
+        "processId": ""
     };
 
     return JSON.stringify(configuration);

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -420,8 +420,7 @@ export function createAttachConfiguration(): string {
     const configuration = {
         "name": ".NET Core Attach",
         "type": "coreclr",
-        "request": "attach",
-        "processId": ""
+        "request": "attach"
     };
 
     return JSON.stringify(configuration);

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -13,6 +13,7 @@ import { EventStream } from '../EventStream';
 import CSharpExtensionExports from '../CSharpExtensionExports';
 import { getRuntimeDependencyPackageWithId } from '../tools/RuntimeDependencyPackageUtils';
 import { getDotnetInfo, DotnetInfo } from '../utils/getDotnetInfo';
+import { CoreCLRConfigurationProvider } from './debugConfigurationProvider';
 
 let _debugUtil: CoreClrDebugUtil = null;
 
@@ -30,6 +31,7 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
     }
 
     const factory = new DebugAdapterExecutableFactory(platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath);
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new CoreCLRConfigurationProvider(platformInformation)));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
 }

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -13,7 +13,7 @@ import { EventStream } from '../EventStream';
 import CSharpExtensionExports from '../CSharpExtensionExports';
 import { getRuntimeDependencyPackageWithId } from '../tools/RuntimeDependencyPackageUtils';
 import { getDotnetInfo, DotnetInfo } from '../utils/getDotnetInfo';
-import { CoreCLRConfigurationProvider } from './debugConfigurationProvider';
+import { DotnetDebugConfigurationProvider } from './debugConfigurationProvider';
 
 let _debugUtil: CoreClrDebugUtil = null;
 
@@ -31,7 +31,8 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
     }
 
     const factory = new DebugAdapterExecutableFactory(platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath);
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new CoreCLRConfigurationProvider(platformInformation)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation)));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
 }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+import { DotNetAttachItemsProviderFactory, AttachPicker, AttachItem } from '../features/processPicker';
+import { PlatformInformation } from '../platform';
+
+export class CoreCLRConfigurationProvider implements vscode.DebugConfigurationProvider {
+    constructor(public platformInformation: PlatformInformation) {}
+
+    public async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration>
+    {
+        if (!debugConfiguration)
+        {
+            return null;
+        }
+
+        // Process Id is empty, handle Attach to Process Dialog.
+        if (debugConfiguration.request === "attach" && !debugConfiguration.processId)
+        {
+            let attachItemsProvider = DotNetAttachItemsProviderFactory.Get();
+            let attacher = new AttachPicker(attachItemsProvider);
+            const process: AttachItem = await attacher.SelectProcess();
+
+            if (process)
+            {
+                debugConfiguration.processId = process.id;
+                if (this.platformInformation.isMacOS() && this.platformInformation.architecture == 'arm64')
+                {
+                    if (process.flags & 0x20000)
+                    {
+                        debugConfiguration.targetArchitecture = "x86_64";
+                    }
+                    else
+                    {
+                        debugConfiguration.targetArchitecture = "arm64";
+                    }
+                }
+            }
+            else
+            {
+                throw new Error("No process was selected.");
+            }
+        }
+
+        return debugConfiguration;
+    }
+}

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
-import { DotNetAttachItemsProviderFactory, AttachPicker, RemoteAttachPicker } from './processPicker';
+import { RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
 import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
@@ -40,10 +40,9 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
     // running the command activates the extension, which is all we need for installation to kickoff
     disposable.add(vscode.commands.registerCommand('csharp.downloadDebugger', () => { }));
 
-    // register process picker for attach
-    let attachItemsProvider = DotNetAttachItemsProviderFactory.Get();
-    let attacher = new AttachPicker(attachItemsProvider);
-    disposable.add(vscode.commands.registerCommand('csharp.listProcess', async () => attacher.ShowAttachEntries()));
+    // register process picker for attach for legacy configurations.
+    disposable.add(vscode.commands.registerCommand('csharp.listProcess', async () => ""));
+
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));
     // Register command for remote process picker for attach

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -11,7 +11,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
-import { RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
 import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
@@ -41,12 +40,12 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
     disposable.add(vscode.commands.registerCommand('csharp.downloadDebugger', () => { }));
 
     // register process picker for attach for legacy configurations.
-    disposable.add(vscode.commands.registerCommand('csharp.listProcess', async () => ""));
+    disposable.add(vscode.commands.registerCommand('csharp.listProcess', () => ""));
+    disposable.add(vscode.commands.registerCommand('csharp.listRemoteProcess', () => ""));
+
 
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));
-    // Register command for remote process picker for attach
-    disposable.add(vscode.commands.registerCommand('csharp.listRemoteProcess', async (args) => RemoteAttachPicker.ShowAttachEntries(args, platformInfo)));
 
     disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver)));
 

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -406,12 +406,12 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
-              "default": "${command:pickProcess}"
+              "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+              "default": ""
             },
             {
               "type": "integer",
-              "description": "The process id to attach to. Use \"${command:pickProcess}\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
+              "description": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If 'processId' used, 'processName' should not be used.",
               "default": 0
             }
           ]


### PR DESCRIPTION
VS Code commands are limited to only being able to have a single output.
We will handle having an empty processId and show the dialog for
ProcessPicker in resolveDebugConfigurationWithSubstitutedVariables.
We need multiple outputs to handle the latest macOS on Apple M1.

For Apple Silicon M1 (ARM64), we need to determine if we need to use the
x86_64 or arm64 debugger. We are able to detect if the process is using
S_TRANSLATED using the ps commandline with 'flags', if it is set with
0x20000, it is emulated.