### PR TITLE
Update missing `dotnet` sdk error message

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -106,8 +106,8 @@ function showInstallErrorMessage(eventStream: EventStream) {
 function showDotnetToolsWarning(message: string): void {
     const config = vscode.workspace.getConfiguration('csharp');
     if (!config.get('suppressDotnetInstallWarning', false)) {
-        const getDotNetMessage = 'Get the .NET Core SDK';
-        const goToSettingsMessage = 'Disable this message in user settings';
+        const getDotNetMessage = 'Get the SDK';
+        const goToSettingsMessage = 'Disable message in settings';
         const helpMessage = 'Help';
         // Buttons are shown in right-to-left order, with a close button to the right of everything;
         // getDotNetMessage will be the first button, then goToSettingsMessage, then the close button.


### PR DESCRIPTION
For: https://github.com/OmniSharp/omnisharp-vscode/issues/4771

Current Message:
![image](https://user-images.githubusercontent.com/14852843/133529370-1ca691e2-c928-418d-a884-3bb3ffd55e50.png)
