### PR TITLE
Improvement to offline packaging

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -22,7 +22,9 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
 
     if (!CoreClrDebugUtil.existsSync(_debugUtil.debugAdapterDir())) {
         let isValidArchitecture: boolean = await checkIsValidArchitecture(platformInformation, eventStream);
-        if (!isValidArchitecture) {
+        // If this is a valid architecture, we should have had a debugger, so warn if we didn't, otherwise
+        // a warning was already issued, so do nothing.
+        if (isValidArchitecture) {
             eventStream.post(new DebuggerPrerequisiteFailure("[ERROR]: C# Extension failed to install the debugger package."));
             showInstallErrorMessage(eventStream);
         }
@@ -41,7 +43,7 @@ async function checkIsValidArchitecture(platformInformation: PlatformInformation
     if (platformInformation) {
         if (platformInformation.isMacOS()) {
             if (platformInformation.architecture === "arm64") {
-                eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: arm64 macOS is not officially supported by the .NET Core debugger. You may experience unexpected issues when running in this configuration.`));
+                eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: arm64 macOS is not officially supported by the .NET debugger. You may experience unexpected issues when running in this configuration.`));
                 return true;
             }
 
@@ -56,7 +58,7 @@ async function checkIsValidArchitecture(platformInformation: PlatformInformation
         }
         else if (platformInformation.isWindows()) {
             if (platformInformation.architecture === "x86") {
-                eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: x86 Windows is not currently supported by the .NET Core debugger. Debugging will not be available.`));
+                eventStream.post(new DebuggerPrerequisiteWarning(`[WARNING]: x86 Windows is not supported by the .NET debugger. Debugging will not be available.`));
                 return false;
             }
 
@@ -85,7 +87,6 @@ async function completeDebuggerInstall(platformInformation: PlatformInformation,
 
             // Write install.complete
             CoreClrDebugUtil.writeEmptyFile(_debugUtil.installCompleteFilePath());
-            vscode.window.setStatusBarMessage('Successfully installed .NET Core Debugger.', 5000);
 
             return true;
         }, (err) => {
@@ -100,7 +101,7 @@ async function completeDebuggerInstall(platformInformation: PlatformInformation,
 
 function showInstallErrorMessage(eventStream: EventStream) {
     eventStream.post(new DebuggerNotInstalledFailure());
-    vscode.window.showErrorMessage("An error occurred during installation of the .NET Core Debugger. The C# extension may need to be reinstalled.");
+    vscode.window.showErrorMessage("An error occurred during installation of the .NET Debugger. The C# extension may need to be reinstalled.");
 }
 
 function showDotnetToolsWarning(message: string): void {

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -4,11 +4,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as debugUtil from '../src/coreclr-debug/util';
 import * as del from 'del';
 import * as fs from 'fs';
 import * as gulp from 'gulp';
 import * as path from 'path';
+import * as util from '../src/common';
 import spawnNode from '../tasks/spawnNode';
 import { codeExtensionPath, offlineVscodeignorePath, vscodeignorePath, vscePath, packedVsixOutputRoot } from '../tasks/projectPaths';
 import { CsharpLoggerObserver } from '../src/observers/CsharpLoggerObserver';
@@ -24,6 +24,13 @@ import { getAbsolutePathPackagesToInstall } from '../src/packageManager/getAbsol
 import { isValidDownload } from '../src/packageManager/isValidDownload';
 
 gulp.task('vsix:offline:package', async () => {
+
+    if (process.platform === 'win32') {
+        throw new Error('Do not build offline packages on windows. Runtime executables will not be marked executable in *nix packages.');
+    }
+
+    await cleanAsync(true);
+
     del.sync(vscodeignorePath);
 
     fs.copyFileSync(offlineVscodeignorePath, vscodeignorePath);
@@ -39,10 +46,10 @@ gulp.task('vsix:offline:package', async () => {
 async function doPackageOffline() {
     if (commandLineOptions.retainVsix) {
         //if user doesnot want to clean up the existing vsix packages
-        cleanSync(false);
+        await cleanAsync(false);
     }
     else {
-        cleanSync(true);
+        await cleanAsync(true);
     }
 
     const packageJSON = getPackageJSON();
@@ -51,36 +58,41 @@ async function doPackageOffline() {
     const packageName = name + '.' + version;
 
     const packages = [
-        new PlatformInformation('win32', 'x86_64'),
-        new PlatformInformation('darwin', 'x86_64'),
-        new PlatformInformation('linux', 'x86_64')
+        { platformInfo: new PlatformInformation('win32', 'x86_64'), id: "win32-x64" },
+        { platformInfo: new PlatformInformation('win32', 'x86'), id: "win32-ia32" },
+        { platformInfo: new PlatformInformation('win32', 'arm64'), id: "win32-arm64" },
+        { platformInfo: new PlatformInformation('linux', 'x86_64'), id: "linux-x64" },
+        { platformInfo: new PlatformInformation('darwin', 'x86_64'), id: "darwin-x64" },
+        { platformInfo: new PlatformInformation('darwin', 'arm64'), id: "darwin-arm64" },
     ];
 
-    for (let platformInfo of packages) {
-        await doOfflinePackage(platformInfo, packageName, packageJSON, packedVsixOutputRoot);
+    for (let p of packages) {
+        try
+        {
+            await doOfflinePackage(p.platformInfo, p.id, packageName, packageJSON, packedVsixOutputRoot);
+        }
+        catch (err)
+        {
+            // NOTE: Extra `\n---` at the end is because gulp will print this message following by the 
+            // stack trace of this line. So that seperates the two stack traces.
+            throw Error(`Failed to create package ${p.id}. ${err.stack ?? err ?? '<unknown error>'}\n---`);
+        }
     }
 }
 
-function cleanSync(deleteVsix: boolean) {
-    del.sync('install.*');
-    del.sync('.omnisharp*');
-    del.sync('.debugger');
-    del.sync('.razor');
+async function cleanAsync(deleteVsix: boolean) {
+    await del([ 'install.*', '.omnisharp*', '.debugger', '.razor']);
 
     if (deleteVsix) {
-        del.sync('*.vsix');
+        await del('*.vsix');
     }
 }
 
-async function doOfflinePackage(platformInfo: PlatformInformation, packageName: string, packageJSON: any, outputFolder: string) {
-    if (process.platform === 'win32') {
-        throw new Error('Do not build offline packages on windows. Runtime executables will not be marked executable in *nix packages.');
-    }
-
-    cleanSync(false);
-    const packageFileName = `${packageName}-${platformInfo.platform}-${platformInfo.architecture}.vsix`;
+async function doOfflinePackage(platformInfo: PlatformInformation, vscodePlatformId: string, packageName: string, packageJSON: any, outputFolder: string) {
+    await cleanAsync(false);
+    const packageFileName = `${packageName}-${vscodePlatformId}.vsix`;
     await install(platformInfo, packageJSON);
-    await doPackageSync(packageFileName, outputFolder);
+    await createPackageAsync(packageFileName, outputFolder, vscodePlatformId);
 }
 
 // Install Tasks
@@ -89,18 +101,29 @@ async function install(platformInfo: PlatformInformation, packageJSON: any) {
     const logger = new Logger(message => process.stdout.write(message));
     let stdoutObserver = new CsharpLoggerObserver(logger);
     eventStream.subscribe(stdoutObserver.post);
-    const debuggerUtil = new debugUtil.CoreClrDebugUtil(path.resolve('.'));
     let runTimeDependencies = getRuntimeDependenciesPackages(packageJSON);
     let packagesToInstall = await getAbsolutePathPackagesToInstall(runTimeDependencies, platformInfo, codeExtensionPath);
     let provider = () => new NetworkSettings(undefined, undefined);
-    await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload);
-    await debugUtil.CoreClrDebugUtil.writeEmptyFile(debuggerUtil.installCompleteFilePath());
+    if (!(await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload)))
+    {
+        throw Error("Failed to download package.");
+    }
+
+    // The VSIX Format doesn't allow files that differ only my case. The Linux OmniSharp package had a lowercase version of these files ('.targets') targets from mono,
+    // and an upper case ('.Targets') from Microsoft.Build.Runtime. Remove the lowercase versions.
+    await del([ '.omnisharp/*/omnisharp/.msbuild/Current/Bin/Workflow.targets', '.omnisharp/*/omnisharp/.msbuild/Current/Bin/Workflow.VisualBasic.targets' ]);
 }
 
 /// Packaging (VSIX) Tasks
-async function doPackageSync(packageName: string, outputFolder: string) {
+async function createPackageAsync(packageName: string, outputFolder: string, vscodePlatformId: string) {
 
     let vsceArgs = [];
+    let packagePath = undefined;
+
+    if (!(await util.fileExists(vscePath))) {
+        throw new Error(`vsce does not exist at expected location: '${vscePath}'`);
+    }
+
     vsceArgs.push(vscePath);
     vsceArgs.push('package'); // package command
 
@@ -108,12 +131,22 @@ async function doPackageSync(packageName: string, outputFolder: string) {
         vsceArgs.push('-o');
         if (outputFolder) {
             //if we have specified an output folder then put the files in that output folder
-            vsceArgs.push(path.join(outputFolder, packageName));
+            packagePath = path.join(outputFolder, packageName);
+            vsceArgs.push(packagePath);
         }
         else {
             vsceArgs.push(packageName);
         }
     }
 
-    return spawnNode(vsceArgs);
+    const spawnResult = await spawnNode(vsceArgs);
+    if (spawnResult.code != 0) {
+        throw new Error(`'${vsceArgs.join(' ')}' failed with code ${spawnResult.code}.`);
+    }
+
+    if (packagePath) {
+        if (!(await util.fileExists(packagePath))) {
+            throw new Error(`vsce failed to create: '${packagePath}'`);
+        }
+    }
 }

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -109,7 +109,7 @@ async function install(platformInfo: PlatformInformation, packageJSON: any) {
         throw Error("Failed to download package.");
     }
 
-    // The VSIX Format doesn't allow files that differ only my case. The Linux OmniSharp package had a lowercase version of these files ('.targets') targets from mono,
+    // The VSIX Format doesn't allow files that differ only by case. The Linux OmniSharp package had a lowercase version of these files ('.targets') targets from mono,
     // and an upper case ('.Targets') from Microsoft.Build.Runtime. Remove the lowercase versions.
     await del([ '.omnisharp/*/omnisharp/.msbuild/Current/Bin/Workflow.targets', '.omnisharp/*/omnisharp/.msbuild/Current/Bin/Workflow.VisualBasic.targets' ]);
 }


### PR DESCRIPTION
This PR makes various improvements to our offline package support in preparation for switching to that as our primary means of distribution.

More significant changes:
1. Added support for the missing supported platforms
2. Switched to using the same schema as VS Code for the names of platforms
3. Stop dropping the debugger install complete file. The install complete file is used to do some first run OS validation logic, so it should not have been dropped by the offline installer.
4. Lots of error handling improvements:
    * Add a try/catch around `doOfflinePackage` so we could know which package failed
    * Detect and fail if a package download fails
    * Detect and fail if the vsce process exits with a non-zero exit code
    * Detect and fail if the vsce process fails to create the file we expect it to
5. Fix offline package creation on Linux-x64. This would fail due to multiple files with the same name but different casing.
6. Fix incorrect check in debugger activation code

A few minor changes too:
1. Used more async APIs
2. Move the win32 check up to the start instead of failing each package
3. All the debugger references were to the '.NET Core' debugger and I dropped the 'Core' from this.