### PR TITLE
Change official builds to use platform-specific VSIXs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Compile
       run: npm run compile
 
-    - name: Build extension package
-      run: gulp 'vsix:release:package'
+    - name: Build platform-neutral extension package
+      run: gulp 'vsix:release:package:platform-neutral'
 
     - name: Run unit and integration tests
       run: |
@@ -45,3 +45,6 @@ jobs:
       env:
         CODE_VERSION: 1.45.0
         DISPLAY: :99.0
+
+    - name: Build platform-specific extension package
+      run: gulp 'vsix:release:package:platform-specific'

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -22,7 +22,7 @@ jobs:
           npm i -g gulp
 
     - name: Build extension package
-      run: gulp 'vsix:release:package'
+      run: gulp 'vsix:release:package:platform-specific'
 
     - name: Run release tests
       run: npm run test:release
@@ -30,13 +30,68 @@ jobs:
     - name: Get package version
       run: node -e "console.log('VERSION=' + require('./package.json').version)" >> $GITHUB_ENV
 
-    - name: Upload release build
+    - name: Upload release build (darwin-arm64)
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./csharp-${{ env.VERSION }}.vsix
-        asset_name: csharp-${{ env.VERSION }}.vsix
+        asset_path: ./csharp-${{ env.VERSION }}-(darwin-arm64).vsix
+        asset_name: csharp-${{ env.VERSION }}-(darwin-arm64).vsix
+        asset_content_type: application/zip
+
+    - name: Upload release build (darwin-x64)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./csharp-${{ env.VERSION }}-(darwin-x64).vsix
+        asset_name: csharp-${{ env.VERSION }}-(darwin-x64).vsix
+        asset_content_type: application/zip
+
+    - name: Upload release build (linux-x64)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./csharp-${{ env.VERSION }}-(linux-x64).vsix
+        asset_name: csharp-${{ env.VERSION }}-(linux-x64).vsix
+        asset_content_type: application/zip
+
+    - name: Upload release build (win32-arm64)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./csharp-${{ env.VERSION }}-(win32-arm64).vsix
+        asset_name: csharp-${{ env.VERSION }}-(win32-arm64).vsix
+        asset_content_type: application/zip
+
+    - name: Upload release build (win32-ia32)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./csharp-${{ env.VERSION }}-(win32-ia32).vsix
+        asset_name: csharp-${{ env.VERSION }}-(win32-ia32).vsix
+        asset_content_type: application/zip
+
+    - name: Upload release build (win32-x64)
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./csharp-${{ env.VERSION }}-(win32-x64).vsix
+        asset_name: csharp-${{ env.VERSION }}-(win32-x64).vsix
         asset_content_type: application/zip

--- a/tasks/backcompatTasks.ts
+++ b/tasks/backcompatTasks.ts
@@ -5,4 +5,5 @@
 
 import * as gulp from 'gulp';
 
-gulp.task('package:offline', gulp.series('vsix:offline:package'));
+gulp.task('package:offline', gulp.series('vsix:release:package:platform-specific'));
+gulp.task('vsix:offline:package', gulp.series('vsix:release:package:platform-specific'));

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -38,7 +38,7 @@ export function getPackageName(packageJSON: any, vscodePlatformId: string) {
     return `${name}.${version}-${vscodePlatformId}.vsix`;
 }
 
-gulp.task('vsix:offline:package', async () => {
+gulp.task('vsix:release:package:platform-specific', async () => {
 
     if (process.platform === 'win32') {
         throw new Error('Do not build offline packages on windows. Runtime executables will not be marked executable in *nix packages.');

--- a/tasks/onlinePackagingTasks.ts
+++ b/tasks/onlinePackagingTasks.ts
@@ -21,7 +21,7 @@ gulp.task('vsix:release:unpackage', () => {
     return fs.createReadStream(packageName).pipe(Extract({ path: unpackedVsixPath }));
 });
 
-gulp.task('vsix:release:package', async (onError) => {
+gulp.task('vsix:release:package:platform-neutral', async (onError) => {
     del.sync(vscodeignorePath);
 
     fs.copyFileSync(onlineVscodeignorePath, vscodeignorePath);


### PR DESCRIPTION
This PR hopefully completes the work to switch to platform-specific VSIXs. This renames the gulp tasks to give better names and changes the official builds to use the new tasks.