### PR TITLE
Send document buffer when semantically highlighting old document versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * Use 6.0.100 SDK for building (PR: [omnisharp-roslyn#2269](https://github.com/OmniSharp/omnisharp-roslyn/pull/2269))
   * Added Code of Conduct (PR: [omnisharp-roslyn#2266](https://github.com/OmniSharp/omnisharp-roslyn/pull/2266))
   * Improved Cake/CSX info messages (PR: [omnisharp-roslyn#2264](https://github.com/OmniSharp/omnisharp-roslyn/pull/2264))
+* Send document buffer when semantically highlighting old document versions (PR: [#4915](https://github.com/OmniSharp/omnisharp-vscode/pull/4915))
 * Improved Regex syntax highlighting (PR: [#4902](https://github.com/OmniSharp/omnisharp-vscode/pull/4902))
 * .NET 6 bug fixes ([#4931](https://github.com/OmniSharp/omnisharp-vscode/issues/4931), PR: [#4950](https://github.com/OmniSharp/omnisharp-vscode/pull/4950))
 * Add File-scoped namespace snippet (PR: [#4948](https://github.com/OmniSharp/omnisharp-vscode/pull/4948))

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You can also use the .NET 6 build of OmniSharp which runs on the .NET 6 SDK. See
   * Use 6.0.100 SDK for building (PR: [omnisharp-roslyn#2269](https://github.com/OmniSharp/omnisharp-roslyn/pull/2269))
   * Added Code of Conduct (PR: [omnisharp-roslyn#2266](https://github.com/OmniSharp/omnisharp-roslyn/pull/2266))
   * Improved Cake/CSX info messages (PR: [omnisharp-roslyn#2264](https://github.com/OmniSharp/omnisharp-roslyn/pull/2264))
+* Send document buffer when semantically highlighting old document versions (PR: [#4915](https://github.com/OmniSharp/omnisharp-vscode/pull/4915))
 * Improved Regex syntax highlighting (PR: [#4902](https://github.com/OmniSharp/omnisharp-vscode/pull/4902))
 * .NET 6 bug fixes ([#4931](https://github.com/OmniSharp/omnisharp-vscode/issues/4931), PR: [#4950](https://github.com/OmniSharp/omnisharp-vscode/pull/4950))
 * Add File-scoped namespace snippet (PR: [#4948](https://github.com/OmniSharp/omnisharp-vscode/pull/4948))

--- a/package.json
+++ b/package.json
@@ -842,7 +842,7 @@
         },
         "csharp.semanticHighlighting.enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable/disable Semantic Highlighting for C# files (Razor files currently unsupported). Defaults to false. Close open files for changes to take effect.",
           "scope": "window"
         },

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -198,6 +198,14 @@ export default class SemanticTokensProvider extends AbstractProvider implements 
         let req = createRequest<protocol.V2.SemanticHighlightRequest>(document, new vscode.Position(0, 0));
         req.Range = range;
 
+
+        // We need to include the document contents in our request when we are highlighting a version of the document other than the current version, such as in the Diff view.
+        const currentDocument = vscode.workspace.textDocuments.find(d => d.fileName === document.fileName);
+        const isCurrentVersion = currentDocument?.version === document.version;
+        if (!isCurrentVersion) {
+            req.VersionedText = document.getText();
+        }
+
         const versionBeforeRequest = document.version;
 
         const response = await serverUtils.getSemanticHighlights(this._server, req);

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -610,6 +610,7 @@ export namespace V2 {
 
     export interface SemanticHighlightRequest extends Request {
         Range?: Range;
+        VersionedText?: string;
     }
 
     export interface SemanticHighlightResponse {


### PR DESCRIPTION
Enables Semantic Highlighting by default.

Before:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/611219/143950276-3b0ef2c1-6460-4ace-8596-3f5dfcc99857.png">

After:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/611219/143950342-89ec5a39-220c-4484-8931-3d91c9c6b020.png">
