### PR TITLE
Add command 'listRemoteDockerProcess' and variable 'pickRemoteDockerProcess'

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,7 +399,7 @@
     "onCommand:csharp.downloadDebugger",
     "onCommand:csharp.listProcess",
     "onCommand:csharp.listRemoteProcess",
-    "onCommand:csharp.listDockerRemoteProcess",
+    "onCommand:csharp.listRemoteDockerProcess",
     "onCommand:omnisharp.registerLanguageMiddleware",
     "workspaceContains:project.json",
     "workspaceContains:*.csproj",

--- a/package.json
+++ b/package.json
@@ -399,6 +399,7 @@
     "onCommand:csharp.downloadDebugger",
     "onCommand:csharp.listProcess",
     "onCommand:csharp.listRemoteProcess",
+    "onCommand:csharp.listDockerRemoteProcess",
     "onCommand:omnisharp.registerLanguageMiddleware",
     "workspaceContains:project.json",
     "workspaceContains:*.csproj",
@@ -975,6 +976,11 @@
         "category": "CSharp"
       },
       {
+        "command": "csharp.listRemoteDockerProcess",
+        "title": "List processes on Docker connection",
+        "category": "CSharp"
+      },
+      {
         "command": "csharp.reportIssue",
         "title": "Report an issue",
         "category": "CSharp"
@@ -1043,7 +1049,8 @@
         "label": ".NET Core",
         "variables": {
           "pickProcess": "csharp.listProcess",
-          "pickRemoteProcess": "csharp.listRemoteProcess"
+          "pickRemoteProcess": "csharp.listRemoteProcess",
+          "pickRemoteDockerProcess": "csharp.listRemoteDockerProcess"
         },
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {
@@ -2142,7 +2149,8 @@
         "label": ".NET",
         "variables": {
           "pickProcess": "csharp.listProcess",
-          "pickRemoteProcess": "csharp.listRemoteProcess"
+          "pickRemoteProcess": "csharp.listRemoteProcess",
+          "pickRemoteDockerProcess": "csharp.listRemoteDockerProcess"
         },
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
         "configurationAttributes": {

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as protocol from '../omnisharp/protocol';
 import * as vscode from 'vscode';
+import { RemoteAttachPicker } from './processPicker';
 import { generateAssets } from '../assets';
 import { ShowOmniSharpChannel, CommandDotNetRestoreStart, CommandDotNetRestoreProgress, CommandDotNetRestoreSucceeded, CommandDotNetRestoreFailed } from '../omnisharp/loggingEvents';
 import { EventStream } from '../EventStream';
@@ -42,6 +43,9 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
     disposable.add(vscode.commands.registerCommand('csharp.listProcess', () => ""));
     disposable.add(vscode.commands.registerCommand('csharp.listRemoteProcess', () => ""));
 
+    // List remote processes for docker extension.
+    // Change to return "" when https://github.com/microsoft/vscode/issues/110889 is resolved.
+    disposable.add(vscode.commands.registerCommand('csharp.listRemoteDockerProcess', async (args) => RemoteAttachPicker.ShowAttachEntries(args, platformInfo)));
 
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -45,7 +45,10 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
 
     // List remote processes for docker extension.
     // Change to return "" when https://github.com/microsoft/vscode/issues/110889 is resolved.
-    disposable.add(vscode.commands.registerCommand('csharp.listRemoteDockerProcess', async (args) => RemoteAttachPicker.ShowAttachEntries(args, platformInfo)));
+    disposable.add(vscode.commands.registerCommand('csharp.listRemoteDockerProcess', async (args) => {
+        const attachItem = await RemoteAttachPicker.ShowAttachEntries(args, platformInfo);
+        return attachItem ? attachItem.id : Promise.reject<string>(new Error("Could not find a process id to attach."));
+    }));
 
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));


### PR DESCRIPTION
This will enable the old RemoteAttachPicker call that will only return
processIds.

Temporary workaround for #4607 until https://github.com/microsoft/vscode/issues/110889 is resolved.