### PR TITLE
Build fix in `commands.pickProjectAndStart`

### DIFF
--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -81,7 +81,7 @@ async function restartOmniSharp(context: vscode.ExtensionContext, server: OmniSh
 
 async function pickProjectAndStart(server: OmniSharpServer, optionProvider: OptionProvider): Promise<void> {
     let options = optionProvider.GetLatestOptions();
-    return findLaunchTargets(options).then(targets => {
+    return findLaunchTargets(options).then(async targets => {
 
         let currentPath = server.getSolutionPathOrFolder();
         if (currentPath) {


### PR DESCRIPTION
Getting the following without it:

```
npm run compile

> csharp@1.23.15 compile
> tsc -p ./ && gulp tslint

[17:31:43] Requiring external module ts-node/register
[17:31:47] Using gulpfile ~/dev/omnisharp-vscode/gulpfile.ts
[17:31:47] Starting 'tslint'...

ERROR: /Users/tanay/dev/omnisharp-vscode/src/features/commands.ts:84:44 - functions that return promises must be async

[17:31:53] Finished 'tslint' after 5.25 s
```