### PR TITLE
Label optional dependencies as external

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,9 @@ const config = {
     },
     devtool: 'source-map',
     externals: {
-        vscode: "commonjs vscode" // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+        vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+        'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics', // we're not native
+        '@opentelemetry/tracing': 'commonjs @opentelemetry/tracing', // optional
     },
     resolve: { // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
         extensions: ['.ts', '.js']


### PR DESCRIPTION
Silences two useless errors. This is taken from the Webpack config in [microsoft/azure-pipelines-vscode](https://github.com/microsoft/azure-pipelines-vscode), which as a disclaimer, I also wrote.

Before:
```
> csharp@1.23.18 compileDev
> tsc -p ./ && gulp tslint && webpack --mode development

[17:39:15] Requiring external module ts-node/register
[17:39:19] Using gulpfile ~\repos\omnisharp-vscode\gulpfile.ts
[17:39:19] Starting 'tslint'...
[17:39:26] Finished 'tslint' after 6.23 s
asset extension.js 3.54 MiB [emitted] (name: main) 1 related asset
runtime modules 670 bytes 3 modules
modules by path ./node_modules/ 2.41 MiB
  cacheable modules 2.41 MiB
    javascript modules 2.41 MiB 529 modules
    json modules 1.82 KiB 3 modules
  modules by path ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*//lib// 320 bytes
    ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*\/lib\/Connection$ 160 bytes [built] [code generated]
    ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*\/lib\/Pool$ 160 bytes [built] [code generated]
  ./node_modules/vscode-nls/lib/ sync 160 bytes [built] [code generated]
modules by path ./src/ 599 KiB 110 modules
25 modules

WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js 49:44-89
Module not found: Error: Can't resolve 'applicationinsights-native-metrics' in 'C:\Users\Winston\repos\omnisharp-vscode\node_modules\applicationinsights\out\AutoCollection'
 @ ./node_modules/applicationinsights/out/applicationinsights.js 12:26-71
 @ ./node_modules/vscode-extension-telemetry/lib/telemetryReporter.js 11:18-48
 @ ./src/main.ts 36:37-74

WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js 24:26-71
Module not found: Error: Can't resolve '@opentelemetry/tracing' in 'C:\Users\Winston\repos\omnisharp-vscode\node_modules\diagnostic-channel-publishers\dist\src'
 @ ./node_modules/diagnostic-channel-publishers/dist/src/index.js 5:15-49
 @ ./node_modules/applicationinsights/out/AutoCollection/diagnostic-channel/initialization.js 9:21-61
 @ ./node_modules/applicationinsights/out/AutoCollection/Console.js 2:18-64
 @ ./node_modules/applicationinsights/out/applicationinsights.js 4:25-60
 @ ./node_modules/vscode-extension-telemetry/lib/telemetryReporter.js 11:18-48
 @ ./src/main.ts 36:37-74

...a bunch of warnings about vscode-nls...

8 warnings have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.34.0 compiled with 8 warnings in 16171 ms
```

After:
```
> csharp@1.23.18 compileDev
> tsc -p ./ && gulp tslint && webpack --mode development

[17:35:07] Requiring external module ts-node/register
[17:35:12] Using gulpfile ~\repos\omnisharp-vscode\gulpfile.ts
[17:35:12] Starting 'tslint'...
[17:35:18] Finished 'tslint' after 6.32 s
asset extension.js 3.54 MiB [emitted] (name: main) 1 related asset
runtime modules 670 bytes 3 modules
modules by path ./node_modules/ 2.41 MiB
  cacheable modules 2.41 MiB 532 modules
  modules by path ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*//lib// 320 bytes
    ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*\/lib\/Connection$ 160 bytes [built] [code generated]
    ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*\/lib\/Pool$ 160 bytes [built] [code generated]
  ./node_modules/vscode-nls/lib/ sync 160 bytes [built] [code generated]
modules by path ./src/ 599 KiB 106 modules
optional modules 84 bytes [optional]
  external "applicationinsights-native-metrics" 42 bytes [optional] [built] [code generated]
  external "@opentelemetry/tracing" 42 bytes [optional] [built] [code generated]
25 modules

...a bunch of warnings about vscode-nls...

webpack 5.34.0 compiled with 6 warnings in 16822 ms
```