### PR TITLE
Bump the minimum required VSCode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.58.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",


### PR DESCRIPTION
Because of the usage of the new CompletionItem API, autocompletions are broken on v1.57. This PR bumps the minimum required VSCode version to v1.58 (though I'm not sure if this will retroactively do anything for those who have already received the updated omnisharp-vscode).

Fixes #4663.