### PR TITLE
Provide source generated file info for workspace symbols

### DIFF
--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -99,7 +99,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         }
         localDisposables.add(vscode.languages.registerCompletionItemProvider(documentSelector, completionProvider, '.', ' '));
         localDisposables.add(vscode.commands.registerCommand(CompletionAfterInsertCommand, async (item) => completionProvider.afterInsert(item)));
-        localDisposables.add(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(server, optionProvider, languageMiddlewareFeature)));
+        localDisposables.add(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(server, optionProvider, languageMiddlewareFeature, sourceGeneratedDocumentProvider)));
         localDisposables.add(vscode.languages.registerSignatureHelpProvider(documentSelector, new SignatureHelpProvider(server, languageMiddlewareFeature), '(', ','));
         // Since the CodeActionProvider registers its own commands, we must instantiate it and add it to the localDisposables
         // so that it will be cleaned up if OmniSharp is restarted.

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -215,6 +215,8 @@ export interface QuickFix {
 
 export interface SymbolLocation extends QuickFix {
     Kind: string;
+    ContainingSymbolName?: string;
+    GeneratedFileInfo?: SourceGeneratedFileInfo;
 }
 
 export interface QuickFixResponse {


### PR DESCRIPTION
VSCode side of https://github.com/OmniSharp/omnisharp-roslyn/pull/2431. I also updated the source generated doc provider to have a lazy-fetch option, as we don't want to fetch and cache generated files for every single symbol that gets returned in a workspace symbol request.
