### PR TITLE
Low-hanging nullable fruit

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -61,12 +61,6 @@ export function safeLength<T>(arr: T[] | undefined) {
     return arr ? arr.length : 0;
 }
 
-export async function buildPromiseChain<T, TResult>(array: T[], builder: (item: T) => Promise<TResult>): Promise<TResult> {
-    return array.reduce(
-        async (promise, n) => promise.then(async () => builder(n)),
-        Promise.resolve<TResult>(null));
-}
-
 export async function execChildProcess(command: string, workingDirectory: string = getExtensionPath()): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         cp.exec(command, { cwd: workingDirectory, maxBuffer: 500 * 1024 }, (error, stdout, stderr) => {

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -137,7 +137,7 @@ class DiagnosticsProvider extends AbstractSupport {
 
         this._subscriptions.push(this._validateCurrentDocumentPipe
             .pipe(debounceTime(750))
-            .subscribe(x => this._validateDocument(x)));
+            .subscribe(async document => await this._validateDocument(document)));
 
         this._subscriptions.push(this._validateAllPipe
             .pipe(debounceTime(3000))

--- a/src/features/fileOpenCloseProvider.ts
+++ b/src/features/fileOpenCloseProvider.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { IDisposable } from "../Disposable";
 import { OmniSharpServer } from "../omnisharp/server";
 import * as vscode from 'vscode';

--- a/src/omnisharp/LanguageMiddlewareFeature.ts
+++ b/src/omnisharp/LanguageMiddlewareFeature.ts
@@ -22,14 +22,15 @@ type RemapParameterType<M extends keyof RemapApi> = GetRemapType<NonNullable<Rem
 
 export class LanguageMiddlewareFeature implements IDisposable {
     private readonly _middlewares: LanguageMiddleware[];
-    private _registration: IDisposable;
+    private _registration: IDisposable | undefined;
 
     constructor() {
         this._middlewares = [];
     }
 
     public dispose(): void {
-        this._registration.dispose();
+        // this._registration should always be defined, but just in case we never register...
+        this._registration?.dispose();
     }
 
     public register(): void {

--- a/src/omnisharp/OmnisharpDownloader.ts
+++ b/src/omnisharp/OmnisharpDownloader.ts
@@ -35,9 +35,8 @@ export class OmnisharpDownloader {
                 this.eventStream.post(new InstallationSuccess());
                 return true;
             }
-
-            return false;
         }
+        return false;
     }
 
     public async GetLatestVersion(serverUrl: string, latestVersionFileServerPath: string): Promise<string> {

--- a/src/omnisharp/OmnisharpManager.ts
+++ b/src/omnisharp/OmnisharpManager.ts
@@ -22,10 +22,10 @@ export class OmnisharpManager {
         private platformInfo: PlatformInformation) {
     }
 
-    public async GetOmniSharpLaunchInfo(defaultOmnisharpVersion: string, omnisharpPath: string, useFramework: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string): Promise<LaunchInfo> {
-        if (!omnisharpPath) {
+    public async GetOmniSharpLaunchInfo(defaultOmnisharpVersion: string, omnisharpPath: string | undefined, useFramework: boolean, serverUrl: string, latestVersionFileServerPath: string, installPath: string, extensionPath: string): Promise<LaunchInfo> {
+        if (omnisharpPath === undefined) {
             // If omnisharpPath was not specified, return the default path.
-            let basePath = path.resolve(extensionPath, '.omnisharp', defaultOmnisharpVersion + (useFramework ? '' : `-net${modernNetVersion}`));
+            const basePath = path.resolve(extensionPath, '.omnisharp', defaultOmnisharpVersion + (useFramework ? '' : `-net${modernNetVersion}`));
             return this.GetLaunchInfo(this.platformInfo, useFramework, basePath);
         }
 

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
     const languageMiddlewareFeature = new LanguageMiddlewareFeature();
     languageMiddlewareFeature.register();
     disposables.add(languageMiddlewareFeature);
-    let localDisposables: CompositeDisposable;
+    let localDisposables: CompositeDisposable | undefined;
     const testManager = new TestManager(optionProvider, server, eventStream, languageMiddlewareFeature);
     const completionProvider = new CompletionProvider(server, languageMiddlewareFeature);
 
@@ -130,7 +130,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         if (localDisposables) {
             localDisposables.dispose();
         }
-        localDisposables = null;
+        localDisposables = undefined;
     }));
 
     disposables.add(registerCommands(context, server, platformInfo, eventStream, optionProvider, omnisharpMonoResolver, packageJSON, extensionPath));

--- a/src/omnisharp/fileOperationsResponseEditBuilder.ts
+++ b/src/omnisharp/fileOperationsResponseEditBuilder.ts
@@ -12,7 +12,7 @@ import { toRange2 } from './typeConversion';
 export async function buildEditForResponse(changes: FileOperationResponse[], languageMiddlewareFeature: LanguageMiddlewareFeature, token: vscode.CancellationToken): Promise<boolean> {
     let edit = new vscode.WorkspaceEdit();
 
-    let fileToOpen: Uri = null;
+    let fileToOpen: Uri | undefined;
 
     if (!changes || !Array.isArray(changes) || !changes.length) {
         return true;
@@ -55,7 +55,7 @@ export async function buildEditForResponse(changes: FileOperationResponse[], lan
     // and replaced with a command that can only close the active editor.
     // If files were renamed that weren't the active editor, their tabs will
     // be left open and marked as "deleted" by VS Code
-    return fileToOpen != null
+    return fileToOpen !== undefined
         ? applyEditPromise.then(_ => {
             return vscode.commands.executeCommand("vscode.open", fileToOpen);
         })

--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -107,7 +107,7 @@ export function resourcesToLaunchTargets(resources: vscode.Uri[]): LaunchTarget[
             let buckets: vscode.Uri[];
 
             if (workspaceFolderToUriMap.has(folder.index)) {
-                buckets = workspaceFolderToUriMap.get(folder.index);
+                buckets = workspaceFolderToUriMap.get(folder.index)!; // Ensured valid via has.
             } else {
                 buckets = [];
                 workspaceFolderToUriMap.set(folder.index, buckets);

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -46,7 +46,7 @@ export class OmnisharpInitialisation implements BaseEvent {
 
 export class OmnisharpLaunch implements BaseEvent {
     type = EventType.OmnisharpLaunch;
-    constructor(public hostVersion: string, public hostPath: string, public hostIsMono: boolean, public command: string, public pid: number) { }
+    constructor(public hostVersion: string | undefined, public hostPath: string | undefined, public hostIsMono: boolean, public command: string, public pid: number) { }
 }
 
 export class PackageInstallStart implements BaseEvent {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -957,36 +957,36 @@ export namespace V2 {
     }
 }
 
-export function findNetFrameworkTargetFramework(project: MSBuildProject): TargetFramework {
-    let regexp = new RegExp('^net[1-4]');
+export function findNetFrameworkTargetFramework(project: MSBuildProject): TargetFramework | undefined {
+    const regexp = new RegExp('^net[1-4]');
     return project.TargetFrameworks.find(tf => regexp.test(tf.ShortName));
 }
 
-export function findNetCoreTargetFramework(project: MSBuildProject): TargetFramework {
+export function findNetCoreTargetFramework(project: MSBuildProject): TargetFramework | undefined {
     return findNetCoreAppTargetFramework(project) ?? findModernNetFrameworkTargetFramework(project);
 }
 
-export function findNetCoreAppTargetFramework(project: MSBuildProject): TargetFramework {
+export function findNetCoreAppTargetFramework(project: MSBuildProject): TargetFramework | undefined {
     return project.TargetFrameworks.find(tf => tf.ShortName.startsWith('netcoreapp'));
 }
 
-export function findModernNetFrameworkTargetFramework(project: MSBuildProject): TargetFramework {
-    let regexp = new RegExp('^net[5-9]');
+export function findModernNetFrameworkTargetFramework(project: MSBuildProject): TargetFramework | undefined {
+    const regexp = new RegExp('^net[5-9]');
     const targetFramework = project.TargetFrameworks.find(tf => regexp.test(tf.ShortName));
 
     // Shortname is being reported as net50 instead of net5.0
     if (targetFramework !== undefined && targetFramework.ShortName.charAt(4) !== ".") {
-        targetFramework.ShortName = targetFramework.ShortName.substr(0, 4) + "." + targetFramework.ShortName.substr(4);
+        targetFramework.ShortName = `${targetFramework.ShortName.substring(0, 4)}.${targetFramework.ShortName.substring(4)}`;
     }
 
     return targetFramework;
 }
 
-export function findNetStandardTargetFramework(project: MSBuildProject): TargetFramework {
+export function findNetStandardTargetFramework(project: MSBuildProject): TargetFramework | undefined {
     return project.TargetFrameworks.find(tf => tf.ShortName.startsWith('netstandard'));
 }
 
-export function isDotNetCoreProject(project: MSBuildProject): Boolean {
+export function isDotNetCoreProject(project: MSBuildProject): boolean {
     return findNetCoreTargetFramework(project) !== undefined ||
         findNetStandardTargetFramework(project) !== undefined ||
         findNetFrameworkTargetFramework(project) !== undefined;

--- a/src/omnisharp/requestQueue.ts
+++ b/src/omnisharp/requestQueue.ts
@@ -92,7 +92,7 @@ class RequestQueue {
         this.eventStream.post(new OmnisharpServerProcessRequestStart(this._name, availableRequestSlots));
 
         for (let i = 0; i < availableRequestSlots && this._pending.length > 0; i++) {
-            const item = this._pending.shift();
+            const item = this._pending.shift()!; // We know from this._pending.length that we can still shift
             item.startTime = Date.now();
 
             const id = this._makeRequest(item);
@@ -117,6 +117,7 @@ export class RequestQueueCollection {
         concurrency: number,
         makeRequest: (request: Request) => number
     ) {
+        this._isProcessing = false;
         this._priorityQueue = new RequestQueue('Priority', 1, eventStream, makeRequest);
         this._normalQueue = new RequestQueue('Normal', concurrency, eventStream, makeRequest);
         this._deferredQueue = new RequestQueue('Deferred', Math.max(Math.floor(concurrency / 4), 2), eventStream, makeRequest);

--- a/src/omnisharp/typeConversion.ts
+++ b/src/omnisharp/typeConversion.ts
@@ -62,29 +62,18 @@ export function toVSCodePosition(point: protocol.V2.Point): vscode.Position {
     return new vscode.Position(point.Line, point.Column);
 }
 
-export function createRequest<T extends protocol.Request>(document: vscode.TextDocument, where: vscode.Position | vscode.Range, includeBuffer: boolean = false): T {
-
-    let Line: number, Column: number;
-
-    if (where instanceof vscode.Position) {
-        Line = where.line;
-        Column = where.character;
-    } else if (where instanceof vscode.Range) {
-        Line = where.start.line;
-        Column = where.start.character;
-    }
-
+export function createRequest<T extends protocol.Request>(document: vscode.TextDocument, where: vscode.Position, includeBuffer: boolean = false): T {
     // for metadata sources, we need to remove the [metadata] from the filename, and prepend the $metadata$ authority
     // this is expected by the Omnisharp server to support metadata-to-metadata navigation
-    let fileName = document.uri.scheme === "omnisharp-metadata" ?
+    const fileName = document.uri.scheme === "omnisharp-metadata" ?
         `${document.uri.authority}${document.fileName.replace("[metadata] ", "")}` :
         document.fileName;
 
-    let request: protocol.Request = {
+    const request: protocol.Request = {
         FileName: fileName,
         Buffer: includeBuffer ? document.getText() : undefined,
-        Line,
-        Column
+        Line: where.line,
+        Column: where.character,
     };
 
     return <T>request;

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -205,7 +205,7 @@ export async function fileClose(server: OmniSharpServer, request: protocol.Reque
     return server.makeRequest<void>(protocol.Requests.FileClose, request);
 }
 
-export async function isNetCoreProject(project: protocol.MSBuildProject) {
+export function isNetCoreProject(project: protocol.MSBuildProject) {
     return project.TargetFrameworks.find(tf => tf.ShortName.startsWith('netcoreapp') || tf.ShortName.startsWith('netstandard')) !== undefined;
 }
 

--- a/test/unitTests/common.test.ts
+++ b/test/unitTests/common.test.ts
@@ -5,28 +5,12 @@
 
 import * as path from 'path';
 
-import { buildPromiseChain, isSubfolderOf, safeLength, sum } from '../../src/common';
+import { isSubfolderOf, safeLength, sum } from '../../src/common';
 
 import { should, expect } from 'chai';
 
 suite("Common", () => {
     suiteSetup(() => should());
-
-    suite("buildPromiseChain", () => {
-        test("produce a sequence of promises", async () => {
-            let array: number[] = [];
-            let items = [1, 2, 3, 4, 5];
-
-            let promise = buildPromiseChain(items, async n => new Promise<void>((resolve, reject) => {
-                array.push(n);
-                resolve();
-            }));
-
-            return promise.then(() => {
-                array.should.deep.equal([1, 2, 3, 4, 5]);
-            });
-        });
-    });
 
     suite("safeLength", () => {
         test("return 0 for empty array", () => {


### PR DESCRIPTION
There's a bunch of low-hanging fruit to get variables properly classified as nullable (and null-checked).

This pass gets most of src/features strict-clean, with the exception of server.ts and anything that depends on IHostExecutableResolver.

I'm hoping most of the changes should be self-explanatory, let me know if anything looks suspicious. Any changes to functionality are unintentional.

Also let me know if you'd prefer not to receive these types of PRs, because I get that they change a lot of files and reviewing is probably a bit of a small headache.