### PR TITLE
Improved Regex syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3598,6 +3598,38 @@
       {
         "id": "xmlDocCommentText",
         "description": ""
+      },
+      {
+        "id": "regexComment",
+        "description": ""
+      },
+      {
+        "id": "regexCharacterClass",
+        "description": ""
+      },
+      {
+        "id": "regexAnchor",
+        "description": ""
+      },
+      {
+        "id": "regexQuantifier",
+        "description": ""
+      },
+      {
+        "id": "regexGrouping",
+        "description": ""
+      },
+      {
+        "id": "regexAlternation",
+        "description": ""
+      },
+      {
+        "id": "regexSelfEscapedCharacter",
+        "description": ""
+      },
+      {
+        "id": "regexOtherEscape",
+        "description": ""
       }
     ],
     "semanticTokenModifiers": [],
@@ -3735,6 +3767,40 @@
           ],
           "xmlDocCommentText": [
             "comment.documentation.cs"
+          ],
+          "regexComment": [
+            "string.regexp.comment.cs"
+          ],
+          "regexCharacterClass": [
+            "constant.character.character-class.regexp.cs",
+            "constant.other.character-class.set.regexp.cs",
+            "constant.other.character-class.regexp.cs",
+            "constant.character.set.regexp.cs"
+          ],
+          "regexAnchor": [
+            "keyword.control.anchor.regexp.cs"
+          ],
+          "regexQuantifier": [
+            "keyword.operator.quantifier.regexp.cs"
+          ],
+          "regexGrouping": [
+            "punctuation.definition.group.regexp.cs",
+            "punctuation.definition.group.assertion.regexp.cs",
+            "punctuation.definition.character-class.regexp.cs",
+            "punctuation.character.set.begin.regexp.cs",
+            "punctuation.character.set.end.regexp.cs",
+            "keyword.operator.negation.regexp.cs",
+            "support.other.parenthesis.regexp.cs"
+          ],
+          "regexAlternation": [
+            "keyword.operator.or.regexp.cs",
+            "keyword.control.anchor.regexp.cs"
+          ],
+          "regexSelfEscapedCharacter": [
+            "string.regexp.self-escaped-character.cs"
+          ],
+          "regexOtherEscape": [
+            "string.regexp.other-escape.cs"
           ]
         }
       }

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -64,6 +64,14 @@ enum CustomTokenType {
     xmlDocCommentName,
     xmlDocCommentProcessingInstruction,
     xmlDocCommentText,
+    regexComment,
+    regexCharacterClass,
+    regexAnchor,
+    regexQuantifier,
+    regexGrouping,
+    regexAlternation,
+    regexSelfEscapedCharacter,
+    regexOtherEscape,
 }
 
 // The default TokenModifiers defined by VS Code https://github.com/microsoft/vscode/blob/master/src/vs/platform/theme/common/tokenClassificationRegistry.ts#L393
@@ -281,6 +289,14 @@ tokenTypes[CustomTokenType.xmlDocCommentEntityReference] = "xmlDocCommentEntityR
 tokenTypes[CustomTokenType.xmlDocCommentName] = "xmlDocCommentName";
 tokenTypes[CustomTokenType.xmlDocCommentProcessingInstruction] = "xmlDocCommentProcessingInstruction";
 tokenTypes[CustomTokenType.xmlDocCommentText] = "xmlDocCommentText";
+tokenTypes[CustomTokenType.regexComment] = "regexComment";
+tokenTypes[CustomTokenType.regexCharacterClass] = "regexCharacterClass";
+tokenTypes[CustomTokenType.regexAnchor] = "regexAnchor";
+tokenTypes[CustomTokenType.regexQuantifier] = "regexQuantifier";
+tokenTypes[CustomTokenType.regexGrouping] = "regexGrouping";
+tokenTypes[CustomTokenType.regexAlternation] = "regexAlternation";
+tokenTypes[CustomTokenType.regexSelfEscapedCharacter] = "regexSelfEscapedCharacter";
+tokenTypes[CustomTokenType.regexOtherEscape] = "regexOtherEscape";
 
 const tokenModifiers: string[] = [];
 tokenModifiers[DefaultTokenModifier.declaration] = 'declaration';
@@ -348,15 +364,15 @@ tokenTypeMap[SemanticHighlightClassification.XmlLiteralEntityReference] = undefi
 tokenTypeMap[SemanticHighlightClassification.XmlLiteralName] = undefined;
 tokenTypeMap[SemanticHighlightClassification.XmlLiteralProcessingInstruction] = undefined;
 tokenTypeMap[SemanticHighlightClassification.XmlLiteralText] = undefined;
-tokenTypeMap[SemanticHighlightClassification.RegexComment] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexCharacterClass] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexAnchor] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexQuantifier] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexGrouping] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexAlternation] = DefaultTokenType.regexp;
+tokenTypeMap[SemanticHighlightClassification.RegexComment] = CustomTokenType.regexComment;
+tokenTypeMap[SemanticHighlightClassification.RegexCharacterClass] = CustomTokenType.regexCharacterClass;
+tokenTypeMap[SemanticHighlightClassification.RegexAnchor] = CustomTokenType.regexAnchor;
+tokenTypeMap[SemanticHighlightClassification.RegexQuantifier] = CustomTokenType.regexQuantifier;
+tokenTypeMap[SemanticHighlightClassification.RegexGrouping] = CustomTokenType.regexGrouping;
+tokenTypeMap[SemanticHighlightClassification.RegexAlternation] = CustomTokenType.regexAlternation;
 tokenTypeMap[SemanticHighlightClassification.RegexText] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexSelfEscapedCharacter] = DefaultTokenType.regexp;
-tokenTypeMap[SemanticHighlightClassification.RegexOtherEscape] = DefaultTokenType.regexp;
+tokenTypeMap[SemanticHighlightClassification.RegexSelfEscapedCharacter] = CustomTokenType.regexSelfEscapedCharacter;
+tokenTypeMap[SemanticHighlightClassification.RegexOtherEscape] = CustomTokenType.regexOtherEscape;
 
 const tokenModifierMap: number[] = [];
 tokenModifierMap[SemanticHighlightModifier.Static] = 2 ** DefaultTokenModifier.static;


### PR DESCRIPTION
Improves semantic highlighting of regex by utilizing Roslyn data that was previously unused.
This "breaks" themes that only style the `regexp` token because new specialized token types were added. 