### PR TITLE
Remove obsolete settings checks for Blazor debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1055,11 +1055,6 @@
           "scope": "window",
           "default": true,
           "description": "Enable/disable default Razor formatter."
-        },
-        "razor.disableBlazorDebugPrompt": {
-          "type": "boolean",
-          "default": false,
-          "description": "Disable Blazor WebAssembly's debug requirements notification."
         }
       }
     },

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -105,6 +105,7 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
         }
 
         if (blazorWebAssemblyProjectFound && !vscode.extensions.getExtension('ms-dotnettools.blazorwasm-companion')) {
+            // No need to await this call, we don't depend on the prompt being shown.
             showBlazorDebuggingExtensionPrompt(server);
         }
     }
@@ -248,18 +249,16 @@ function isWebProject(project: MSBuildProject): boolean {
     return projectFileText.toLowerCase().indexOf('sdk="microsoft.net.sdk.web"') >= 0;
 }
 
-function showBlazorDebuggingExtensionPrompt(server: OmniSharpServer) {
+async function showBlazorDebuggingExtensionPrompt(server: OmniSharpServer) {
     const promptShownKey = 'blazor_debugging_extension_prompt_shown';
     if (!server.sessionProperties[promptShownKey]) {
         server.sessionProperties[promptShownKey] = true;
 
         const msg = 'The Blazor WASM Debugging Extension is required to debug Blazor WASM apps in VS Code.';
-        vscode.window.showInformationMessage(msg, 'Install Extension', 'Close')
-            .then(async result => {
-                if (result === 'Install Extension') {
-                    const uriToOpen = vscode.Uri.parse('vscode:extension/ms-dotnettools.blazorwasm-companion');
-                    await vscode.commands.executeCommand('vscode.open', uriToOpen);
-                }
-            });
+        const result = await vscode.window.showInformationMessage(msg, 'Install Extension', 'Close');
+        if (result === 'Install Extension') {
+            const uriToOpen = vscode.Uri.parse('vscode:extension/ms-dotnettools.blazorwasm-companion');
+            await vscode.commands.executeCommand('vscode.open', uriToOpen);
+        }
     }
 }


### PR DESCRIPTION
The extension currently displays false positive prompts that "Additional setup is required to debug Blazor WebAssembly applications" because it's looking for configuration settings that no longer exist. Remove them all, and in the process, streamline the check to only look for the existence of the companion extension.

### Details
The extension currently determines if a Blazor workspace is ready for Blazor debugging if:
1. The Blazor companion extension is installed, AND
2. The `debug.javascript.usePreview` setting is true, OR
3. The `debug.node.useV3` AND `debug.chrome.useV3` settings are true.

However,
* `debug.javascript.usePreview` was removed in VS Code 1.60 along with the old debugger: https://code.visualstudio.com/updates/v1_60#_javascript-debugging
* The legacy node-debug extension was also removed in 1.60. Even if it wasn't, the `debug.node.useV3` setting was [removed 15 months ago](https://github.com/microsoft/vscode-node-debug/commit/034f91bb445e24f430da461a80be7493108d0b66).
* `debug.chrome.useV3` was [removed in August](https://github.com/microsoft/vscode-chrome-debug/commit/20203f217efff04f8189069f531aa7d36ec1a7d4#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), and the extension is similarly deprecated in favor of the new built-in debugger.

The extension [currently sets](https://github.com/OmniSharp/omnisharp-vscode/blob/83618ae0c5b71a27f3eb2aeee9ab630983bc6e5b/package.json#L541) a minimum VS Code requirement of 1.61.0, meaning that those settings are guaranteed to not control anything. Thus, by removing those checks, we can see that the only remaining check is for the Blazor companion extension, and the code can be greatly simplified to only look for that.

Oh yeah, and the corresponding documentation has already been [updated](https://github.com/dotnet/AspNetCore.Docs/pull/23728) to remove the parts that talk about enabling the debugger preview, so anyone who clicks on the "Learn more" prompt isn't going to get the information they need anyway.