### PR TITLE
Show C# project files in the project selector

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -5,7 +5,7 @@
 
 import { OmniSharpServer } from '../omnisharp/server';
 import * as serverUtils from '../omnisharp/utils';
-import { findLaunchTargets } from '../omnisharp/launcher';
+import { findLaunchTargets, LaunchTarget } from '../omnisharp/launcher';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -92,14 +92,18 @@ async function pickProjectAndStart(server: OmniSharpServer, optionProvider: Opti
             }
         }
 
-        return vscode.window.showQuickPick(targets, {
-            matchOnDescription: true,
-            placeHolder: `Select 1 of ${targets.length} projects`
-        }).then(async launchTarget => {
-            if (launchTarget) {
-                return server.restart(launchTarget);
-            }
-        });
+        return showProjectSelector(server, targets);
+    });
+}
+
+export async function showProjectSelector(server: OmniSharpServer, targets: LaunchTarget[]): Promise<void> {
+    return vscode.window.showQuickPick(targets, {
+        matchOnDescription: true,
+        placeHolder: `Select 1 of ${targets.length} projects`
+    }).then(async launchTarget => {
+        if (launchTarget) {
+            return server.restart(launchTarget);
+        }
     });
 }
 

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -116,10 +116,10 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
         }
     }
 
-    return resourcesAndFolderMapToLaunchTargets(resources, workspaceFolderToUriMap);
+    return resourcesAndFolderMapToLaunchTargets(resources, vscode.workspace.workspaceFolders.concat(), workspaceFolderToUriMap);
 }
 
