### PR TITLE
Remove inlayHints from diff view.

### DIFF
--- a/src/features/inlayHintProvider.ts
+++ b/src/features/inlayHintProvider.ts
@@ -30,6 +30,11 @@ export default class CSharpInlayHintProvider extends AbstractProvider implements
     }
 
     async provideInlayHints(document: vscode.TextDocument, range: vscode.Range, token: vscode.CancellationToken): Promise<vscode.InlayHint[]> {
+        // Exclude documents from other schemes, such as those in the diff view.
+        if (document.uri.scheme !== "file") {
+            return [];
+        }
+        
         if (isVirtualCSharpDocument(document)) {
             return [];
         }


### PR DESCRIPTION
Similar to issues we had with semantic tokens in the diff view, documents from schemes other than file likely do not match the language server's view of the workspace.