### PR TITLE
Add Debugger Languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1047,6 +1047,12 @@
       {
         "type": "coreclr",
         "label": ".NET Core",
+        "languages": [
+          "csharp",
+          "razor",
+          "qsharp",
+          "aspnetcorerazor"
+        ],
         "variables": {
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess",
@@ -2147,6 +2153,12 @@
       {
         "type": "clr",
         "label": ".NET",
+        "languages": [
+          "csharp",
+          "razor",
+          "qsharp",
+          "aspnetcorerazor"
+        ],
         "variables": {
           "pickProcess": "csharp.listProcess",
           "pickRemoteProcess": "csharp.listRemoteProcess",


### PR DESCRIPTION
VS Code checks for `languages` in the `debuggers` object to see if there is an extension available for it to debug.


Related: #4599