### PR TITLE
Rename LaunchTarget.kind to not conflict with VSCode separators.

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -30,7 +30,7 @@ export interface LaunchTarget {
     description: string;
     directory: string;
     target: string;
-    kind: LaunchTargetKind;
+    workspaceKind: LaunchTargetKind;
 }
 
 export const vslsTarget: LaunchTarget = {
@@ -38,7 +38,7 @@ export const vslsTarget: LaunchTarget = {
     description: "Visual Studio Live Share",
     directory: "",
     target: "",
-    kind: LaunchTargetKind.LiveShare
+    workspaceKind: LaunchTargetKind.LiveShare
 };
 
 /** Live share scheme */
@@ -144,7 +144,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                     description: vscode.workspace.asRelativePath(dirname),
                     target: resource.fsPath,
                     directory: path.dirname(resource.fsPath),
-                    kind: LaunchTargetKind.Solution
+                    workspaceKind: LaunchTargetKind.Solution
                 });
             }
             // Add project.json files
@@ -156,7 +156,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                     description: vscode.workspace.asRelativePath(dirname),
                     target: dirname,
                     directory: dirname,
-                    kind: LaunchTargetKind.ProjectJson
+                    workspaceKind: LaunchTargetKind.ProjectJson
                 });
             }
             // Add .csproj files
@@ -170,7 +170,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                     description: vscode.workspace.asRelativePath(dirname),
                     target: dirname,
                     directory: dirname,
-                    kind: LaunchTargetKind.Project
+                    workspaceKind: LaunchTargetKind.Project
                 });
             }
             else {
@@ -198,7 +198,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                 description: 'All contained projects',
                 target: folderPath,
                 directory: folderPath,
-                kind: LaunchTargetKind.Folder
+                workspaceKind: LaunchTargetKind.Folder
             });
         }
 
@@ -209,7 +209,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                 description: path.basename(folderPath),
                 target: folderPath,
                 directory: folderPath,
-                kind: LaunchTargetKind.Csx
+                workspaceKind: LaunchTargetKind.Csx
             });
         }
 
@@ -220,7 +220,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                 description: path.basename(folderPath),
                 target: folderPath,
                 directory: folderPath,
-                kind: LaunchTargetKind.Cake
+                workspaceKind: LaunchTargetKind.Cake
             });
         }
 
@@ -230,7 +230,7 @@ export function resourcesAndFolderMapToLaunchTargets(resources: vscode.Uri[], wo
                 description: '',
                 target: folderPath,
                 directory: folderPath,
-                kind: LaunchTargetKind.Folder
+                workspaceKind: LaunchTargetKind.Folder
             });
         }
     });

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -256,7 +256,7 @@ export class OmniSharpServer {
             return;
         }
 
-        if (launchTarget.kind === LaunchTargetKind.LiveShare) {
+        if (launchTarget.workspaceKind === LaunchTargetKind.LiveShare) {
             this.eventStream.post(new ObservableEvents.OmnisharpServerMessage("During Live Share sessions language services are provided by the Live Share server."));
             return;
         }
@@ -562,7 +562,7 @@ export class OmniSharpServer {
             // To maintain previous behavior when there are mulitple targets available,
             // launch with first Solution or Folder target.
             const firstFolderOrSolutionTarget = launchTargets
-                .find(target => target.kind == LaunchTargetKind.Folder || target.kind == LaunchTargetKind.Solution);
+                .find(target => target.workspaceKind == LaunchTargetKind.Folder || target.workspaceKind == LaunchTargetKind.Solution);
             if (firstFolderOrSolutionTarget) {
                 return this.restart(firstFolderOrSolutionTarget);
             }

--- a/test/integrationTests/launcher.test.ts
+++ b/test/integrationTests/launcher.test.ts
@@ -47,10 +47,10 @@ suite(`launcher:`, () => {
 
         const launchTargets = resourcesAndFolderMapToLaunchTargets(testResources, workspaceFolders, folderMap);
 
-        const solutionTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Solution && target.label === "test.sln");
+        const solutionTarget = launchTargets.find(target => target.workspaceKind === LaunchTargetKind.Solution && target.label === "test.sln");
         assert.exists(solutionTarget, "Launch targets did not include `/test.sln`");
 
-        const projectTarget = launchTargets.find(target => target.kind === LaunchTargetKind.Project && target.label === "test.csproj");
+        const projectTarget = launchTargets.find(target => target.workspaceKind === LaunchTargetKind.Project && target.label === "test.csproj");
         assert.exists(projectTarget, "Launch targets did not include `/test/test.csproj`");
     });
 });


### PR DESCRIPTION
Resolves https://github.com/OmniSharp/omnisharp-vscode/issues/4907

The new QuickPick Separators feature in VS Code uses a `.kind` property on QuickPickItems which we were also using in our LaunchTarget items. Renamed our property to not conflict.