### PR TITLE
Launch with first Folder or Solution target found

### DIFF
--- a/src/observers/ProjectStatusBarObserver.ts
+++ b/src/observers/ProjectStatusBarObserver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basename, join } from 'path';
+import { basename } from 'path';
 import { BaseEvent, WorkspaceInformationUpdated } from "../omnisharp/loggingEvents";
 import { BaseStatusBarItemObserver } from './BaseStatusBarItemObserver';
 import { EventType } from '../omnisharp/EventType';
@@ -27,22 +27,7 @@ export class ProjectStatusBarObserver extends BaseStatusBarItemObserver {
         let label: string;
         let msbuild = event.info.MsBuild;
         if (msbuild && msbuild.SolutionPath) {
-            if (msbuild.SolutionPath.endsWith(".sln")) {
-                label = basename(msbuild.SolutionPath);
-            }
-            else {
-                // a project file was open, determine which project
-                for (const project of msbuild.Projects) {
-                    // Get the project name.
-                    label = basename(project.Path);
-
-                    // The solution path is the folder containing the open project. Combine it with the
-                    // project name and see if it matches the project's path.
-                    if (join(msbuild.SolutionPath, label) === project.Path) {
-                        break;
-                    }
-                }
-            }
+            label = basename(msbuild.SolutionPath);
             this.SetAndShowStatusBar('$(file-directory) ' + label, 'o.pickProjectAndStart');
         }
         else {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -561,8 +561,8 @@ export class OmniSharpServer {
 
             // To maintain previous behavior when there are mulitple targets available,
             // launch with first Solution or Folder target.
-            const firstFolderOrSolutionTarget = launchTargets.find(target => target.kind == LaunchTargetKind.Folder)
-                ?? launchTargets.find(target => target.kind == LaunchTargetKind.Solution);
+            const firstFolderOrSolutionTarget = launchTargets
+                .find(target => target.kind == LaunchTargetKind.Folder || target.kind == LaunchTargetKind.Solution);
             if (firstFolderOrSolutionTarget) {
                 return this.restart(firstFolderOrSolutionTarget);
             }

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -559,6 +559,14 @@ export class OmniSharpServer {
                 }
             }
 
+            // To maintain previous behavior when there are mulitple targets available,
+            // launch with first Solution or Folder target.
+            const firstFolderOrSolutionTarget = launchTargets.find(target => target.kind == LaunchTargetKind.Folder)
+                ?? launchTargets.find(target => target.kind == LaunchTargetKind.Solution);
+            if (firstFolderOrSolutionTarget) {
+                return this.restart(firstFolderOrSolutionTarget);
+            }
+
             // When running integration tests, open the first launch target.
             if (process.env.RUNNING_INTEGRATION_TESTS === "true") {
                 return this.restart(launchTargets[0]);


### PR DESCRIPTION
When individual projects were added to the Project selector we began showing it more often since there were often multiple targets found in the open folder. This change restores the previous behavior of opening the first Solution or Folder when there are multiple potential launch targets.