### PR TITLE
Add targetArch to Attach and documentation

### DIFF
--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -309,3 +309,17 @@ To disable Source Link for all URLs, use `"sourceLinkOptions": { "*": { "enabled
 If multiple entries cover the same URL, the more specific entry (the entry with the longer string length) will be used.
 
 Currently Source Link only works for source files that can be accessed without authentication. So, for example, the debugger can download source files from open source projects on GitHub, but it cannot download from private GitHub repos, or from Visual Studio Team Services.
+
+## Target Architecture options (macOS M1)
+
+.NET on Apple M1 supports both x86_64 and ARM64. When debugging, the architecture of the process the debugger is attaching to and the debugger must match. If they do not match, it may result in `Unknown Error: 0x80131c3c`.
+
+The extension will try to resolve `targetArchitecture` based on the output of `dotnet --info` in the PATH, else it will try to use the same architecture as VS Code.
+
+You can override this behavior by setting `targetArchitecture` in your `launch.json`.
+
+Example:
+
+```json
+    "targetArchitecture": "arm64"
+```

--- a/package.json
+++ b/package.json
@@ -659,6 +659,10 @@
               "description": "When true (the default state), the debugger will attempt faster evaluation by simulating execution of simple properties and methods.",
               "default": true
             },
+            "targetArchitecture": {
+              "type": "string",
+              "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+            },
             "type": {
               "type": "string",
               "enum": [
@@ -2113,6 +2117,10 @@
                 "type": "boolean",
                 "description": "When true (the default state), the debugger will attempt faster evaluation by simulating execution of simple properties and methods.",
                 "default": true
+              },
+              "targetArchitecture": {
+                "type": "string",
+                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               }
             }
           }
@@ -3236,6 +3244,10 @@
                 "type": "boolean",
                 "description": "When true (the default state), the debugger will attempt faster evaluation by simulating execution of simple properties and methods.",
                 "default": true
+              },
+              "targetArchitecture": {
+                "type": "string",
+                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               }
             }
           }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -491,6 +491,10 @@
           "type": "boolean",
           "description": "When true (the default state), the debugger will attempt faster evaluation by simulating execution of simple properties and methods.",
           "default": true
+        },
+        "targetArchitecture": {
+          "type": "string",
+          "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
         }
       }
     },


### PR DESCRIPTION
This PR updates `OptionsSchema.json` and `debugger-launchjson.md` for the launch option `targetArchitecture`.

#4900