### PR TITLE
Provide a friendly name for the Razor language

### DIFF
--- a/package.json
+++ b/package.json
@@ -3749,7 +3749,10 @@
         "mimetypes": [
           "text/x-cshtml"
         ],
-        "configuration": "./src/razor/language-configuration.json"
+        "configuration": "./src/razor/language-configuration.json",
+        "aliases": [
+          "ASP.NET Razor"
+        ]
       }
     ],
     "grammars": [


### PR DESCRIPTION
Instead of showing "aspnetcorerazor" in the language picker and status bar, show the much more user-friendly "ASP.NET Razor". The alias was chosen based on the value of the `name` property in the `aspnetcorerazor.tmLanguage.json` file.
![ASP.NET Razor](https://user-images.githubusercontent.com/2766036/142699641-26a2f944-1b5a-4aea-869e-4f19a9ee3792.png)