### PR TITLE
Don't create launch.json for no selected process

### DIFF
--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -55,7 +55,8 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
             }
             else
             {
-                throw new Error("No process was selected.");
+                vscode.window.showErrorMessage("No process was selected.", { modal: true });
+                return undefined;
             }
         }
 


### PR DESCRIPTION
This PR fixes resolveDebugConfigurationWithSubstitutedVariables to
return undefined when user does not select a process in the process selection
dialog.

This will ensure it does not switch to the `launch.json` tab. 

Related: https://github.com/OmniSharp/omnisharp-vscode/issues/4696