### PR TITLE
Update Debugger Labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1062,7 +1062,7 @@
     "debuggers": [
       {
         "type": "coreclr",
-        "label": ".NET Core",
+        "label": ".NET 5+ and .NET Core",
         "languages": [
           "csharp",
           "razor",
@@ -2168,7 +2168,7 @@
       },
       {
         "type": "clr",
-        "label": ".NET",
+        "label": ".NET Framework 4.x (Windows only)",
         "languages": [
           "csharp",
           "razor",


### PR DESCRIPTION
This PR updates the debugger labels to be:

`.NET Core` -> `.NET 5+ and .NET Core`
`.NET` -> `.NET Framework 4.x (Windows only)`

This is what users will see if they F5 without `tasks.json` or `launch.json`
![image](https://user-images.githubusercontent.com/3953714/136111524-ef3cf772-5335-4ab3-b809-31c5aa20701a.png)
