### PR TITLE
Update README.MD's .NET 6 SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can also use the .NET 6 build of OmniSharp which runs on the .NET 6 SDK. See
 
 ### Note about using .NET 6 SDKs
 
-The .NET 6 SDK requires version 16.10 of MSBuild.
+The .NET 6 SDK requires version 17.0 of MSBuild.
 
 For Windows users who have Visual Studio installed, this means you will need to have Visual Studio 16.11 or newer installed.
 


### PR DESCRIPTION
The .NET 6 SDK requires version 17.0.x of MSBuild instead of version 16.10 as stated in README.MD.

This is based on the requirements in .NET 6 SDK download page:
https://dotnet.microsoft.com/en-us/download/dotnet/6.0
![image](https://user-images.githubusercontent.com/8773147/160460738-83696576-08d1-4cf8-8c8b-994eaf2be843.png)


Even since its Preview version, .NET 6 SDK requires at least MSBuild 17.0.x.