### PR TITLE
Modernize code action provider

### DIFF
--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -24,7 +24,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         this.addDisposables(new CompositeDisposable(registerCommandDisposable));
     }
 
-    public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.Command[]> {
+    public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[]> {
         let options = this.optionProvider.GetLatestOptions();
         if (options.disableCodeActions) {
             return;
@@ -88,8 +88,11 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
 
                 return {
                     title: codeAction.Name,
-                    command: this._commandId,
-                    arguments: [runRequest, token]
+                    command: {
+                        title: codeAction.Name,
+                        command: this._commandId,
+                        arguments: [runRequest, token]
+                    },
                 };
             });
         }

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -13,7 +13,7 @@ import OptionProvider from '../observers/OptionProvider';
 import { LanguageMiddlewareFeature } from '../omnisharp/LanguageMiddlewareFeature';
 import { buildEditForResponse } from '../omnisharp/fileOperationsResponseEditBuilder';
 
-export default class CodeActionProvider extends AbstractProvider implements vscode.CodeActionProvider {
+export default class CodeActionProvider extends AbstractProvider implements vscode.CodeActionProvider<vscode.CodeAction> {
     private _commandId: string;
 
     constructor(server: OmniSharpServer, private optionProvider: OptionProvider, languageMiddlewareFeature: LanguageMiddlewareFeature) {

--- a/test/integrationTests/codeActionRename.integration.test.ts
+++ b/test/integrationTests/codeActionRename.integration.test.ts
@@ -40,13 +40,11 @@ suite(`Code Action Rename ${testAssetWorkspace.description}`, function () {
 
     test("Code actions can rename and open files", async () => {
         await vscode.commands.executeCommand("vscode.open", fileUri);
-        let c = await vscode.commands.executeCommand("vscode.executeCodeActionProvider", fileUri, new vscode.Range(0, 7, 0, 7)) as { command: string, title: string, arguments: string[] }[];
-        let command = c.find(
-            (s) => { return s.title == "Rename file to C.cs"; }
-        );
-        expect(command, "Didn't find rename class command");
+        const codeActions = await vscode.commands.executeCommand<vscode.CodeAction[]>("vscode.executeCodeActionProvider", fileUri, new vscode.Range(0, 7, 0, 7));
+        const codeAction = codeActions.find(codeAction => codeAction.title == "Rename file to C.cs");
+        expect(codeAction, "Didn't find rename class code action");
 
-        await vscode.commands.executeCommand(command.command, ...command.arguments);
+        await vscode.commands.executeCommand(codeAction.command.command, ...codeAction.command.arguments);
 
         await assertWithPoll(() => { }, 15 * 1000, 500, _ => expect(vscode.window.activeTextEditor.document.fileName).contains("C.cs"));
     });


### PR DESCRIPTION
Easiest to review if you look at it per-commit, though there aren't too many changes overall so you could look at the overall diff too.

While investigating a pet peeve of mine in the VS Code C# experience (see below), I discovered that the CodeActionProvider class is using a legacy function signature for provideCodeActions. The [new signature](https://code.visualstudio.com/api/references/vscode-api#CodeActionProvider%3CT%3E) allows for returning CodeActions rather than Commands and also provides a more straightforward way to differentiate between Selections and Ranges.

Benefits:
- [CodeActions](https://code.visualstudio.com/api/references/vscode-api#CodeAction) enable the extension to return richer information about the underlying command which can then be reflected in the UI.
- The Range | Selection type means there's no longer a need to manually query editor state to determine whether there's an active selection.

Things seem to be behaving the same through a quick test I did with a file that had a diagnostic on `ReferenceEquals(null, obj)`.
- No selection, active file: Displays the "Prefer 'is null'" quick fix, along with some code actions for wrapping arguments
- Selection on the first "e", active file: Only displays the "Prefer 'is null'" quick fix
- No selection, inactive file: Same as the active file scenario
- Selection on the first "e", inactive file: Same as the active file scenario

Note that the behavior I observed is different from what's documented in the VS Code API ("[`range`] will always be a selection if there is a currently active editor"), so it might be good to double-check me on that one.

I've also taken this opportunity to constify everything, because it seemed like pretty low-hanging fruit.

---

The pet peeve is that quick fixes aren't displayed in this tooltip right here which misleadingly makes you believe that there's no quick fix support:
<img width="174" alt="No quick fixes available" src="https://user-images.githubusercontent.com/2766036/147887648-cb144fff-5ff8-4076-8cc3-fb2cdbf9ce1e.png">
I've figured out that passing `kind: CodeActionKind.QuickFix` to each CodeAction will cause them to show up in that tooltip. But to do that, CodeActions have to be returned in the first place ;).