### PR TITLE
Explicitly install vscode-nls as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "vscode-debugprotocol": "1.33.0",
         "vscode-extension-telemetry": "0.1.6",
         "vscode-languageserver-protocol": "3.16.0",
+        "vscode-nls": "^5.0.0",
         "yauzl": "2.10.0"
       },
       "devDependencies": {
@@ -8693,6 +8694,11 @@
         "vscode-uri": "^1.0.6"
       }
     },
+    "node_modules/vscode-html-languageservice/node_modules/vscode-nls": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
+      "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
@@ -8750,9 +8756,9 @@
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "node_modules/vscode-nls": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
-      "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
     },
     "node_modules/vscode-test": {
       "version": "1.5.2",
@@ -16258,6 +16264,13 @@
         "vscode-languageserver-types": "^3.12.0",
         "vscode-nls": "^3.2.5",
         "vscode-uri": "^1.0.6"
+      },
+      "dependencies": {
+        "vscode-nls": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
+          "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+        }
       }
     },
     "vscode-jsonrpc": {
@@ -16312,9 +16325,9 @@
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "vscode-nls": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
-      "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
     },
     "vscode-test": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "vscode-debugprotocol": "1.33.0",
     "vscode-extension-telemetry": "0.1.6",
     "vscode-languageserver-protocol": "3.16.0",
+    "vscode-nls": "^5.0.0",
     "yauzl": "2.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[features/json/projectJSONContribution.ts](https://github.com/OmniSharp/omnisharp-vscode/blob/5366059b367d918a9d296485a067a8ea45da4f3b/src/features/json/projectJSONContribution.ts#L6) uses the [vscode-nls](https://www.npmjs.com/package/vscode-nls) package; however, up until now, it wasn't actually included as a direct dependency:
```prompt
$ npm ls vscode-nls
+-- microsoft.aspnetcore.razor.vscode@6.0.0-preview.5.21358.6
| `-- vscode-html-languageservice@2.1.7
|   `-- vscode-nls@3.2.5
`-- request-light@0.4.0
  `-- vscode-nls@4.1.2
```

It's probably a good idea to include it so that its version can be controlled :).

(By the way, what's up with the various zero-width breaking spaces in the package.json? npm keeps trying to convert them to...something else.)