### PR TITLE
Show decompilation authorization once per install.

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -21,7 +21,7 @@ import OptionProvider from '../observers/OptionProvider';
 import reportIssue from './reportIssue';
 import { IMonoResolver } from '../constants/IMonoResolver';
 import { getDotnetInfo } from '../utils/getDotnetInfo';
-import { getDecompilationAuthorization } from '../omnisharp/decompilationPrompt';
+import { getDecompilationAuthorization, resetDecompilationAuthorization } from '../omnisharp/decompilationPrompt';
 
 export default function registerCommands(context: vscode.ExtensionContext, server: OmniSharpServer, platformInfo: PlatformInformation, eventStream: EventStream, optionProvider: OptionProvider, monoResolver: IMonoResolver, packageJSON: any, extensionPath: string): CompositeDisposable {
     let disposable = new CompositeDisposable();
@@ -62,13 +62,13 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
 
 async function showDecompilationTerms(context: vscode.ExtensionContext, server: OmniSharpServer, optionProvider: OptionProvider) {
     // Reset the decompilation authorization so the user will be prompted on restart.
-    context.workspaceState.update("decompilationAuthorized", undefined);
+    resetDecompilationAuthorization(context);
 
     await restartOmniSharp(context, server, optionProvider);
 }
 
 async function restartOmniSharp(context: vscode.ExtensionContext, server: OmniSharpServer, optionProvider: OptionProvider) {
-    // Update decompilation authorization for this workspace.
+    // Update decompilation authorization.
     server.decompilationAuthorized = await getDecompilationAuthorization(context, optionProvider);
 
     if (server.isRunning()) {

--- a/src/omnisharp/decompilationPrompt.ts
+++ b/src/omnisharp/decompilationPrompt.ts
@@ -6,15 +6,19 @@
 import * as vscode from "vscode";
 import OptionProvider from "../observers/OptionProvider";
 
+export async function resetDecompilationAuthorization(context: vscode.ExtensionContext) {
+    context.globalState.update("csharp.decompilationAuthorized", undefined);
+}
+
 export async function getDecompilationAuthorization(context: vscode.ExtensionContext, optionProvider: OptionProvider) {
-    // If decompilation is disabled the return false
+    // If decompilation is disabled, then return false
     const options = optionProvider.GetLatestOptions();
     if (options.enableDecompilationSupport === false) {
         return false;
     }
 
-    // If the terms have been acknowledged for this workspace then return.
-    let decompilationAutorized = context.workspaceState.get<boolean | undefined>("decompilationAuthorized");
+    // If the terms have been acknowledged, then return whether it was authorized.
+    let decompilationAutorized = context.globalState.get<boolean | undefined>("csharp.decompilationAuthorized");
     if (decompilationAutorized !== undefined) {
         return decompilationAutorized;
     }
@@ -22,7 +26,7 @@ export async function getDecompilationAuthorization(context: vscode.ExtensionCon
     const result = await promptToAcceptDecompilationTerms();
     decompilationAutorized = result === PromptResult.Yes;
 
-    await context.workspaceState.update("decompilationAuthorized", decompilationAutorized);
+    await context.globalState.update("csharp.decompilationAuthorized", decompilationAutorized);
 
     return decompilationAutorized;
 }

--- a/src/omnisharp/decompilationPrompt.ts
+++ b/src/omnisharp/decompilationPrompt.ts
@@ -6,8 +6,10 @@
 import * as vscode from "vscode";
 import OptionProvider from "../observers/OptionProvider";
 
+const DecompilationAuthorizedOption = "csharp.decompilationAuthorized";
+
 export async function resetDecompilationAuthorization(context: vscode.ExtensionContext) {
-    context.globalState.update("csharp.decompilationAuthorized", undefined);
+    context.globalState.update(DecompilationAuthorizedOption, undefined);
 }
 
 export async function getDecompilationAuthorization(context: vscode.ExtensionContext, optionProvider: OptionProvider) {
@@ -18,17 +20,17 @@ export async function getDecompilationAuthorization(context: vscode.ExtensionCon
     }
 
     // If the terms have been acknowledged, then return whether it was authorized.
-    let decompilationAutorized = context.globalState.get<boolean | undefined>("csharp.decompilationAuthorized");
-    if (decompilationAutorized !== undefined) {
-        return decompilationAutorized;
+    let decompilationAuthorized = context.globalState.get<boolean | undefined>(DecompilationAuthorizedOption);
+    if (decompilationAuthorized !== undefined) {
+        return decompilationAuthorized;
     }
 
     const result = await promptToAcceptDecompilationTerms();
-    decompilationAutorized = result === PromptResult.Yes;
+    decompilationAuthorized = result === PromptResult.Yes;
 
-    await context.globalState.update("csharp.decompilationAuthorized", decompilationAutorized);
+    await context.globalState.update(DecompilationAuthorizedOption, decompilationAuthorized);
 
-    return decompilationAutorized;
+    return decompilationAuthorized;
 }
 
 enum PromptResult {


### PR DESCRIPTION
Store decompilation authorization in the global state instead of the workspace state. 

Resolves #3982