### PR TITLE
Use MSBuild info when computing program to launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "csharp",
-      "version": "1.24.5",
+      "version": "1.25.0",
       "license": "SEE LICENSE IN RuntimeLicenses/license.txt",
       "dependencies": {
         "@types/cross-spawn": "^6.0.2",
@@ -70,7 +70,7 @@
         "tslint": "5.12.1",
         "tslint-microsoft-contrib": "6.0.0",
         "tslint-no-unused-expression-chai": "0.1.4",
-        "typescript": "4.2.4",
+        "typescript": "4.6.3",
         "unzipper": "0.10.11",
         "vsce": "1.100.2",
         "webpack": "5.34.0",
@@ -8274,9 +8274,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -15933,9 +15933,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "tslint": "5.12.1",
     "tslint-microsoft-contrib": "6.0.0",
     "tslint-no-unused-expression-chai": "0.1.4",
-    "typescript": "4.2.4",
+    "typescript": "4.6.3",
     "unzipper": "0.10.11",
     "vsce": "1.100.2",
     "webpack": "5.34.0",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -162,6 +162,11 @@ export class AssetGenerator {
         }
 
         const relativeTargetPath = path.relative(this.workspaceFolder.uri.fsPath, this.startupProject.TargetPath);
+        if (relativeTargetPath === this.startupProject.TargetPath) {
+            // This can happen if, for example, the workspace folder and the target path
+            // are on completely different drives.
+            return this.startupProject.TargetPath;
+        }
         return path.join('${workspaceFolder}', relativeTargetPath);
     }
 
@@ -170,6 +175,8 @@ export class AssetGenerator {
             throw new Error("Startup project not set");
         }
 
+        // Startup project will always be a child of the workspace folder,
+        // so the special check above isn't necessary.
         const relativeProjectPath = path.relative(this.workspaceFolder.uri.fsPath, this.startupProject.Path);
         return path.join('${workspaceFolder}', path.dirname(relativeProjectPath));
     }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'fs-extra';
 import * as jsonc from 'jsonc-parser';
-import { FormattingOptions, ModificationOptions } from 'jsonc-parser'; 
+import { FormattingOptions, ModificationOptions } from 'jsonc-parser';
 import * as os from 'os';
 import * as path from 'path';
 import * as protocol from './omnisharp/protocol';
@@ -161,12 +161,8 @@ export class AssetGenerator {
             throw new Error("Startup project not set");
         }
 
