### PR TITLE
Fix csharp.unitTestDebuggingOptions description

### DIFF
--- a/package.json
+++ b/package.json
@@ -630,7 +630,7 @@
         },
         "csharp.unitTestDebuggingOptions": {
           "type": "object",
-          "description": "Options to use with the debugger when launching for unit test debugging. Any launch.json option is valid here.",
+          "description": "Options to use with the debugger when launching for unit test debugging.",
           "default": {},
           "properties": {
             "sourceFileMap": {


### PR DESCRIPTION
The `description` for `csharp.unitTestDebuggingOptions` incorrectly implied that all launch.json option was valid. This just removes the sentence since the schema already lays out which options are valid.

This fixes #5309 