### PR TITLE
Add '--target' when creating platform-specific .vsix's

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "tslint-no-unused-expression-chai": "0.1.4",
     "typescript": "4.2.4",
     "unzipper": "0.10.11",
-    "vsce": "1.57.0",
+    "vsce": "1.100.2",
     "vscode-test": "1.5.2",
     "webpack": "5.34.0",
     "webpack-cli": "4.6.0"
@@ -398,7 +398,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.58.0"
+    "vscode": "^1.61.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -131,6 +131,11 @@ async function createPackageAsync(packageName: string, outputFolder: string, vsc
         else {
             vsceArgs.push(packageName);
         }
+
+        if (vscodePlatformId !== undefined) {
+            vsceArgs.push("--target");
+            vsceArgs.push(vscodePlatformId);
+        }
     }
 
     const spawnResult = await spawnNode(vsceArgs);

--- a/tasks/projectPaths.ts
+++ b/tasks/projectPaths.ts
@@ -13,7 +13,7 @@ export const offlineVscodeignorePath = path.join(rootPath, 'offline.vscodeignore
 export const onlineVscodeignorePath = path.join(rootPath, 'release.vscodeignore');
 
 export const nodeModulesPath = path.join(rootPath, 'node_modules');
-export const vscePath = path.join(nodeModulesPath, 'vsce', 'out', 'vsce');
+export const vscePath = path.join(nodeModulesPath, 'vsce', 'vsce');
 export const mochaPath = path.join(nodeModulesPath, 'mocha', 'bin', 'mocha');
 
 export const packageJsonPath = path.join(rootPath, "package.json");


### PR DESCRIPTION
This PR is hopefully the penultimate step before the C# extension can switch to pushing platform specific .vsix's to the gallery. With this PR we are adding the `--target` argument when calling vsce.