-        const startupProjectDir = path.dirname(this.startupProject.Path);
-        const relativeProjectDir = path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, startupProjectDir));
-        const configurationName = 'Debug';
-        const targetFramework = protocol.findNetCoreTargetFramework(this.startupProject);
-        const result = path.join(relativeProjectDir, `bin/${configurationName}/${targetFramework.ShortName}/${this.startupProject.AssemblyName}.dll`);
-        return result;
+        const relativeTargetPath = path.relative(this.workspaceFolder.uri.fsPath, this.startupProject.TargetPath);
+        return path.join('${workspaceFolder}', relativeTargetPath);
     }
 
     private computeWorkingDirectory(): string {
@@ -583,8 +579,8 @@ function getBuildAssetsNotificationSetting() {
     return csharpConfig.get<boolean>('supressBuildAssetsNotification');
 }
 
-export function getFormattingOptions(): FormattingOptions { 
-    const editorConfig = vscode.workspace.getConfiguration('editor'); 
+export function getFormattingOptions(): FormattingOptions {
+    const editorConfig = vscode.workspace.getConfiguration('editor');
 
     const tabSize = editorConfig.get<number>('tabSize') ?? 4;
     const insertSpaces = editorConfig.get<boolean>('insertSpaces') ?? true;
@@ -609,7 +605,7 @@ export async function addTasksJsonIfNecessary(generator: AssetGenerator, operati
         }
 
         const formattingOptions = getFormattingOptions();
-        
+
         const tasksJson = generator.createTasksConfiguration();
 
         let text: string;
@@ -622,7 +618,7 @@ export async function addTasksJsonIfNecessary(generator: AssetGenerator, operati
         else {
             // when tasks.json exists just update the tasks node
             const ourConfigs = tasksJson.tasks;
-            const content = fs.readFileSync(generator.tasksJsonPath).toString(); 
+            const content = fs.readFileSync(generator.tasksJsonPath).toString();
             const updatedJson = updateJsonWithComments(content, ourConfigs, 'tasks', 'label', formattingOptions);
             text = updatedJson;
         }
@@ -659,7 +655,7 @@ async function addLaunchJsonIfNecessary(generator: AssetGenerator, operations: A
             }`;
 
             text = jsonc.applyEdits(launchJsonText, jsonc.format(launchJsonText, null, formattingOptions));
-        } 
+        }
         else {
             // when launch.json exists replace or append our configurations
             const ourConfigs = jsonc.parse(launchJsonConfigurations);
@@ -751,18 +747,18 @@ async function getExistingAssets(generator: AssetGenerator) {
             assets = assets.concat(tasks);
         }
 
-        if(fs.pathExistsSync(generator.launchJsonPath)) { 
+        if(fs.pathExistsSync(generator.launchJsonPath)) {
             const content = fs.readFileSync(generator.launchJsonPath).toString();
             let configurationNames = [
-                ".NET Core Launch (console)", 
+                ".NET Core Launch (console)",
                 ".NET Core Launch (web)",
                 ".NET Core Attach",
-                "Launch and Debug Standalone Blazor WebAssembly App", 
+                "Launch and Debug Standalone Blazor WebAssembly App",
             ];
             const configurations = jsonc.parse(content)?.configurations?.
                 map((t: { name: string; }) => t.name).
                 filter((n: string) => configurationNames.includes(n));
-                
+
             assets = assets.concat(configurations);
         }
 
@@ -833,22 +829,22 @@ export function replaceCommentPropertiesWithComments(text: string) {
     // replacing dummy properties OS-COMMENT with the normal comment syntax
     let regex = /["']OS-COMMENT\d*["']\s*\:\s*["'](.*)["']\s*?,/gi;
     let withComments = text.replace(regex, '// $1');
-    
+
     return withComments;
 }
 
-export function updateJsonWithComments(text: string, replacements: any[], nodeName: string, keyName: string, formattingOptions: FormattingOptions) : string { 
+export function updateJsonWithComments(text: string, replacements: any[], nodeName: string, keyName: string, formattingOptions: FormattingOptions) : string {
     let modificationOptions : ModificationOptions = {
         formattingOptions
     };
-    
+
     // parse using jsonc because there are comments
     // only use this to determine what to change
     // we will modify it as text to keep existing comments
     let parsed = jsonc.parse(text);
     let items = parsed[nodeName];
     let itemKeys : string[] = items.map((i: { [x: string]: string; }) => i[keyName]);
-    
+
     let modified = text;
     // count how many items we inserted to ensure we are putting items at the end
     // in the same order as they are in the replacements array
@@ -866,6 +862,6 @@ export function updateJsonWithComments(text: string, replacements: any[], nodeNa
         // changes one by one
         modified = updated;
     });
-    
+
     return replaceCommentPropertiesWithComments(modified);
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -156,7 +156,7 @@ export class AssetGenerator {
         return ProgramLaunchType.Console;
     }
 
-    private computeProgramPath() {
+    private computeProgramPath(): string {
         if (!this.startupProject) {
             throw new Error("Startup project not set");
         }
@@ -170,9 +170,8 @@ export class AssetGenerator {
             throw new Error("Startup project not set");
         }
 
-        const startupProjectDir = path.dirname(this.startupProject.Path);
-
-        return path.join('${workspaceFolder}', path.relative(this.workspaceFolder.uri.fsPath, startupProjectDir));
+        const relativeProjectPath = path.relative(this.workspaceFolder.uri.fsPath, this.startupProject.Path);
+        return path.join('${workspaceFolder}', path.dirname(relativeProjectPath));
     }
 
     public createLaunchJsonConfigurationsArray(programLaunchType: ProgramLaunchType): vscode.DebugConfiguration[] {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -320,12 +320,15 @@ export interface CakeContext {
 
 export interface MSBuildProject {
     ProjectGuid: string;
+    /** Absolute path to the csproj file. */
     Path: string;
     AssemblyName: string;
+    /** Absolute path to the output assembly DLL. */
     TargetPath: string;
     TargetFramework: string;
     SourceFiles: string[];
     TargetFrameworks: TargetFramework[];
+    /** Absolute path to the output directory. */
     OutputPath: string;
     IsExe: boolean;
     IsUnityProject: boolean;

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -105,24 +105,10 @@ suite("Asset generation: csproj", () => {
 
     [5, 6, 7, 8, 9].forEach(version => {
         const shortName = `net${version}.0`;
-        const alternameShortName = `net${version}0`;
 
         test(`Create launch.json for NET ${version} project opened in workspace with shortname '${shortName}'`, () => {
             let rootPath = path.resolve('testRoot');
             let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', shortName, /*isExe*/ true);
-            let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
-            generator.setStartupProject(0);
-            let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
-            let programPath = launchJson[0].program;
-
-            // ${workspaceFolder}/bin/Debug/net#.0/testApp.dll
-            let segments = programPath.split(path.posix.sep);
-            segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', shortName, 'testApp.dll']);
-        });
-
-        test(`Create launch.json for NET ${version} project opened in workspace with shortname '${alternameShortName}'`, () => {
-            let rootPath = path.resolve('testRoot');
-            let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', alternameShortName, /*isExe*/ true);
             let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
             generator.setStartupProject(0);
             let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
@@ -347,7 +333,7 @@ function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: st
                     ProjectGuid: '',
                     Path: projectPath,
                     AssemblyName: assemblyName,
-                    TargetPath: '',
+                    TargetPath: path.join(path.dirname(projectPath), 'bin', 'Debug', targetFrameworkShortName, `${assemblyName}.dll`),
                     TargetFramework: '',
                     SourceFiles: [],
                     TargetFrameworks: [

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -11,7 +11,9 @@ import * as jsonc from 'jsonc-parser';
 
 import { AssetGenerator, ProgramLaunchType, replaceCommentPropertiesWithComments, updateJsonWithComments } from '../../src/assets';
 import { parse } from 'jsonc-parser';
-import { should } from 'chai';
+import { use as chaiUse, should } from 'chai';
+
+chaiUse(require('chai-string'));
 
 suite("Asset generation: csproj", () => {
     suiteSetup(() => should());
@@ -96,11 +98,9 @@ suite("Asset generation: csproj", () => {
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
+        let programPath: string = launchJson[0].program;
 
-        // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
     });
 
     [5, 6, 7, 8, 9].forEach(version => {
@@ -112,11 +112,9 @@ suite("Asset generation: csproj", () => {
             let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
             generator.setStartupProject(0);
             let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
-            let programPath = launchJson[0].program;
+            let programPath: string = launchJson[0].program;
 
-            // ${workspaceFolder}/bin/Debug/net#.0/testApp.dll
-            let segments = programPath.split(path.posix.sep);
-            segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', shortName, 'testApp.dll']);
+            checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
         });
     });
 
@@ -126,11 +124,9 @@ suite("Asset generation: csproj", () => {
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
+        let programPath: string = launchJson[0].program;
 
-        // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
     });
 
     test("Create launch.json for Blazor web assembly standalone project opened in workspace", () => {
@@ -164,12 +160,12 @@ suite("Asset generation: csproj", () => {
         generator.setStartupProject(0);
         const launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
         const hostedBlazorLaunchConfig = launchJson[0];
-        const programPath = hostedBlazorLaunchConfig.program;
+        const programPath: string = hostedBlazorLaunchConfig.program;
         const cwd = hostedBlazorLaunchConfig.cwd;
         const hosted = hostedBlazorLaunchConfig.hosted;
 
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp3.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
+
         cwd.should.equal('${workspaceFolder}');
         hosted.should.equal(true);
     });
@@ -181,12 +177,12 @@ suite("Asset generation: csproj", () => {
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
         const hostedBlazorLaunchConfig = launchJson[0];
-        const programPath = hostedBlazorLaunchConfig.program;
+        const programPath: string = hostedBlazorLaunchConfig.program;
         const cwd = hostedBlazorLaunchConfig.cwd;
         const hosted = hostedBlazorLaunchConfig.hosted;
 
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp3.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
+
         cwd.should.equal('${workspaceFolder}/nested');
         hosted.should.equal(true);
     });
@@ -197,11 +193,9 @@ suite("Asset generation: csproj", () => {
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
+        let programPath: string = launchJson[0].program;
 
-        // ${workspaceFolder}/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
     });
 
     test("Create launch.json for nested web project opened in workspace", () => {
@@ -210,11 +204,9 @@ suite("Asset generation: csproj", () => {
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
-        let programPath = launchJson[0].program;
+        let programPath: string = launchJson[0].program;
 
-        // ${workspaceFolder}/nested/bin/Debug/netcoreapp1.0/testApp.dll
-        let segments = programPath.split(path.posix.sep);
-        segments.should.deep.equal(['${workspaceFolder}', 'nested', 'bin', 'Debug', 'netcoreapp1.0', 'testApp.dll']);
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
     });
 
     test("Add a new item to JSON", () => {
@@ -316,6 +308,11 @@ suite("Asset generation: csproj", () => {
     });
 });
 
+function checkProgramPath(rootPath: string, programPath: string, targetPath: string): void {
+    programPath.should.startWith('${workspaceFolder}/');
+    programPath.should.equal(targetPath.replace(rootPath, '${workspaceFolder}').replaceAll(path.win32.sep, path.posix.sep));
+}
+
 function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
     return {
         uri: vscode.Uri.file(rootPath),
@@ -333,7 +330,7 @@ function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: st
                     ProjectGuid: '',
                     Path: projectPath,
                     AssemblyName: assemblyName,
-                    TargetPath: path.join(path.dirname(projectPath), 'bin', 'Debug', targetFrameworkShortName, `${assemblyName}.dll`),
+                    TargetPath: path.join(path.dirname(projectPath), 'bin', 'Debug', new Date().getTime().toString(), targetFrameworkShortName, `${assemblyName}.dll`),
                     TargetFramework: '',
                     SourceFiles: [],
                     TargetFrameworks: [

--- a/test/featureTests/assets.test.ts
+++ b/test/featureTests/assets.test.ts
@@ -108,7 +108,7 @@ suite("Asset generation: csproj", () => {
 
         test(`Create launch.json for NET ${version} project opened in workspace with shortname '${shortName}'`, () => {
             let rootPath = path.resolve('testRoot');
-            let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', shortName, /*isExe*/ true);
+            let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', shortName, /*targetPath*/ undefined, /*isExe*/ true);
             let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
             generator.setStartupProject(0);
             let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
@@ -129,9 +129,25 @@ suite("Asset generation: csproj", () => {
         checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
     });
 
+    test("Create launch.json for project opened in workspace with non-relative output path", function() {
+        if (process.platform !== "win32") {
+            this.skip();
+        }
+
+        let rootPath = path.resolve('testRoot');
+        let differentDrive = rootPath.startsWith('C:') ? 'D:' : 'C:';
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', `${differentDrive}\\output.dll`);
+        let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Console), undefined, { disallowComments: true });
+        let programPath: string = launchJson[0].program;
+
+        checkProgramPath(rootPath, programPath, info.MsBuild.Projects[0].TargetPath);
+    });
+
     test("Create launch.json for Blazor web assembly standalone project opened in workspace", () => {
         const rootPath = path.resolve('testRoot');
-        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
+        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netstandard2.1', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
         const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         const launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyStandalone), undefined, { disallowComments: true });
@@ -143,7 +159,7 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for nested Blazor web assembly standalone project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netstandard2.1', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netstandard2.1', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyStandalone), undefined, { disallowComments: true });
@@ -155,7 +171,7 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for Blazor web assembly hosted project opened in workspace", () => {
         const rootPath = path.resolve('testRoot');
-        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
+        const info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
         const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         const launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
@@ -172,7 +188,7 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for nested Blazor web assembly hosted project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp3.0', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true, /*isBlazorWebAssemblyStandalone*/ false, /*isBlazorWebAssemblyHosted*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.BlazorWebAssemblyHosted), undefined, { disallowComments: true });
@@ -189,7 +205,7 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for web project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
@@ -200,7 +216,7 @@ suite("Asset generation: csproj", () => {
 
     test("Create launch.json for nested web project opened in workspace", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'nested', 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchJson = parse(generator.createLaunchJsonConfigurations(ProgramLaunchType.Web), undefined, { disallowComments: true });
@@ -291,7 +307,7 @@ suite("Asset generation: csproj", () => {
 
     test("createLaunchJsonConfigurationsArray removes comments", () => {
         let rootPath = path.resolve('testRoot');
-        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*isExe*/ true, /*isWebProject*/ true);
+        let info = createMSBuildWorkspaceInformation(path.join(rootPath, 'testApp.csproj'), 'testApp', 'netcoreapp1.0', /*targetPath*/ undefined, /*isExe*/ true, /*isWebProject*/ true);
         let generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
         generator.setStartupProject(0);
         let launchConfigurations: vscode.DebugConfiguration[] = generator.createLaunchJsonConfigurationsArray(ProgramLaunchType.Web);
@@ -309,8 +325,12 @@ suite("Asset generation: csproj", () => {
 });
 
 function checkProgramPath(rootPath: string, programPath: string, targetPath: string): void {
-    programPath.should.startWith('${workspaceFolder}/');
-    programPath.should.equal(targetPath.replace(rootPath, '${workspaceFolder}').replaceAll(path.win32.sep, path.posix.sep));
+    if (path.relative(rootPath, targetPath) !== targetPath) {
+        programPath.should.startWith('${workspaceFolder}/');
+        programPath.should.equal(targetPath.replace(rootPath, '${workspaceFolder}').replaceAll(path.win32.sep, path.posix.sep));
+    } else {
+        programPath.should.equal(targetPath.replaceAll(path.win32.sep, path.posix.sep));
+    }
 }
 
 function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
@@ -321,7 +341,7 @@ function createMockWorkspaceFolder(rootPath: string): vscode.WorkspaceFolder {
     };
 }
 
-function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, isExe: boolean = true, isWebProject: boolean = false, isBlazorWebAssemblyStandalone: boolean = false, isBlazorWebAssemblyHosted: boolean = false): protocol.WorkspaceInformationResponse {
+function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: string, targetFrameworkShortName: string, targetPath: string = undefined, isExe: boolean = true, isWebProject: boolean = false, isBlazorWebAssemblyStandalone: boolean = false, isBlazorWebAssemblyHosted: boolean = false): protocol.WorkspaceInformationResponse {
     return {
         MsBuild: {
             SolutionPath: '',
@@ -330,7 +350,7 @@ function createMSBuildWorkspaceInformation(projectPath: string, assemblyName: st
                     ProjectGuid: '',
                     Path: projectPath,
                     AssemblyName: assemblyName,
-                    TargetPath: path.join(path.dirname(projectPath), 'bin', 'Debug', new Date().getTime().toString(), targetFrameworkShortName, `${assemblyName}.dll`),
+                    TargetPath: targetPath ?? path.join(path.dirname(projectPath), 'bin', 'Debug', new Date().getTime().toString(), targetFrameworkShortName, `${assemblyName}.dll`),
                     TargetFramework: '',
                     SourceFiles: [],
                     TargetFrameworks: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "commonjs",
 		"outDir": "out",
 		"lib": [
-			"ES2017"
+			"ES2021"
 		],
 		"sourceMap": true,
 		"moduleResolution": "node",


### PR DESCRIPTION
While working on nullability improvements in the root src folder, I came across this bit of code that didn't have an easy nullability fix. After investigating a bit, I realized it was attempting to form the program path manually, when MSBuild already supplies the correct paths.
I left the whitespace changes in because that seems like good code hygiene to cleanup. Actual changes are only L164-165 in assets.ts and all changes in protocol.ts.

### Details
`computeProgramPath` takes in a project (via `this.startupProject`) and returns the path to the entry assembly DLL.
The problem is that it tries to do this manually with a bit of path manipulation and assumes the output path is always the default `<project>/bin/<config>/<tfm>/<assembly>.dll`. **This is a bad assumption** as the output path can be changed via the MSBuild `OutputPath` property. omnisharp-roslyn itself does this! https://github.com/OmniSharp/omnisharp-roslyn/blob/c6f1e848202d7fff16d52b81496b6980b436952d/build/Settings.props#L20

Luckily, omnisharp-roslyn already computes the absolute assembly path for us via `TargetPath`. So just...use that. Nice. And add some documentation to MSBuildProject to help others along in the future.
![TargetPath contains correct path](https://user-images.githubusercontent.com/2766036/169750362-9e6c5165-6db5-4a47-967e-bbe3914bb2d8.png)

(It would be good to add an integration test for this. And I don't know how the Configuration is determined, since I don't have VS installed on this laptop to try toggling it in VS and seeing if it changes in VS Code.)

Fixes #3535