### PR TITLE
Add short namespace snippet (.NET 6)

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -302,12 +302,12 @@
         ],
         "description": "Namespace"
     },
-    "ShortNamespace": {
-        "prefix": "snamespace",
+    "FileScopedNamespace": {
+        "prefix": "fsnamespace",
         "body": [
             "namespace ${1:Name};"
         ],
-        "description": "Short namespace (.NET 6)"
+        "description": "File-scoped namespace"
     },
     "#if": {
         "prefix": "ifd",

--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -302,6 +302,13 @@
         ],
         "description": "Namespace"
     },
+    "ShortNamespace": {
+        "prefix": "snamespace",
+        "body": [
+            "namespace ${1:Name};"
+        ],
+        "description": "Short namespace (.NET 6)"
+    },
     "#if": {
         "prefix": "ifd",
         "body": [


### PR DESCRIPTION
When C# 10 released, new cleaner way to implement `namespace` was [added](https://docs.microsoft.com/pl-pl/dotnet/csharp/fundamentals/types/namespaces). To activate this snippet type `snamespace` and press enter.