### PR TITLE
Update Razor to 6.0.0-preview.5.21271.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   * Added support for osx-arm64 debugging ([#4390](https://github.com/OmniSharp/omnisharp-vscode/issues/4390))
   * Added support for exception conditions. See [documentation](https://aka.ms/VSCode-CS-ExceptionSettings) for more information ([#4356](https://github.com/OmniSharp/omnisharp-vscode/issues/4356)).
   * Fixed an issue with character encoding for multi-byte characters written to the debug console ([#4398](https://github.com/OmniSharp/omnisharp-vscode/issues/4398))
+* Fixed a bug where Blazor WASM debugging would fail to launch correctly ([dotnet/aspnetcore#31653](https://github.com/dotnet/aspnetcore/issues/31653)) 
 
 ## 1.23.11 (April 9, 2021)
 * Move the global Mono check to the correct place ([#4489](https://github.com/OmniSharp/omnisharp-vscode/issues/4489), PR: [#4492](https://github.com/OmniSharp/omnisharp-vscode/pull/4492))

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "http-proxy-agent": "4.0.1",
         "https-proxy-agent": "5.0.0",
         "jsonc-parser": "3.0.0",
-        "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/d2dce097206432dfa3e47d9b09e58c93/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.21201.19.tgz",
+        "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/c83b913a02e68b5b5453c68a75471ba4/microsoft.aspnetcore.razor.vscode-6.0.0-preview.5.21271.1.tgz",
         "node-machine-id": "1.1.12",
         "request-light": "0.4.0",
         "rxjs": "6.6.7",
@@ -5080,9 +5080,9 @@
       }
     },
     "node_modules/microsoft.aspnetcore.razor.vscode": {
-      "version": "6.0.0-alpha.1.21201.19",
-      "resolved": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/d2dce097206432dfa3e47d9b09e58c93/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.21201.19.tgz",
-      "integrity": "sha512-EfQLIg3JdGdwDYw7aU1JHKy4tF0Es7PoZmsK5eTzXK7bDsiu3nXsUNctcF2tsGgf5HeOia+Bm5utIbUnpfl10w==",
+      "version": "6.0.0-preview.5.21271.1",
+      "resolved": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/c83b913a02e68b5b5453c68a75471ba4/microsoft.aspnetcore.razor.vscode-6.0.0-preview.5.21271.1.tgz",
+      "integrity": "sha512-JCF9Ck7fwxUuS2HTACYm3O3sL1RTpAtxBZgIO4WI0NA2g+HfOqlzABaYlMP0TNtVkSpuLlK4J0JSx523F3WGjg==",
       "dependencies": {
         "ps-list": "^7.0.0",
         "vscode-html-languageservice": "2.1.7",
@@ -13258,8 +13258,8 @@
       }
     },
     "microsoft.aspnetcore.razor.vscode": {
-      "version": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/d2dce097206432dfa3e47d9b09e58c93/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.21201.19.tgz",
-      "integrity": "sha512-EfQLIg3JdGdwDYw7aU1JHKy4tF0Es7PoZmsK5eTzXK7bDsiu3nXsUNctcF2tsGgf5HeOia+Bm5utIbUnpfl10w==",
+      "version": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/c83b913a02e68b5b5453c68a75471ba4/microsoft.aspnetcore.razor.vscode-6.0.0-preview.5.21271.1.tgz",
+      "integrity": "sha512-JCF9Ck7fwxUuS2HTACYm3O3sL1RTpAtxBZgIO4WI0NA2g+HfOqlzABaYlMP0TNtVkSpuLlK4J0JSx523F3WGjg==",
       "requires": {
         "ps-list": "^7.0.0",
         "vscode-html-languageservice": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "http-proxy-agent": "4.0.1",
     "https-proxy-agent": "5.0.0",
     "jsonc-parser": "3.0.0",
-    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/d2dce097206432dfa3e47d9b09e58c93/microsoft.aspnetcore.razor.vscode-6.0.0-alpha.1.21201.19.tgz",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/c83b913a02e68b5b5453c68a75471ba4/microsoft.aspnetcore.razor.vscode-6.0.0-preview.5.21271.1.tgz",
     "node-machine-id": "1.1.12",
     "request-light": "0.4.0",
     "rxjs": "6.6.7",
@@ -327,7 +327,7 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/32982b98737ab510fb2f840e6271b668/razorlanguageserver-win-x64-6.0.0-alpha.1.21201.19.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/e6d849b750944ceea9bb5fbdec1f5a2c/razorlanguageserver-win-x64-6.0.0-preview.5.21271.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -339,7 +339,7 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/d44b829f47f1227c021f0c00acc22e2e/razorlanguageserver-win-x86-6.0.0-alpha.1.21201.19.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/ff03e990c4d320cc3e30880e835c65db/razorlanguageserver-win-x86-6.0.0-preview.5.21271.1.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
@@ -351,7 +351,7 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/edb3faa70dfc2896bc656a379538f5cc/razorlanguageserver-linux-x64-6.0.0-alpha.1.21201.19.zip",
+      "url": " https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/344a62e65802d1f611bb0a8e94751cc8/razorlanguageserver-linux-x64-6.0.0-preview.5.21271.1.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -366,7 +366,7 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/92748a92-32fe-4cf9-b6c2-e3d0edacf90d/43ccc87635d42521809c69061b4ec787/razorlanguageserver-osx-x64-6.0.0-alpha.1.21201.19.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/752cb2c4-4352-499f-ab81-54454d6e7a92/095200d2ec40538faa0f59b52e229192/razorlanguageserver-osx-x64-6.0.0-preview.5.21271.1.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "defaults": {
     "omniSharp": "1.37.9",
-    "razor": "6.0.0-alpha.1.21201.19"
+    "razor": "6.0.0-preview.5.21271.1"
   },
   "main": "./dist/extension",
   "scripts": {


### PR DESCRIPTION
Bumping this up to consume a bug fix for the Blazor WASM debug extension.