### PR TITLE
Use new CompletionItem label API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/semver": "5.5.0",
         "@types/tmp": "0.0.33",
         "@types/unzipper": "^0.9.1",
-        "@types/vscode": "1.57.0",
+        "@types/vscode": "1.58.0",
         "@types/yauzl": "2.9.1",
         "archiver": "5.3.0",
         "chai": "4.3.4",
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-      "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.58.0.tgz",
+      "integrity": "sha512-enznxcBi4uYt20LWal09E0+VKEHZlq9PZawTu/mpWCVCFWWbiyR8HNI1ikBP1Ypqv8b3A/0md3DY1jcx+oQ8kQ==",
       "dev": true
     },
     "node_modules/@types/yauzl": {
@@ -9391,9 +9391,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-      "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.58.0.tgz",
+      "integrity": "sha512-enznxcBi4uYt20LWal09E0+VKEHZlq9PZawTu/mpWCVCFWWbiyR8HNI1ikBP1Ypqv8b3A/0md3DY1jcx+oQ8kQ==",
       "dev": true
     },
     "@types/yauzl": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@types/semver": "5.5.0",
     "@types/tmp": "0.0.33",
     "@types/unzipper": "^0.9.1",
-    "@types/vscode": "1.57.0",
+    "@types/vscode": "1.58.0",
     "@types/yauzl": "2.9.1",
     "archiver": "5.3.0",
     "chai": "4.3.4",

--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -124,9 +124,8 @@ export default class OmnisharpCompletionProvider extends AbstractProvider implem
         const insertRange = omnisharpCompletion.TextEdit ? mapRange(omnisharpCompletion.TextEdit) : undefined;
 
         return {
-            label: omnisharpCompletion.Label,
+            label: { label: omnisharpCompletion.Label, description: omnisharpCompletion.Detail },
             kind: omnisharpCompletion.Kind - 1,
-            detail: omnisharpCompletion.Detail,
             documentation: docs,
             commitCharacters: omnisharpCompletion.CommitCharacters,
             preselect: omnisharpCompletion.Preselect,

--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -9,7 +9,7 @@ import { configure as configureXHR, xhr } from 'request-light';
 
 import {
     CompletionItem, CompletionItemProvider, CompletionList, TextDocument, Position, Hover, HoverProvider,
-    CancellationToken, Range, TextEdit, MarkedString, DocumentSelector, languages, workspace
+    CancellationToken, Range, MarkedString, DocumentSelector, languages, workspace
 } from 'vscode';
 import CompositeDisposable from '../../CompositeDisposable';
 
@@ -113,10 +113,11 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
         let proposed: { [key: string]: boolean } = {};
         let collector: ISuggestionsCollector = {
             add: (suggestion: CompletionItem) => {
-                if (!proposed[suggestion.label]) {
-                    proposed[suggestion.label] = true;
+                if (!proposed[<string>suggestion.label]) {
+                    proposed[<string>suggestion.label] = true;
                     if (overwriteRange) {
-                        suggestion.textEdit = TextEdit.replace(overwriteRange, <string>suggestion.insertText);
+                        suggestion.insertText = suggestion.insertText;
+                        suggestion.range = overwriteRange;
                     }
 
                     items.push(suggestion);

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -185,7 +185,7 @@ export class ProjectJSONContribution implements IJSONContribution {
     public resolveSuggestion(item: CompletionItem): Thenable<CompletionItem> {
         if (item.kind === CompletionItemKind.Property) {
             let pack = item.label;
-            return this.getInfo(pack).then(info => {
+            return this.getInfo(<string>pack).then(info => {
                 if (info.description) {
                     item.documentation = info.description;
                 }


### PR DESCRIPTION
1.58 brought a new completion item API that allows us to specify a description for the completion label. This will give us an experience more akin to VS for import completion, where the namespace of the item is always displayed, right-aligned and slightly faded, in the completion list. Anything else that Roslyn adds to InlineDescription here will automatically show up, but import completion is the only thing that uses it for now.

Closes https://github.com/OmniSharp/omnisharp-vscode/issues/4640.