### PR TITLE
Do not hardcode VS Code version in integration tests

### DIFF
--- a/test/runFeatureTests.ts
+++ b/test/runFeatureTests.ts
@@ -17,7 +17,9 @@ async function main() {
         const extensionTestsPath = path.resolve(__dirname, './featureTests/index');
 
         // Download VS Code, unzip it and run the integration test
-        await runTests({ version: "1.65.0", extensionDevelopmentPath, extensionTestsPath, launchArgs: ['-n', '--verbose'] });
+        const exitCode = await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['-n', '--verbose'] });
+
+        process.exit(exitCode);
     } catch (err) {
         console.error(err);
         console.error('Failed to run tests');

--- a/test/runIntegrationTests.ts
+++ b/test/runIntegrationTests.ts
@@ -43,7 +43,9 @@ async function main() {
         }
 
         // Download VS Code, unzip it and run the integration test
-        await runTests({ version: "1.65.0", extensionDevelopmentPath, extensionTestsPath, launchArgs: [workspacePath, '-n', '--verbose'], extensionTestsEnv: process.env });
+        const exitCode = await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [workspacePath, '-n', '--verbose'], extensionTestsEnv: process.env });
+
+        process.exit(exitCode);
     } catch (err) {
         console.error(err);
         console.error('Failed to run tests');


### PR DESCRIPTION
An attempt to work around integration tests hanging when running version of VS Code > 1.65.0.