### PR TITLE
Package manager nullability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "csharp",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "SEE LICENSE IN RuntimeLicenses/license.txt",
       "dependencies": {
         "@types/cross-spawn": "^6.0.2",
@@ -47,7 +47,7 @@
         "@types/tmp": "0.0.33",
         "@types/unzipper": "^0.9.1",
         "@types/vscode": "1.66.0",
-        "@types/yauzl": "2.9.1",
+        "@types/yauzl": "2.10.0",
         "@vscode/test-electron": "2.1.3",
         "archiver": "5.3.0",
         "chai": "4.3.4",
@@ -338,9 +338,9 @@
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -9619,9 +9619,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/gulp": "4.0.5",
         "@types/minimist": "1.2.1",
         "@types/mocha": "5.2.5",
-        "@types/node": "10.12.24",
+        "@types/node": "16.11.38",
         "@types/semver": "5.5.0",
         "@types/tmp": "0.0.33",
         "@types/unzipper": "^0.9.1",
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.12.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.24.tgz",
-      "integrity": "sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ=="
+      "version": "16.11.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
+      "integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg=="
     },
     "node_modules/@types/semver": {
       "version": "5.5.0",
@@ -9550,9 +9550,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.24.tgz",
-      "integrity": "sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ=="
+      "version": "16.11.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
+      "integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg=="
     },
     "@types/semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/tmp": "0.0.33",
     "@types/unzipper": "^0.9.1",
     "@types/vscode": "1.66.0",
-    "@types/yauzl": "2.9.1",
+    "@types/yauzl": "2.10.0",
     "@vscode/test-electron": "2.1.3",
     "archiver": "5.3.0",
     "chai": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/gulp": "4.0.5",
     "@types/minimist": "1.2.1",
     "@types/mocha": "5.2.5",
-    "@types/node": "10.12.24",
+    "@types/node": "16.11.38",
     "@types/semver": "5.5.0",
     "@types/tmp": "0.0.33",
     "@types/unzipper": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,9 @@
       "platforms": [
         "darwin"
       ],
