### PR TITLE
Use temporary directory for debug sockets on NIX systems

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -23,6 +23,16 @@ export function getExtensionPath() {
     return extensionPath;
 }
 
+export function getUnixTempDirectory(){
+    let envTmp = process.env.TMPDIR;
+    if(!envTmp)
+    {
+        return "/tmp/";
+    }
+
+    return envTmp;
+}
+
 export function isBoolean(obj: any): obj is boolean {
     return obj === true || obj === false;
 }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -546,7 +546,7 @@ class DebugEventListener {
         this._server = server;
         this._eventStream = eventStream;
         // NOTE: The max pipe name on OSX is fairly small, so this name shouldn't bee too long.
-        const pipeSuffix = "TestDebugEvents-" + process.pid;
+        const pipeSuffix = "T-" + process.pid;
         if (os.platform() === 'win32') {
             this._pipePath = "\\\\.\\pipe\\Microsoft.VSCode.CSharpExt." + pipeSuffix;
         } else {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -545,14 +545,13 @@ class DebugEventListener {
         this._fileName = fileName;
         this._server = server;
         this._eventStream = eventStream;
-        const pipeSuffix = "TestDebugEvents-" + process.pid;
 
         if (os.platform() === 'win32') {
-            this._pipePath = "\\\\.\\pipe\\Microsoft.VSCode.CSharpExt." + pipeSuffix;
+            this._pipePath = "\\\\.\\pipe\\Microsoft.VSCode.CSharpExt.TestDebugEvents" + process.pid;
         }
         else {
             let tmpdir = utils.getUnixTempDirectory();
-            this._pipePath = path.join(tmpdir, "." + pipeSuffix);
+            this._pipePath = path.join(tmpdir, "ms-dotnettools.csharp-tde-" + process.pid);
         }
     }
 

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -545,11 +545,18 @@ class DebugEventListener {
         this._fileName = fileName;
         this._server = server;
         this._eventStream = eventStream;
-        // NOTE: The max pipe name on OSX is fairly small, so this name shouldn't bee too long.
-        const pipeSuffix = "T-" + process.pid;
-        if (os.platform() === 'win32') {
+        const pipeSuffix = "TestDebugEvents-" + process.pid;
+
+        let platform = os.platform();
+        if (platform === 'win32') {
             this._pipePath = "\\\\.\\pipe\\Microsoft.VSCode.CSharpExt." + pipeSuffix;
-        } else {
+        } 
+        else if (platform === 'linux' || platform === 'darwin') {
+            // NOTE: The max pipe name on *NIX is fairly small, so this name shouldn't be too long.
+            let tmpdir = utils.getUnixTempDirectory();
+            this._pipePath = path.join(tmpdir,"." + pipeSuffix);
+        }
+        else {
             this._pipePath = path.join(utils.getExtensionPath(), "." + pipeSuffix);
         }
     }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -547,17 +547,12 @@ class DebugEventListener {
         this._eventStream = eventStream;
         const pipeSuffix = "TestDebugEvents-" + process.pid;
 
-        let platform = os.platform();
-        if (platform === 'win32') {
+        if (os.platform() === 'win32') {
             this._pipePath = "\\\\.\\pipe\\Microsoft.VSCode.CSharpExt." + pipeSuffix;
-        } 
-        else if (platform === 'linux' || platform === 'darwin') {
-            // NOTE: The max pipe name on *NIX is fairly small, so this name shouldn't be too long.
-            let tmpdir = utils.getUnixTempDirectory();
-            this._pipePath = path.join(tmpdir,"." + pipeSuffix);
         }
         else {
-            this._pipePath = path.join(utils.getExtensionPath(), "." + pipeSuffix);
+            let tmpdir = utils.getUnixTempDirectory();
+            this._pipePath = path.join(tmpdir, "." + pipeSuffix);
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/OmniSharp/omnisharp-vscode/issues/4523

This PR stores debug sockets in `/tmp/` or `$TMPDIR` (if set) on Linux & OSX platforms.