### PR TITLE
Add `CimAttachItemsProvider` to replace `WmicAttachItemsProvider`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -215,11 +215,10 @@ export function isSubfolderOf(subfolder: string, folder: string): boolean {
  */
  export function findPowerShell(): string | undefined {
     const dirs: string[] = (process.env.PATH || '').replace(/"+/g, '').split(';').filter(x => x);
-    const exts: string[] = (process.env.PATHEXT || '').split(';');
-    const names: string[] = ['pwsh', 'powershell'];
+    const names: string[] = ['pwsh.exe', 'powershell.exe'];
     for (const name of names) {
         const candidates: string[] = dirs.reduce<string[]>((paths, dir) => [
-            ...paths, ...exts.map(ext => path.join(dir, name + ext))
+            ...paths, path.join(dir, name)
         ], []);
         for (const candidate of candidates) {
             try {

--- a/src/features/processPicker.ts
+++ b/src/features/processPicker.ts
@@ -427,9 +427,6 @@ export class PsOutputParser {
 export class CimAttachItemsProvider extends DotNetAttachItemsProvider {
     constructor(private pwsh: string) { super(); }
 
-    // Perf numbers on Win10:
-    // TODO
-
     protected async getInternalProcessEntries(): Promise<Process[]> {
         const pwshCommand: string = `${this.pwsh} -NoProfile -Command`;
         const cimCommand: string = 'Get-CimInstance Win32_Process | Select-Object Name,ProcessId,CommandLine | ConvertTo-JSON';

--- a/test/featureTests/processPicker.test.ts
+++ b/test/featureTests/processPicker.test.ts
@@ -185,6 +185,8 @@ suite("Remote Process Picker: Validate quoting arguments.", () => {
 
         const parsedOutput: Process[] = CimProcessParser.ParseProcessFromCim(cimOutput);
 
+        parsedOutput.length.should.equal(4);
+
         const process1: Process = parsedOutput[0];
         const process2: Process = parsedOutput[1];
         const process3: Process = parsedOutput[2];


### PR DESCRIPTION
Add `CimAttachItemsProvider` to retrieve processes with `Get-CimInstance
Win32_Process` if powershell is found in `PATH`.

Keeping `WmicAttachItemsProvider` if finding powershell fails.

Adapted from @eternalphane work in the VSCode C/C++ Extension: https://github.com/microsoft/vscode-cpptools/pull/8329