-export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], workspaceFolderToUriMap: Map<number, vscode.Uri[]>): LaunchTarget[] {
+export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], workspaceFolders: vscode.WorkspaceFolder[], workspaceFolderToUriMap: Map<number, vscode.Uri[]>): LaunchTarget[] {
     let solutionTargets: LaunchTarget[] = [];
     let projectJsonTargets: LaunchTarget[] = [];
     let projectTargets: LaunchTarget[] = [];
@@ -131,7 +131,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
         let hasCake = false;
         let hasCs = false;
 
-        let folder = vscode.workspace.workspaceFolders[folderIndex];
+        let folder = workspaceFolders[folderIndex];
         let folderPath = folder.uri.fsPath;
 
         resources.forEach(resource => {

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -14,6 +14,7 @@ import { IMonoResolver } from '../constants/IMonoResolver';
 
 export enum LaunchTargetKind {
     Solution,
+    Project,
     ProjectJson,
     Folder,
     Csx,
@@ -115,82 +116,81 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
         }
     }
 
-    let targets: LaunchTarget[] = [];
+    return resourcesAndFolderMapToLaunchTargets(resources, workspaceFolderToUriMap);
+}
+
+export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], workspaceFolderToUriMap: Map<number, vscode.Uri[]>): LaunchTarget[] {
+    let solutionTargets: LaunchTarget[] = [];
+    let projectJsonTargets: LaunchTarget[] = [];
+    let projectTargets: LaunchTarget[] = [];
+    let otherTargets: LaunchTarget[] = [];
 
     workspaceFolderToUriMap.forEach((resources, folderIndex) => {
-        let hasCsProjFiles = false,
-            hasSlnFile = false,
-            hasProjectJson = false,
-            hasProjectJsonAtRoot = false,
-            hasCSX = false,
-            hasCake = false,
-            hasCs = false;
-
-        hasCsProjFiles = resources.some(isCSharpProject);
+        let hasProjectJsonAtRoot = false;
+        let hasCSX = false;
+        let hasCake = false;
+        let hasCs = false;
 
         let folder = vscode.workspace.workspaceFolders[folderIndex];
         let folderPath = folder.uri.fsPath;
 
         resources.forEach(resource => {
-            // Add .sln and .slnf files if there are .csproj files
-            if (hasCsProjFiles && isSolution(resource)) {
-                hasSlnFile = true;
-                targets.push({
+            // Add .sln and .slnf files
+            if (isSolution(resource)) {
+                const dirname = path.dirname(resource.fsPath);
+                solutionTargets.push({
                     label: path.basename(resource.fsPath),
-                    description: vscode.workspace.asRelativePath(path.dirname(resource.fsPath)),
+                    description: vscode.workspace.asRelativePath(dirname),
                     target: resource.fsPath,
                     directory: path.dirname(resource.fsPath),
                     kind: LaunchTargetKind.Solution
                 });
             }
-
             // Add project.json files
-            if (isProjectJson(resource)) {
+            else if (isProjectJson(resource)) {
                 const dirname = path.dirname(resource.fsPath);
-                hasProjectJson = true;
                 hasProjectJsonAtRoot = hasProjectJsonAtRoot || dirname === folderPath;
-
-                targets.push({
+                projectJsonTargets.push({
                     label: path.basename(resource.fsPath),
-                    description: vscode.workspace.asRelativePath(path.dirname(resource.fsPath)),
+                    description: vscode.workspace.asRelativePath(dirname),
                     target: dirname,
                     directory: dirname,
                     kind: LaunchTargetKind.ProjectJson
                 });
             }
-
-            // Discover if there is any CSX file
-            if (!hasCSX && isCsx(resource)) {
-                hasCSX = true;
+            // Add .csproj files
+            else if (isCSharpProject(resource)) {
+                const dirname = path.dirname(resource.fsPath);
+                // OmniSharp doesn't support opening a project directly, however, it will open a project if
+                // we pass a folder path which contains a single .csproj. This is similar to how project.json
+                // is supported.
+                projectTargets.push({
+                    label: path.basename(resource.fsPath),
+                    description: vscode.workspace.asRelativePath(dirname),
+                    target: dirname,
+                    directory: dirname,
+                    kind: LaunchTargetKind.Project
+                });
             }
+            else {
+                // Discover if there is any CSX file
+                hasCSX ||= isCsx(resource);
 
-            // Discover if there is any Cake file
-            if (!hasCake && isCake(resource)) {
-                hasCake = true;
-            }
+                // Discover if there is any Cake file
+                hasCake ||= isCake(resource);
 
-            //Discover if there is any cs file
-            if (!hasCs && isCs(resource)) {
-                hasCs = true;
+                //Discover if there is any cs file
+                hasCs ||= isCs(resource);
             }
         });
 
-        // Add the root folder under the following circumstances:
-        // * If there are .csproj files, but no .sln or .slnf file, and none in the root.
-        // * If there are project.json files, but none in the root.
-        if ((hasCsProjFiles && !hasSlnFile) || (hasProjectJson && !hasProjectJsonAtRoot)) {
-            targets.push({
-                label: path.basename(folderPath),
-                description: '',
-                target: folderPath,
-                directory: folderPath,
-                kind: LaunchTargetKind.Folder
-            });
-        }
+        const hasCsProjFiles = projectTargets.length > 0;
+        const hasSlnFile = solutionTargets.length > 0;
+        const hasProjectJson = projectJsonTargets.length > 0;
 
         // if we noticed any CSX file(s), add a single CSX-specific target pointing at the root folder
         if (hasCSX) {
-            targets.push({
+            otherTargets.push({
                 label: "CSX",
                 description: path.basename(folderPath),
                 target: folderPath,
@@ -201,7 +201,7 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
 
         // if we noticed any Cake file(s), add a single Cake-specific target pointing at the root folder
         if (hasCake) {
-            targets.push({
+            otherTargets.push({
                 label: "Cake",
                 description: path.basename(folderPath),
                 target: folderPath,
@@ -211,7 +211,7 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
         }
 
         if (hasCs && !hasSlnFile && !hasCsProjFiles && !hasProjectJson && !hasProjectJsonAtRoot) {
-            targets.push({
+            otherTargets.push({
                 label: path.basename(folderPath),
                 description: '',
                 target: folderPath,
@@ -221,7 +221,11 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
         }
     });
 
-    return targets.sort((a, b) => a.directory.localeCompare(b.directory));
+    solutionTargets = solutionTargets.sort((a, b) => a.directory.localeCompare(b.directory));
+    projectJsonTargets = projectJsonTargets.sort((a, b) => a.directory.localeCompare(b.directory));
+    projectTargets = projectTargets.sort((a, b) => a.directory.localeCompare(b.directory));
+
+    return otherTargets.concat(solutionTargets).concat(projectJsonTargets).concat(projectTargets);
 }
 
 function isCSharpProject(resource: vscode.Uri): boolean {

--- a/test/integrationTests/launcher.test.ts
+++ b/test/integrationTests/launcher.test.ts
@@ -5,20 +5,11 @@
 
 import * as vscode from 'vscode';
 import { assert } from "chai";
-import { resourcesToLaunchTargets, vsls, vslsTarget } from "../../src/omnisharp/launcher";
-import { isSlnWithGenerator } from './integrationHelpers';
-
-const chai = require('chai');
-chai.use(require('chai-arrays'));
-chai.use(require('chai-fs'));
+import { LaunchTargetKind, resourcesAndFolderMapToLaunchTargets, vsls, vslsTarget } from "../../src/omnisharp/launcher";
 
 suite(`launcher:`, () => {
 
-    suiteSetup(async function () {
-        if (isSlnWithGenerator(vscode.workspace)) {
-            this.skip();
-        }
-    });
+    const folderMap = new Map<number, vscode.Uri[]>([[0, [vscode.Uri.parse(`/`)]]]);
 
     test(`Returns the LiveShare launch target when processing vsls resources`, () => {
         const testResources: vscode.Uri[] = [
@@ -27,7 +18,7 @@ suite(`launcher:`, () => {
             vscode.Uri.parse(`${vsls}:/test/Program.cs`),
         ];
 
-        const launchTargets = resourcesToLaunchTargets(testResources);
+        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
 
         const liveShareTarget = launchTargets.find(target => target === vslsTarget);
         assert.exists(liveShareTarget, "Launch targets was not the Visual Studio Live Share target.");
@@ -40,9 +31,25 @@ suite(`launcher:`, () => {
             vscode.Uri.parse(`/test/Program.cs`),
         ];
 
-        const launchTargets = resourcesToLaunchTargets(testResources);
+        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
 
         const liveShareTarget = launchTargets.find(target => target === vslsTarget);
         assert.notExists(liveShareTarget, "Launch targets contained the Visual Studio Live Share target.");
+    });
+
+    test(`Returns a Solution and Project target`, () => {
+        const testResources: vscode.Uri[] = [
+            vscode.Uri.parse(`/test.sln`),
+            vscode.Uri.parse(`/test/test.csproj`),
+            vscode.Uri.parse(`/test/Program.cs`),
+        ];
+
+        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
+
+        const solutionTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Solution && target.directory === "/test.sln");
+        assert.exists(solutionTarget, "Launch targets did not include `/test.sln`");
+
+        const projectTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Project && target.directory === "/test");
+        assert.exists(projectTarget, "Launch targets did not include `/test/test.csproj`");
     });
 });

--- a/test/integrationTests/launcher.test.ts
+++ b/test/integrationTests/launcher.test.ts
@@ -5,11 +5,10 @@
 
 import * as vscode from 'vscode';
 import { assert } from "chai";
-import { LaunchTargetKind, resourcesAndFolderMapToLaunchTargets, vsls, vslsTarget } from "../../src/omnisharp/launcher";
+import { LaunchTargetKind, resourcesAndFolderMapToLaunchTargets, resourcesToLaunchTargets, vsls, vslsTarget } from "../../src/omnisharp/launcher";
 
 suite(`launcher:`, () => {
-
-    const folderMap = new Map<number, vscode.Uri[]>([[0, [vscode.Uri.parse(`/`)]]]);
+    const workspaceFolders: vscode.WorkspaceFolder[] = [{ uri: vscode.Uri.parse('/'), name: "root", index: 0 }];
 
     test(`Returns the LiveShare launch target when processing vsls resources`, () => {
         const testResources: vscode.Uri[] = [
@@ -18,7 +17,7 @@ suite(`launcher:`, () => {
             vscode.Uri.parse(`${vsls}:/test/Program.cs`),
         ];
 
-        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
+        const launchTargets = resourcesToLaunchTargets(testResources);
 
         const liveShareTarget = launchTargets.find(target => target === vslsTarget);
         assert.exists(liveShareTarget, "Launch targets was not the Visual Studio Live Share target.");
@@ -30,8 +29,9 @@ suite(`launcher:`, () => {
             vscode.Uri.parse(`/test/test.csproj`),
             vscode.Uri.parse(`/test/Program.cs`),
         ];
+        const folderMap = new Map<number, vscode.Uri[]>([[0, testResources]]);
 
-        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
+        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, workspaceFolders, folderMap);
 
         const liveShareTarget = launchTargets.find(target => target === vslsTarget);
         assert.notExists(liveShareTarget, "Launch targets contained the Visual Studio Live Share target.");
@@ -43,13 +43,14 @@ suite(`launcher:`, () => {
             vscode.Uri.parse(`/test/test.csproj`),
             vscode.Uri.parse(`/test/Program.cs`),
         ];
+        const folderMap = new Map<number, vscode.Uri[]>([[0, testResources]]);
 
-        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, folderMap);
+        const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, workspaceFolders, folderMap);
 
-        const solutionTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Solution && target.directory === "/test.sln");
+        const solutionTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Solution && target.label === "test.sln");
         assert.exists(solutionTarget, "Launch targets did not include `/test.sln`");
 
-        const projectTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Project && target.directory === "/test");
+        const projectTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Project && target.label === "test.csproj");
         assert.exists(projectTarget, "Launch targets did not include `/test/test.csproj`");
     });
 });


### PR DESCRIPTION
Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/4633

Project Selector sorting will be:
1. CSX (if present)
2. CAKE (if present)
3. Solution file sorted by directory
4. Project files sorted by directory

Before:
![image](https://user-images.githubusercontent.com/611219/125152117-67577800-e0ff-11eb-9919-5e838a6bc17e.png)

After:
![image](https://user-images.githubusercontent.com/611219/125152151-9c63ca80-e0ff-11eb-8f26-031145d0b2fc.png)
