### PR TITLE
Always send document text when Semantic Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * For Mono-based development (e.g. Unity) that requires full .NET framework, you need to set `"omnisharp.useGlobalMono": "always"`. The current value of "auto" will remain "never" until Mono [upgrades their bundled MSBuild version](https://github.com/mono/mono/issues/20250).
 * After selecting a solution filter (*.slnf) from the project selector, the solution's name will be displayed in the status bar instead of the filter's.
 * Known limitations with the preview Razor (cshtml) language service to be addressed in a future release:
+  * Not all platforms ship with the Razor LSP, such as Linux arm64.
   * Only ASP.NET Core projects are supported (no support for ASP.NET projects)
   * Error squiggles misaligned for expressions near the start of a new line
   * Emmet based abbreviation expansion is not yet supported (See note in readme for how to enable through your settings.json)
@@ -36,6 +37,11 @@
 * Update Debugger to 1.23.19 (PR: [4899](https://github.com/OmniSharp/omnisharp-vscode/pull/4899))
 * Add targetArch to Attach and documentation ([#4900](https://github.com/OmniSharp/omnisharp-vscode/pull/4900), PR: [#4901](https://github.com/OmniSharp/omnisharp-vscode/pull/4901))
 * Allow Linux Arm64 users to run the experimental O# build (PR: [#4892](https://github.com/OmniSharp/omnisharp-vscode/pull/4892))
+* Always send document text when Semantic Highlighting (PR: [#5003](https://github.com/OmniSharp/omnisharp-vscode/pull/5003))
+* Remove obsolete settings checks for Blazor debugging (PR: [#4964](https://github.com/OmniSharp/omnisharp-vscode/pull/4964))
+* Explicitly install vscode-nls as a dependency (PR: [#4980](https://github.com/OmniSharp/omnisharp-vscode/pull/4980))
+* Modernize code action provider (PR: [#4988](https://github.com/OmniSharp/omnisharp-vscode/pull/4988))
+* Fix OmnisharpDownloader tests (PR: [#4989](https://github.com/OmniSharp/omnisharp-vscode/pull/4989))
 
 ## 1.23.17 (Dec 3rd, 2021)
 * Greatly improved download experience: when the C# extension is downloaded from the VS Code Marketplace, it will include all of its dependencies already ([#4775](https://github.com/OmniSharp/omnisharp-vscode/issues/4775))

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ You can also use the .NET 6 build of OmniSharp which runs on the .NET 6 SDK. See
 * Update Debugger to 1.23.19 (PR: [4899](https://github.com/OmniSharp/omnisharp-vscode/pull/4899))
 * Add targetArch to Attach and documentation ([#4900](https://github.com/OmniSharp/omnisharp-vscode/pull/4900), PR: [#4901](https://github.com/OmniSharp/omnisharp-vscode/pull/4901))
 * Allow Linux Arm64 users to run the experimental O# build (PR: [#4892](https://github.com/OmniSharp/omnisharp-vscode/pull/4892))
+* Always send document text when Semantic Highlighting (PR: [#5003](https://github.com/OmniSharp/omnisharp-vscode/pull/5003))
+* Remove obsolete settings checks for Blazor debugging (PR: [#4964](https://github.com/OmniSharp/omnisharp-vscode/pull/4964))
+* Explicitly install vscode-nls as a dependency (PR: [#4980](https://github.com/OmniSharp/omnisharp-vscode/pull/4980))
+* Modernize code action provider (PR: [#4988](https://github.com/OmniSharp/omnisharp-vscode/pull/4988))
+* Fix OmnisharpDownloader tests (PR: [#4989](https://github.com/OmniSharp/omnisharp-vscode/pull/4989))
 
 ## What's new in 1.23.17
 * Greatly improved download experience: when the C# extension is downloaded from the VS Code Marketplace, it will include all of its dependencies already ([#4775](https://github.com/OmniSharp/omnisharp-vscode/issues/4775))

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -197,14 +197,9 @@ export default class SemanticTokensProvider extends AbstractProvider implements 
 
         let req = createRequest<protocol.V2.SemanticHighlightRequest>(document, new vscode.Position(0, 0));
         req.Range = range;
-
-
-        // We need to include the document contents in our request when we are highlighting a version of the document other than the current version, such as in the Diff view.
-        const currentDocument = vscode.workspace.textDocuments.find(d => d.fileName === document.fileName);
-        const isCurrentVersion = currentDocument?.version === document.version;
-        if (!isCurrentVersion) {
-            req.VersionedText = document.getText();
-        }
+        // We need to include the document contents in our request for cases where we are highlighting
+        // a version of the document other than the current version, such as in the Diff view.
+        req.VersionedText = document.getText();
 
         const versionBeforeRequest = document.version;
 

--- a/test-plan.md
+++ b/test-plan.md
@@ -468,6 +468,13 @@ Changing this option should result in a notification message at the bottom right
 
 #### OmniSharp Options
 
+  ### omnisharp.useModernNet (all platforms)
+  This option is defaulted to `false`.
+
+  When this option is set to `true` a .NET 6 build of OmniSharp is downloaded and used for language services. This setting should only be used when working with newer SDK style projects and would be expected to fail when trying to load a Full Framework projects (such as Unity projects).
+  * if the option is not set, the OmniSharp log should indicate that the registered MSBuild instance is either the Standalone MSBuild, a Visual Studio MSBuild instance, or a Mono MSBuild isntance.
+  * if the option is set, the OmniSharp log should inlcude text like the following "OmniSharp server started with .NET 6.0.100" and "Registered MSBuild instance: .NET Core SDK 6.0.100 17.0.0 - "/usr/local/share/dotnet/sdk/6.0.100/". All language services should continue to work as expected when an SDK-style project is open.
+
   #### omnisharp.useGlobalMono (for Linux/Mac)
   This option can be set to any of the following values:
   * "auto" - Will launch OmniSharp using mono if version>=5.2.0 is installed but will launch using the run script if that is not so.


### PR DESCRIPTION
The check for whether the document being highlighted was the current version of the document did not work. Always send the document text for the time being.