+      "architectures": [
+        "x86_64"
+      ],
       "binaries": [
         "./mono.osx",
         "./run"

--- a/src/common.ts
+++ b/src/common.ts
@@ -33,10 +33,6 @@ export function getUnixTempDirectory(){
     return envTmp;
 }
 
-export function isBoolean(obj: any): obj is boolean {
-    return obj === true || obj === false;
-}
-
 export function sum<T>(arr: T[], selector: (item: T) => number): number {
     return arr.reduce((prev, curr) => prev + selector(curr), 0);
 }

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -48,7 +48,7 @@ async function checkIsValidArchitecture(platformInformation: PlatformInformation
             }
 
             // Validate we are on compatiable macOS version if we are x86_64
-            if ((platformInformation.architecture !== "x86_64") || 
+            if ((platformInformation.architecture !== "x86_64") ||
                 (platformInformation.architecture === "x86_64" && !CoreClrDebugUtil.isMacOSSupported())) {
                 eventStream.post(new DebuggerPrerequisiteFailure("[ERROR] The debugger cannot be installed. The debugger requires macOS 10.12 (Sierra) or newer."));
                 return false;
@@ -149,8 +149,8 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
 
             // install.Lock does not exist, need to wait for packages to finish downloading.
             let installLock = false;
-            let debuggerPackage = getRuntimeDependencyPackageWithId("Debugger", this.packageJSON, this.platformInfo, this.extensionPath);
-            if (debuggerPackage && debuggerPackage.installPath) {
+            const debuggerPackage = getRuntimeDependencyPackageWithId("Debugger", this.packageJSON, this.platformInfo, this.extensionPath);
+            if (debuggerPackage?.installPath) {
                 installLock = await common.installFileExists(debuggerPackage.installPath, common.InstallFileType.Lock);
             }
 

--- a/src/observers/TelemetryObserver.ts
+++ b/src/observers/TelemetryObserver.ts
@@ -82,10 +82,7 @@ export class TelemetryObserver {
         if (event.error instanceof PackageError) {
             // we can log the message in a PackageError to telemetry as we do not put PII in PackageError messages
             telemetryProps['error.message'] = event.error.message;
-
-            if (event.error.pkg) {
-                telemetryProps['error.packageUrl'] = event.error.pkg.url;
-            }
+            telemetryProps['error.packageUrl'] = event.error.pkg.url;
         }
 
         this.reporter.sendTelemetryEvent('AcquisitionFailed', telemetryProps);

--- a/src/omnisharp/OmnisharpDownloader.ts
+++ b/src/omnisharp/OmnisharpDownloader.ts
@@ -28,7 +28,7 @@ export class OmnisharpDownloader {
         let runtimeDependencies = getRuntimeDependenciesPackages(this.packageJSON);
         let omniSharpPackages = GetPackagesFromVersion(version, useFramework, runtimeDependencies, serverUrl, installPath);
         let packagesToInstall = await getAbsolutePathPackagesToInstall(omniSharpPackages, this.platformInfo, this.extensionPath);
-        if (packagesToInstall && packagesToInstall.length > 0) {
+        if (packagesToInstall.length > 0) {
             this.eventStream.post(new PackageInstallation(`OmniSharp Version = ${version}`));
             this.eventStream.post(new LogPlatformInfo(this.platformInfo));
             if (await downloadAndInstallPackages(packagesToInstall, this.networkSettingsProvider, this.eventStream, isValidDownload, useFramework)) {

--- a/src/omnisharp/OmnisharpPackageCreator.ts
+++ b/src/omnisharp/OmnisharpPackageCreator.ts
@@ -8,13 +8,9 @@ import { Package } from "../packageManager/Package";
 export const modernNetVersion = "6.0";
 
 export function GetPackagesFromVersion(version: string, useFramework: boolean, runTimeDependencies: Package[], serverUrl: string, installPath: string): Package[] {
-    if (!version) {
-        throw new Error('Invalid version');
-    }
-
-    let versionPackages = new Array<Package>();
-    for (let inputPackage of runTimeDependencies) {
-        if (inputPackage.platformId && inputPackage.isFramework === useFramework) {
+    const versionPackages: Package[] = [];
+    for (const inputPackage of runTimeDependencies) {
+        if (inputPackage.platformId !== undefined && inputPackage.isFramework === useFramework) {
             versionPackages.push(SetBinaryAndGetPackage(inputPackage, useFramework, serverUrl, version, installPath));
         }
     }
@@ -60,4 +56,3 @@ function GetPackage(inputPackage: Package, useFramework: boolean, serverUrl: str
 
     return versionPackage;
 }
-

--- a/src/omnisharp/OmnisharpPackageCreator.ts
+++ b/src/omnisharp/OmnisharpPackageCreator.ts
@@ -8,14 +8,11 @@ import { Package } from "../packageManager/Package";
 export const modernNetVersion = "6.0";
 
 export function GetPackagesFromVersion(version: string, useFramework: boolean, runTimeDependencies: Package[], serverUrl: string, installPath: string): Package[] {
-    const versionPackages: Package[] = [];
-    for (const inputPackage of runTimeDependencies) {
-        if (inputPackage.platformId !== undefined && inputPackage.isFramework === useFramework) {
-            versionPackages.push(SetBinaryAndGetPackage(inputPackage, useFramework, serverUrl, version, installPath));
-        }
-    }
-
-    return versionPackages;
+    return runTimeDependencies
+        .filter(inputPackage =>
+            inputPackage.platformId !== undefined && inputPackage.isFramework === useFramework)
+        .map(inputPackage =>
+            SetBinaryAndGetPackage(inputPackage, useFramework, serverUrl, version, installPath));
 }
 
 export function SetBinaryAndGetPackage(inputPackage: Package, useFramework: boolean, serverUrl: string, version: string, installPath: string): Package {
@@ -24,7 +21,7 @@ export function SetBinaryAndGetPackage(inputPackage: Package, useFramework: bool
         // .NET 6 packages use system `dotnet OmniSharp.dll`
         installBinary = 'OmniSharp.dll';
     }
-    else if (inputPackage.platformId === 'win-x86' || inputPackage.platformId === 'win-x64' || inputPackage.platformId === 'win-arm64') {
+    else if (inputPackage.platforms.includes('win32')) {
         installBinary = 'OmniSharp.exe';
     }
     else {
@@ -35,24 +32,13 @@ export function SetBinaryAndGetPackage(inputPackage: Package, useFramework: bool
 }
 
 function GetPackage(inputPackage: Package, useFramework: boolean, serverUrl: string, version: string, installPath: string, installBinary: string): Package {
-    if (!version) {
-        throw new Error('Invalid version');
-    }
-
     const packageSuffix = useFramework ? '' : `-net${modernNetVersion}`;
 
-    let versionPackage: Package = {
-        id: inputPackage.id,
+    return {
+        ...inputPackage,
         description: `${inputPackage.description}, Version = ${version}`,
         url: `${serverUrl}/releases/${version}/omnisharp-${inputPackage.platformId}${packageSuffix}.zip`,
         installPath: `${installPath}/${version}${packageSuffix}`,
         installTestPath: `./${installPath}/${version}${packageSuffix}/${installBinary}`,
-        platforms: inputPackage.platforms,
-        architectures: inputPackage.architectures,
-        binaries: inputPackage.binaries,
-        platformId: inputPackage.platformId,
-        isFramework: useFramework
     };
-
-    return versionPackage;
 }

--- a/src/packageManager/AbsolutePath.ts
+++ b/src/packageManager/AbsolutePath.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isAbsolute, resolve } from "path";
+import * as path from "path";
 
 export class AbsolutePath {
     constructor(public value: string) {
-        if (!isAbsolute(value)) {
+        if (!path.isAbsolute(value)) {
             throw new Error("The path must be absolute");
         }
     }
 
     public static getAbsolutePath(...pathSegments: string[]): AbsolutePath {
-        return new AbsolutePath(resolve(...pathSegments));
+        return new AbsolutePath(path.resolve(...pathSegments));
     }
 }

--- a/src/packageManager/AbsolutePathPackage.ts
+++ b/src/packageManager/AbsolutePathPackage.ts
@@ -14,7 +14,7 @@ export class AbsolutePathPackage implements IPackage {
         public platforms: string[],
         public architectures: string[],
         public binaries: AbsolutePath[],
-        public installPath?: AbsolutePath,
+        public installPath: AbsolutePath,
         public installTestPath?: AbsolutePath,
         public fallbackUrl?: string,
         public platformId?: string,
@@ -58,7 +58,7 @@ function getAbsoluteBinaries(pkg: Package, extensionPath: string): AbsolutePath[
 }
 
 function getAbsoluteInstallPath(pkg: Package, extensionPath: string): AbsolutePath {
-    if (pkg.installPath) {
+    if (pkg.installPath !== undefined) {
         return AbsolutePath.getAbsolutePath(extensionPath, pkg.installPath);
     }
 

--- a/src/packageManager/AbsolutePathPackage.ts
+++ b/src/packageManager/AbsolutePathPackage.ts
@@ -13,8 +13,8 @@ export class AbsolutePathPackage implements IPackage {
         public url: string,
         public platforms: string[],
         public architectures: string[],
-        public binaries: AbsolutePath[],
         public installPath: AbsolutePath,
+        public binaries?: AbsolutePath[],
         public installTestPath?: AbsolutePath,
         public fallbackUrl?: string,
         public platformId?: string,
@@ -29,8 +29,8 @@ export class AbsolutePathPackage implements IPackage {
             pkg.url,
             pkg.platforms,
             pkg.architectures,
-            getAbsoluteBinaries(pkg, extensionPath),
             getAbsoluteInstallPath(pkg, extensionPath),
+            getAbsoluteBinaries(pkg, extensionPath),
             getAbsoluteInstallTestPath(pkg, extensionPath),
             pkg.fallbackUrl,
             pkg.platformId,
@@ -40,21 +40,17 @@ export class AbsolutePathPackage implements IPackage {
     }
 }
 
-function getAbsoluteInstallTestPath(pkg: Package, extensionPath: string): AbsolutePath {
-    if (pkg.installTestPath) {
+function getAbsoluteInstallTestPath(pkg: Package, extensionPath: string): AbsolutePath | undefined {
+    if (pkg.installTestPath !== undefined) {
         return AbsolutePath.getAbsolutePath(extensionPath, pkg.installTestPath);
     }
 
-    return null;
+    return undefined;
 }
 
-function getAbsoluteBinaries(pkg: Package, extensionPath: string): AbsolutePath[] {
-    let basePath = getAbsoluteInstallPath(pkg, extensionPath).value;
-    if (pkg.binaries) {
-        return pkg.binaries.map(value => AbsolutePath.getAbsolutePath(basePath, value));
-    }
-
-    return null;
+function getAbsoluteBinaries(pkg: Package, extensionPath: string): AbsolutePath[] | undefined {
+    const basePath = getAbsoluteInstallPath(pkg, extensionPath).value;
+    return pkg.binaries?.map(value => AbsolutePath.getAbsolutePath(basePath, value));
 }
 
 function getAbsoluteInstallPath(pkg: Package, extensionPath: string): AbsolutePath {

--- a/src/packageManager/FileDownloader.ts
+++ b/src/packageManager/FileDownloader.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as https from 'https';
-import * as util from '../common';
 import { EventStream } from "../EventStream";
 import { DownloadSuccess, DownloadStart, DownloadFallBack, DownloadFailure, DownloadProgress, DownloadSizeObtained } from "../omnisharp/loggingEvents";
 import { NestedError } from "../NestedError";
@@ -51,7 +50,7 @@ async function downloadFile(description: string, urlString: string, eventStream:
         path: url.path,
         agent: getProxyAgent(url, proxy, strictSSL),
         port: url.port,
-        rejectUnauthorized: util.isBoolean(strictSSL) ? strictSSL : true
+        rejectUnauthorized: strictSSL,
     };
 
     let buffers: any[] = [];

--- a/src/packageManager/FileDownloader.ts
+++ b/src/packageManager/FileDownloader.ts
@@ -24,7 +24,7 @@ export async function DownloadFile(description: string, eventStream: EventStream
         // If the package has a fallback Url, and downloading from the primary Url failed, try again from
         // the fallback. This is used for debugger packages as some users have had issues downloading from
         // the CDN link
-        if (fallbackUrl) {
+        if (fallbackUrl !== undefined) {
             eventStream.post(new DownloadFallBack(fallbackUrl));
             try {
                 let buffer = await downloadFile(description, fallbackUrl, eventStream, networkSettingsProvider);

--- a/src/packageManager/IPackage.ts
+++ b/src/packageManager/IPackage.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 export interface IPackage {
-    id?: string;
+    id: string;
     description: string;
     url: string;
     fallbackUrl?: string;

--- a/src/packageManager/PackageError.ts
+++ b/src/packageManager/PackageError.ts
@@ -9,8 +9,8 @@ import { IPackage } from "./IPackage";
 export class PackageError extends NestedError {
     // Do not put PII (personally identifiable information) in the 'message' field as it will be logged to telemetry
     constructor(public message: string,
-        public pkg: IPackage = null,
-        public innerError: any = null) {
+        public pkg: IPackage,
+        public innerError: Error | undefined) {
         super(message, innerError);
     }
 }

--- a/src/packageManager/PackageFilterer.ts
+++ b/src/packageManager/PackageFilterer.ts
@@ -5,7 +5,6 @@
 
 import { PlatformInformation } from "../platform";
 import * as util from '../common';
-import { PackageError } from "./PackageError";
 import { AbsolutePathPackage } from "./AbsolutePathPackage";
 
 export async function getNotInstalledPackagesForPlatform(packages: AbsolutePathPackage[], platformInfo: PlatformInformation): Promise<AbsolutePathPackage[]> {
@@ -14,33 +13,15 @@ export async function getNotInstalledPackagesForPlatform(packages: AbsolutePathP
 }
 
 export function filterPlatformPackages(packages: AbsolutePathPackage[], platformInfo: PlatformInformation) {
-    if (packages) {
-        return packages.filter(pkg => {
-            if (pkg.architectures && pkg.architectures.indexOf(platformInfo.architecture) === -1) {
-                return false;
-            }
-
-            if (pkg.platforms && pkg.platforms.indexOf(platformInfo.platform) === -1) {
-                return false;
-            }
-
-            return true;
-        });
-    }
-    else {
-        throw new PackageError("Package manifest does not exist.");
-    }
+    return packages.filter(pkg =>
+        pkg.architectures.includes(platformInfo.architecture) && pkg.platforms.includes(platformInfo.platform)
+    );
 }
 
 async function filterAlreadyInstalledPackages(packages: AbsolutePathPackage[]): Promise<AbsolutePathPackage[]> {
-    return util.filterAsync(packages, async (pkg: AbsolutePathPackage) => {
-        //If the install.Lock file is present for this package then do not install it again
-        let testPath = util.getInstallFilePath(pkg.installPath, util.InstallFileType.Lock);
-        if (!testPath) {
-            //if there is no testPath then we will not filter it
-            return true;
-        }
-
+    return util.filterAsync(packages, async pkg => {
+        // If the install.Lock file is present for this package then do not install it again
+        const testPath = util.getInstallFilePath(pkg.installPath, util.InstallFileType.Lock);
         return !(await util.fileExists(testPath));
     });
 }

--- a/src/packageManager/ZipInstaller.ts
+++ b/src/packageManager/ZipInstaller.ts
@@ -17,7 +17,7 @@ export async function InstallZip(buffer: Buffer, description: string, destinatio
 
     return new Promise<void>((resolve, reject) => {
         yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zipFile) => {
-            if (err) {
+            if (err !== null) {
                 let message = "C# Extension was unable to download its dependencies. Please check your internet connection. If you use a proxy server, please visit https://aka.ms/VsCodeCsharpNetworking";
                 eventStream.post(new ZipError(message));
                 return reject(new NestedError(message));
@@ -35,7 +35,8 @@ export async function InstallZip(buffer: Buffer, description: string, destinatio
                         zipFile.readEntry();
                     }
                     catch (err) {
-                        return reject(new NestedError('Error creating directory for zip directory entry:' + err?.code || '', err));
+                        const error = err as NodeJS.ErrnoException; // Hack for TypeScript to type err correctly
+                        return reject(new NestedError('Error creating directory for zip directory entry:' + error.code ?? '', error));
                     }
                 }
                 else {
@@ -59,7 +60,7 @@ export async function InstallZip(buffer: Buffer, description: string, destinatio
                             readStream.on('end', () => zipFile.readEntry());
                         }
                         catch (err) {
-                            return reject(new NestedError('Error creating directory for zip file entry', err));
+                            return reject(new NestedError('Error creating directory for zip file entry', err as NodeJS.ErrnoException));
                         }
                     });
                 }
@@ -75,4 +76,3 @@ export async function InstallZip(buffer: Buffer, description: string, destinatio
         });
     });
 }
-

--- a/src/packageManager/ZipInstaller.ts
+++ b/src/packageManager/ZipInstaller.ts
@@ -12,7 +12,7 @@ import { InstallationStart, ZipError } from "../omnisharp/loggingEvents";
 import { NestedError } from '../NestedError';
 import { AbsolutePath } from './AbsolutePath';
 
-export async function InstallZip(buffer: Buffer, description: string, destinationInstallPath: AbsolutePath, binaries: AbsolutePath[], eventStream: EventStream): Promise<void> {
+export async function InstallZip(buffer: Buffer, description: string, destinationInstallPath: AbsolutePath, binaries: AbsolutePath[] | undefined, eventStream: EventStream): Promise<void> {
     eventStream.post(new InstallationStart(description));
 
     return new Promise<void>((resolve, reject) => {
@@ -49,12 +49,9 @@ export async function InstallZip(buffer: Buffer, description: string, destinatio
                         try {
                             await mkdirp(path.dirname(absoluteEntryPath), 0o775);
 
-                            let binaryPaths = binaries && binaries.map(binary => binary.value);
-
                             // Make sure executable files have correct permissions when extracted
-                            let fileMode = binaryPaths && binaryPaths.indexOf(absoluteEntryPath) !== -1
-                                ? 0o755
-                                : 0o664;
+                            const binaryPaths = binaries?.map(binary => binary.value);
+                            const fileMode = binaryPaths?.includes(absoluteEntryPath) ? 0o755 : 0o664;
 
                             readStream.pipe(fs.createWriteStream(absoluteEntryPath, { mode: fileMode }));
                             readStream.on('end', () => zipFile.readEntry());

--- a/src/packageManager/downloadAndInstallPackages.ts
+++ b/src/packageManager/downloadAndInstallPackages.ts
@@ -17,64 +17,50 @@ import { PackageInstallStart } from "../omnisharp/loggingEvents";
 import { DownloadValidator } from './isValidDownload';
 
 export async function downloadAndInstallPackages(packages: AbsolutePathPackage[], provider: NetworkSettingsProvider, eventStream: EventStream, downloadValidator: DownloadValidator, useFramework: boolean): Promise<boolean> {
-    if (packages) {
-        eventStream.post(new PackageInstallStart());
-        for (let pkg of packages) {
-            let installationStage = "touchBeginFile";
-
-            if (pkg.id === "OmniSharp") {
-                if (pkg.isFramework !== useFramework) {
-                    continue;
-                }
-
-                if (pkg.url === null) {
-                    eventStream.post(new InstallationFailure(installationStage, new Error("A release package of OmniSharp does not exist for this platform. Set \"omnisharp.path\" to \"latest\" in Settings to use an experimental build.")));
-                    continue;
-                }
-            }
-
-            try {
-                mkdirpSync(pkg.installPath.value);
-                await touchInstallFile(pkg.installPath, InstallFileType.Begin);
-                let count = 1;
-                let willTryInstallingPackage = () => count <= 2; // try 2 times
-                while (willTryInstallingPackage()) {
-                    count = count + 1;
-                    installationStage = "downloadPackage";
-                    let buffer = await DownloadFile(pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
-                    if (downloadValidator(buffer, pkg.integrity, eventStream)) {
-                        installationStage = "installPackage";
-                        await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
-                        installationStage = 'touchLockFile';
-                        await touchInstallFile(pkg.installPath, InstallFileType.Lock);
-                        break;
-                    }
-                    else {
-                        eventStream.post(new IntegrityCheckFailure(pkg.description, pkg.url, willTryInstallingPackage()));
-                    }
-                }
-            }
-            catch (error) {
-                if (error instanceof NestedError) {
-                    let packageError = new PackageError(error.message, pkg, error.err);
-                    eventStream.post(new InstallationFailure(installationStage, packageError));
+    eventStream.post(new PackageInstallStart());
+    for (let pkg of packages) {
+        let installationStage = "touchBeginFile";
+        try {
+            mkdirpSync(pkg.installPath.value);
+            await touchInstallFile(pkg.installPath, InstallFileType.Begin);
+            let count = 1;
+            let willTryInstallingPackage = () => count <= 2; // try 2 times
+            while (willTryInstallingPackage()) {
+                count = count + 1;
+                installationStage = "downloadPackage";
+                let buffer = await DownloadFile(pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
+                if (downloadValidator(buffer, pkg.integrity, eventStream)) {
+                    installationStage = "installPackage";
+                    await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
+                    installationStage = 'touchLockFile';
+                    await touchInstallFile(pkg.installPath, InstallFileType.Lock);
+                    break;
                 }
                 else {
-                    eventStream.post(new InstallationFailure(installationStage, error));
+                    eventStream.post(new IntegrityCheckFailure(pkg.description, pkg.url, willTryInstallingPackage()));
                 }
-
-                return false;
-            }
-            finally {
-                try {
-                    if (await installFileExists(pkg.installPath, InstallFileType.Begin)) {
-                        await deleteInstallFile(pkg.installPath, InstallFileType.Begin);
-                    }
-                }
-                catch (error) { }
             }
         }
+        catch (error) {
+            if (error instanceof NestedError) {
+                let packageError = new PackageError(error.message, pkg, error.err);
+                eventStream.post(new InstallationFailure(installationStage, packageError));
+            }
+            else {
+                eventStream.post(new InstallationFailure(installationStage, error));
+            }
 
-        return true; //if all packages succeded in installing return true
+            return false;
+        }
+        finally {
+            try {
+                if (await installFileExists(pkg.installPath, InstallFileType.Begin)) {
+                    await deleteInstallFile(pkg.installPath, InstallFileType.Begin);
+                }
+            }
+            catch (error) { }
+        }
     }
+
+    return true;
 }

--- a/src/packageManager/getAbsolutePathPackagesToInstall.ts
+++ b/src/packageManager/getAbsolutePathPackagesToInstall.ts
@@ -9,10 +9,6 @@ import { getNotInstalledPackagesForPlatform } from "./PackageFilterer";
 import { Package } from "./Package";
 
 export async function getAbsolutePathPackagesToInstall(packages: Package[], platformInfo: PlatformInformation, extensionPath: string): Promise<AbsolutePathPackage[]> {
-    if (packages && packages.length > 0) {
-        let absolutePathPackages = packages.map(pkg => AbsolutePathPackage.getAbsolutePathPackage(pkg, extensionPath));
-        return getNotInstalledPackagesForPlatform(absolutePathPackages, platformInfo);
-    }
-
-    return [];
+    const absolutePathPackages = packages.map(pkg => AbsolutePathPackage.getAbsolutePathPackage(pkg, extensionPath));
+    return getNotInstalledPackagesForPlatform(absolutePathPackages, platformInfo);
 }

--- a/src/packageManager/isValidDownload.ts
+++ b/src/packageManager/isValidDownload.ts
@@ -8,14 +8,14 @@ import { EventStream } from "../EventStream";
 import { IntegrityCheckSuccess, DownloadValidation } from "../omnisharp/loggingEvents";
 
 export interface DownloadValidator {
-    (buffer: Buffer, integrity: string, eventStream: EventStream): boolean;
+    (buffer: Buffer, integrity: string | undefined, eventStream: EventStream): boolean;
 }
 
-export function isValidDownload(buffer: Buffer, integrity: string, eventStream: EventStream): boolean {
-    if (integrity && integrity.length > 0) {
+export function isValidDownload(buffer: Buffer, integrity: string | undefined, eventStream: EventStream): boolean {
+    if (integrity !== undefined && integrity.length > 0) {
         eventStream.post(new DownloadValidation());
         let value = getBufferIntegrityHash(buffer);
-        if (value == integrity.toUpperCase()) {
+        if (value === integrity.toUpperCase()) {
             eventStream.post(new IntegrityCheckSuccess());
             return true;
         }

--- a/src/packageManager/proxy.ts
+++ b/src/packageManager/proxy.ts
@@ -4,39 +4,41 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Url, parse as parseUrl } from 'url';
-import { isBoolean } from '../common';
 import HttpProxyAgent = require('http-proxy-agent');
 import HttpsProxyAgent = require('https-proxy-agent');
 import { Agent } from 'http';
 
-function getSystemProxyURL(requestURL: Url): string {
+function getSystemProxyURL(requestURL: Url): string | undefined {
     if (requestURL.protocol === 'http:') {
-        return process.env.HTTP_PROXY || process.env.http_proxy || null;
+        return process.env.HTTP_PROXY ?? process.env.http_proxy;
     } else if (requestURL.protocol === 'https:') {
-        return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null;
+        return process.env.HTTPS_PROXY ?? process.env.https_proxy ?? process.env.HTTP_PROXY ?? process.env.http_proxy;
     }
 
-    return null;
+    return undefined;
 }
 
-export function getProxyAgent(requestURL: Url, proxy: string, strictSSL: boolean): Agent {
+export function getProxyAgent(requestURL: Url, proxy: string, strictSSL: boolean): Agent | undefined {
     const proxyURL = proxy.length > 0 ? proxy : getSystemProxyURL(requestURL);
 
-    if (!proxyURL) {
-        return null;
+    if (proxyURL === undefined) {
+        return undefined;
     }
 
     const proxyEndpoint = parseUrl(proxyURL);
-
-    if (!/^https?:$/.test(proxyEndpoint.protocol)) {
-        return null;
+    if (proxyEndpoint.protocol === undefined) {
+        return undefined;
     }
 
-    const opts = {
+    if (!/^https?:$/.test(proxyEndpoint.protocol)) {
+        return undefined;
+    }
+
+    const opts: HttpProxyAgent.HttpProxyAgentOptions & HttpsProxyAgent.HttpsProxyAgentOptions = {
         host: proxyEndpoint.hostname,
-        port: Number(proxyEndpoint.port),
+        port: proxyEndpoint.port,
         auth: proxyEndpoint.auth,
-        rejectUnauthorized: isBoolean(strictSSL) ? strictSSL : true
+        rejectUnauthorized: strictSSL,
     };
 
     return requestURL.protocol === 'http:' ? HttpProxyAgent(opts) : HttpsProxyAgent(opts);

--- a/src/packageManager/proxy.ts
+++ b/src/packageManager/proxy.ts
@@ -26,7 +26,7 @@ export function getProxyAgent(requestURL: Url, proxy: string, strictSSL: boolean
     }
 
     const proxyEndpoint = parseUrl(proxyURL);
-    if (proxyEndpoint.protocol === undefined) {
+    if (proxyEndpoint.protocol === null) {
         return undefined;
     }
 

--- a/src/razor/razor.ts
+++ b/src/razor/razor.ts
@@ -11,12 +11,12 @@ import { EventStream } from '../EventStream';
 
 export async function activateRazorExtension(context: vscode.ExtensionContext, extensionPath: string, eventStream: EventStream) {
     const razorConfig = vscode.workspace.getConfiguration('razor');
-    const configuredLanguageServerDir = razorConfig.get<string>('languageServer.directory', null);
-    const languageServerDir = configuredLanguageServerDir || path.join(extensionPath, '.razor');
+    const configuredLanguageServerDir = razorConfig.get<string>('languageServer.directory', '');
+    const languageServerDir = configuredLanguageServerDir.length > 0 ? configuredLanguageServerDir : path.join(extensionPath, '.razor');
 
     if (fs.existsSync(languageServerDir)) {
         await Razor.activate(vscode, context, languageServerDir, eventStream, /* enableProposedApis: */ false);
-    } else if (configuredLanguageServerDir) {
+    } else if (configuredLanguageServerDir.length > 0) {
         // It's only an error if the nonexistent dir was explicitly configured
         // If it's the default dir, this is expected for unsupported platforms
         vscode.window.showErrorMessage(

--- a/src/tools/RuntimeDependencyPackageUtils.ts
+++ b/src/tools/RuntimeDependencyPackageUtils.ts
@@ -8,11 +8,11 @@ import { AbsolutePathPackage } from '../packageManager/AbsolutePathPackage';
 import { filterPlatformPackages } from '../packageManager/PackageFilterer';
 import { Package } from '../packageManager/Package';
 
-export function getRuntimeDependencyPackageWithId(packageId: string, packageJSON: any, platformInfo: PlatformInformation, extensionPath: string): AbsolutePathPackage {
-    let runtimeDependencies = getRuntimeDependenciesPackages(packageJSON);
-    let absolutePathPackages = runtimeDependencies.map(pkg => AbsolutePathPackage.getAbsolutePathPackage(pkg, extensionPath));
-    let platformSpecificPackage = filterPlatformPackages(absolutePathPackages, platformInfo);
-    return platformSpecificPackage.find(pkg => pkg.id == packageId);
+export function getRuntimeDependencyPackageWithId(packageId: string, packageJSON: any, platformInfo: PlatformInformation, extensionPath: string): AbsolutePathPackage | undefined {
+    const runtimeDependencies = getRuntimeDependenciesPackages(packageJSON);
+    const absolutePathPackages = runtimeDependencies.map(pkg => AbsolutePathPackage.getAbsolutePathPackage(pkg, extensionPath));
+    const platformSpecificPackage = filterPlatformPackages(absolutePathPackages, platformInfo);
+    return platformSpecificPackage.find(pkg => pkg.id === packageId);
 }
 
 export function getRuntimeDependenciesPackages(packageJSON: any): Package[] {

--- a/src/utils/removeBOM.ts
+++ b/src/utils/removeBOM.ts
@@ -7,7 +7,7 @@ import removeBomBuffer = require("strip-bom-buf");
 import removeBomString from "strip-bom";
 
 export function removeBOMFromBuffer(buffer: Buffer): Buffer {
-    return <Buffer>removeBomBuffer(buffer);
+    return removeBomBuffer(buffer);
 }
 
 export function removeBOMFromString(line: string): string {

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -104,7 +104,7 @@ async function install(platformInfo: PlatformInformation, packageJSON: any, isFr
     let runTimeDependencies = getRuntimeDependenciesPackages(packageJSON)
         .filter(dep => dep.isFramework === undefined || dep.isFramework === isFramework);
     let packagesToInstall = await getAbsolutePathPackagesToInstall(runTimeDependencies, platformInfo, codeExtensionPath);
-    let provider = () => new NetworkSettings('', undefined);
+    let provider = () => new NetworkSettings('', true);
     if (!(await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload, isFramework))) {
         throw Error("Failed to download package.");
     }

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -73,9 +73,10 @@ async function doPackageOffline() {
             await doOfflinePackage(p.platformInfo, p.id, p.isFramework, packageJSON, packedVsixOutputRoot);
         }
         catch (err) {
+            const message = (err instanceof Error ? err.stack : err) ?? '<unknown error>';
             // NOTE: Extra `\n---` at the end is because gulp will print this message following by the
             // stack trace of this line. So that seperates the two stack traces.
-            throw Error(`Failed to create package ${p.id}. ${err.stack ?? err ?? '<unknown error>'}\n---`);
+            throw Error(`Failed to create package ${p.id}. ${message}\n---`);
         }
     }
 }

--- a/tasks/spawnNode.ts
+++ b/tasks/spawnNode.ts
@@ -23,7 +23,7 @@ export default async function spawnNode(args?: string[], options?: SpawnSyncOpti
         stdio: "inherit"
     };
 
-    console.log(`starting ${nodePath} ${args.join(' ')}`);
+    console.log(`starting ${nodePath} ${args ? args.join(' ') : ''}`);
 
     const buffer = spawnSync(nodePath, args, optionsWithFullEnvironment);
 

--- a/tasks/testTasks.ts
+++ b/tasks/testTasks.ts
@@ -18,7 +18,7 @@ gulp.task("test:feature", async () => {
 
     const result = await spawnNode([featureTestRunnerPath], { env });
 
-    if (result.code > 0) {
+    if (result.code === null || result.code > 0) {
         // Ensure that gulp fails when tests fail
         throw new Error(`Exit code: ${result.code}  Signal: ${result.signal}`);
     }
@@ -35,7 +35,7 @@ gulp.task("test:unit", async () => {
         'test/unitTests/**/*.test.ts'
     ]);
 
-    if (result.code > 0) {
+    if (result.code === null || result.code > 0) {
         // Ensure that gulp fails when tests fail
         throw new Error(`Exit code: ${result.code}  Signal: ${result.signal}`);
     }
@@ -83,7 +83,7 @@ async function runIntegrationTest(testAssetName: string) {
 
     const result = await spawnNode([integrationTestRunnerPath], { env, cwd: rootPath });
 
-    if (result.code > 0) {
+    if (result.code === null || result.code > 0) {
         // Ensure that gulp fails when tests fail
         throw new Error(`Exit code: ${result.code}  Signal: ${result.signal}`);
     }

--- a/test/unitTests/InstallRuntimeDependencies.test.ts
+++ b/test/unitTests/InstallRuntimeDependencies.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 import { installRuntimeDependencies } from "../../src/InstallRuntimeDependencies";
 import IInstallDependencies from "../../src/packageManager/IInstallDependencies";
 import { EventStream } from "../../src/EventStream";
@@ -17,7 +16,7 @@ const expect = chai.expect;
 
 suite(`${installRuntimeDependencies.name}`, () => {
     let packageJSON = {
-        runtimeDependencies: {}
+        runtimeDependencies: [] as Package[]
     };
 
     let extensionPath = "/ExtensionPath";
@@ -36,7 +35,7 @@ suite(`${installRuntimeDependencies.name}`, () => {
     suite("When all the dependencies already exist", () => {
         suiteSetup(() => {
             packageJSON = {
-                runtimeDependencies: {}
+                runtimeDependencies: []
             };
         });
 
@@ -46,8 +45,8 @@ suite(`${installRuntimeDependencies.name}`, () => {
         });
 
         test("Doesn't log anything to the eventStream", async () => {
-            let packageJSON = {
-                runtimeDependencies: {}
+            packageJSON = {
+                runtimeDependencies: []
             };
 
             await installRuntimeDependencies(packageJSON, extensionPath, installDependencies, eventStream, platformInfo, useFramework);

--- a/test/unitTests/OmnisharpPackageCreator.test.ts
+++ b/test/unitTests/OmnisharpPackageCreator.test.ts
@@ -133,8 +133,9 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
         });
 
         test('Returns experiment packages with install test path depending on install path and version', () => {
-            let inputPackages = <Package[]>[
+            let inputPackages: Package[] = [
                 {
+                    id: "OmniSharp",
                     description: "OmniSharp for Windows (.NET 4.7.2 / x64)",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505821/c570a9e20dbf7172f79850babd058872/omnisharp-win-x64-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.28.0.zip",
@@ -150,6 +151,7 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
                     isFramework: useFramework
                 },
                 {
+                    id: "OmniSharp",
                     description: "OmniSharp for Windows (.NET 4.7.2 / x64)",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505821/c570a9e20dbf7172f79850babd058872/omnisharp-win-x64-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.28.0.zip",
@@ -165,12 +167,16 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
                     isFramework: !useFramework
                 },
                 {
+                    id: "OmniSharp",
                     description: "OmniSharp for OSX",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505818/6b99c6a86da3221919158ca0f36a3e45/omnisharp-osx-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-osx-1.28.0.zip",
                     installPath: ".omnisharp",
                     platforms: [
                         "darwin"
+                    ],
+                    architectures: [
+                        "x86_64"
                     ],
                     binaries: [
                         "./mono.osx",
@@ -191,8 +197,9 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
 
         test('Returns only omnisharp packages with experimentalIds', () => {
             let version = "0.0.0";
-            let inputPackages = <Package[]>[
+            let inputPackages: Package[] = [
                 {
+                    id: "OmniSharp",
                     description: "OmniSharp for Windows (.NET 4.7.2 / x64)",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505821/c570a9e20dbf7172f79850babd058872/omnisharp-win-x64-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.28.0.zip",
@@ -208,6 +215,7 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
                     isFramework: useFramework
                 },
                 {
+                    id: "OmniSharp",
                     description: "OmniSharp for Windows (.NET 4.7.2 / x64)",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505821/c570a9e20dbf7172f79850babd058872/omnisharp-win-x64-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-win-x64-1.28.0.zip",
@@ -223,12 +231,16 @@ suite('GetPackagesFromVersion : Gets the experimental omnisharp packages from a 
                     isFramework: !useFramework
                 },
                 {
+                    id: "OmniSharp",
                     description: "Some other package - no experimental id",
                     url: "https://download.visualstudio.microsoft.com/download/pr/100505818/6b99c6a86da3221919158ca0f36a3e45/omnisharp-osx-1.28.0.zip",
                     fallbackUrl: "https://omnisharpdownload.blob.core.windows.net/ext/omnisharp-osx-1.28.0.zip",
                     installPath: ".omnisharp",
                     platforms: [
                         "darwin"
+                    ],
+                    architectures: [
+                        "x86_64"
                     ],
                     binaries: [
                         "./mono.osx",

--- a/test/unitTests/logging/CsharpLoggerObserver.test.ts
+++ b/test/unitTests/logging/CsharpLoggerObserver.test.ts
@@ -9,6 +9,7 @@ import { CsharpLoggerObserver } from '../../../src/observers/CsharpLoggerObserve
 import { PlatformInformation } from '../../../src/platform';
 import * as Event from '../../../src/omnisharp/loggingEvents';
 import { PackageError } from '../../../src/packageManager/PackageError';
+import { Package } from '../../../src/packageManager/Package';
 
 suite("CsharpLoggerObserver", () => {
     suiteSetup(() => should());
@@ -18,6 +19,13 @@ suite("CsharpLoggerObserver", () => {
         ...getNullChannel(),
         append: (text?: string) => { logOutput += text || ""; },
     });
+    let pkg: Package = {
+        id: "id",
+        description: "description",
+        url: "url",
+        platforms: [],
+        architectures: [],
+    };
 
     setup(() => {
         logOutput = "";
@@ -39,14 +47,14 @@ suite("CsharpLoggerObserver", () => {
         });
 
         test('Stage and Error is logged if a PackageError without inner error', () => {
-            let event = new Event.InstallationFailure("someStage", new PackageError("someError", null, null));
+            let event = new Event.InstallationFailure("someStage", new PackageError("someError", pkg, undefined));
             observer.post(event);
             expect(logOutput).to.contain(event.stage);
             expect(logOutput).to.contain(event.error.message);
         });
 
         test('Stage and Inner error is logged if a PackageError without inner error', () => {
-            let event = new Event.InstallationFailure("someStage", new PackageError("someError", null, "innerError"));
+            let event = new Event.InstallationFailure("someStage", new PackageError("someError", pkg, new Error("innerError")));
             observer.post(event);
             expect(logOutput).to.contain(event.stage);
             expect(logOutput).to.contain(event.error.innerError.toString());

--- a/test/unitTests/logging/TelemetryObserver.test.ts
+++ b/test/unitTests/logging/TelemetryObserver.test.ts
@@ -127,7 +127,7 @@ suite('TelemetryReporterObserver', () => {
         });
 
         test(`Telemetry Props contains message and packageUrl if error is package error`, () => {
-            let error = new PackageError("someError", <Package>{ "description": "foo", "url": "someurl" });
+            let error = new PackageError("someError", <Package>{ "description": "foo", "url": "someurl" }, undefined);
             let event = new InstallationFailure("someStage", error);
             observer.post(event);
             expect(name).to.be.equal("AcquisitionFailed");

--- a/test/unitTests/testAssets/testAssets.ts
+++ b/test/unitTests/testAssets/testAssets.ts
@@ -74,6 +74,9 @@ export let testPackageJSON = {
             "platforms": [
                 "darwin"
             ],
+            "architectures": [
+                "x86"
+            ],
             "binaries": [
                 "./mono.osx",
                 "./run"
@@ -89,6 +92,9 @@ export let testPackageJSON = {
             "installPath": ".omnisharp",
             "platforms": [
                 "darwin"
+            ],
+            "architectures": [
+                "x86"
             ],
             "binaries": [
                 "./mono.osx",


### PR DESCRIPTION
Covers:
* src/packageManager/
* src/razor/
* src/tools/

Notable changes:
* Added missing `architectures` to macOS x64 OmniSharp download (I hope this wasn't intentional to allow M1 Macs to download both ARM64 + x64 OmniSharps? `architectures` is marked as non-null in IPackage).
* Remove all guards that checked for non-null packages, as there is a root check for that when initially reading `runtimeDependencies` from package.json.
  * This is _slightly_ risky as it's possible I missed a root caller that doesn't check that runtimeDependencies from an `any`-typed package.json is non-null - but I mean, with the previous behavior we would just _silently refuse to download OmniSharp_. At least now there will be an obvious error thrown somewhere.
* Similarly, removed all version checks as there's a root `semver.valid(version)` check.
* `downloadAndInstallPackages` is only ever called with a list of validated OmniSharp packages (function should be renamed to reflect that...), so removed some unnecessary checks around that.

While we're here, I'd like to understand the current state of how runtimeDependencies are defined/parsed, so that I have the context to create a followup PR cleaning up some of the associated logic.
* Is `installTestPath` used for anything? There's 0 references from AbsolutePathPackage and I don't see any meaningful reads from IPackage.
* Why do the packages in package.json specify a URL + installPath, if they're just overriden in OmnisharpPackageCreator (albeit, to the same thing) from constants in server.ts?