### PR TITLE
Add option to filter diagnostics out of the FixAll list

### DIFF
--- a/package.json
+++ b/package.json
@@ -682,6 +682,14 @@
           "default": true,
           "description": "Suppress 'hidden' diagnostics (such as 'unnecessary using directives') from appearing in the editor or the Problems pane."
         },
+        "csharp.fixAll.filteredDiagnostics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Array of diagnostic ids which FixAll should ignore."
+        },
         "csharp.referencesCodeLens.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -101,7 +101,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables.add(vscode.languages.registerCodeActionsProvider(documentSelector, codeActionProvider));
         // Since the FixAllProviders registers its own commands, we must instantiate it and add it to the localDisposables
         // so that it will be cleaned up if OmniSharp is restarted.
-        const fixAllProvider = new FixAllProvider(server, languageMiddlewareFeature);
+        const fixAllProvider = new FixAllProvider(server, optionProvider, languageMiddlewareFeature);
         localDisposables.add(fixAllProvider);
         localDisposables.add(vscode.languages.registerCodeActionsProvider(documentSelector, fixAllProvider, FixAllProvider.metadata));
         localDisposables.add(reportDiagnostics(server, advisor, languageMiddlewareFeature));

--- a/src/omnisharp/options.ts
+++ b/src/omnisharp/options.ts
@@ -21,6 +21,7 @@ export class Options {
         public showTestsCodeLens: boolean,
         public filteredSymbolsCodeLens: string[],
         public disableCodeActions: boolean,
+        public filteredDiagnosticsFixAll: Set<string>,
         public disableMSBuildDiagnosticWarning: boolean,
         public showOmnisharpLogOnError: boolean,
         public minFindSymbolsFilterLength: number,
@@ -88,6 +89,11 @@ export class Options {
         const useSemanticHighlighting = csharpConfig.get<boolean>('semanticHighlighting.enabled', false);
 
         const disableCodeActions = csharpConfig.get<boolean>('disableCodeActions', false);
+        const filteredDiagnosticsFixAllArray = csharpConfig.get<string[]>('fixAll.filteredDiagnostics', []);
+        const filteredDiagnosticsFixAll = filteredDiagnosticsFixAllArray.reduce((set, diagnosticId) => {
+            set.add(diagnosticId.toLowerCase());
+            return set;
+        }, new Set<string>());
 
         const disableMSBuildDiagnosticWarning = omnisharpConfig.get<boolean>('disableMSBuildDiagnosticWarning', false);
 
@@ -121,6 +127,7 @@ export class Options {
             showTestsCodeLens,
             filteredSymbolsCodeLens,
             disableCodeActions,
+            filteredDiagnosticsFixAll,
             disableMSBuildDiagnosticWarning,
             showOmnisharpLogOnError,
             minFindSymbolsFilterLength,

--- a/test/unitTests/Fakes/FakeOptions.ts
+++ b/test/unitTests/Fakes/FakeOptions.ts
@@ -6,5 +6,5 @@
 import { Options } from "../../../src/omnisharp/options";
 
 export function getEmptyOptions(): Options {
-    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, [], false, false, false, 0, 0, false, false, false, false, false, false, false, false, undefined, "", "");
+    return new Options("", "", false, "", false, 0, 0, false, false, false, false, false, [], false, new Set(), false, false, 0, 0, false, false, false, false, false, false, false, false, undefined, "", "");
 }


### PR DESCRIPTION
Addresses https://github.com/OmniSharp/omnisharp-roslyn/issues/2231

Not all Code Action are desired when FixAll is applied. Allow users to configure a set of diagnostic ids to filter out of FixAll operations.