### PR TITLE
Support generated files in referenceProvider

### DIFF
--- a/src/features/referenceProvider.ts
+++ b/src/features/referenceProvider.ts
@@ -6,10 +6,17 @@
 import AbstractSupport from './abstractProvider';
 import * as protocol from '../omnisharp/protocol';
 import * as serverUtils from '../omnisharp/utils';
-import {createRequest, toLocation} from '../omnisharp/typeConversion';
+import {createRequest, toLocation, toLocationFromUri} from '../omnisharp/typeConversion';
 import {ReferenceProvider, Location, TextDocument, CancellationToken, Position} from 'vscode';
+import { OmniSharpServer } from '../omnisharp/server';
+import { LanguageMiddlewareFeature } from '../omnisharp/LanguageMiddlewareFeature';
+import SourceGeneratedDocumentProvider from './sourceGeneratedDocumentProvider';
 
 export default class OmnisharpReferenceProvider extends AbstractSupport implements ReferenceProvider {
+
+    public constructor(server: OmniSharpServer, languageMiddlewareFeature: LanguageMiddlewareFeature, private generatedDocumentProvider: SourceGeneratedDocumentProvider) {
+        super(server, languageMiddlewareFeature);
+    }
 
     public async provideReferences(document: TextDocument, position: Position, options: { includeDeclaration: boolean;}, token: CancellationToken): Promise<Location[]> {
 
@@ -20,8 +27,8 @@ export default class OmnisharpReferenceProvider extends AbstractSupport implemen
         try {
             let res = await serverUtils.findUsages(this._server, req, token);
             if (res && Array.isArray(res.QuickFixes)) {
-                const references = res.QuickFixes.map(toLocation);
-                
+                const references = res.QuickFixes.map(l => this.mapToLocationWithGeneratedInfoPopulation(l));
+
                 // Allow language middlewares to re-map its edits if necessary.
                 const result = await this._languageMiddlewareFeature.remap("remapLocations", references, token);
                 return result;
@@ -30,5 +37,14 @@ export default class OmnisharpReferenceProvider extends AbstractSupport implemen
         catch (error) {
             return [];
         }
+    }
+
+    private mapToLocationWithGeneratedInfoPopulation(symbolLocation: protocol.SymbolLocation): Location {
+        if (symbolLocation.GeneratedFileInfo) {
+            const uri = this.generatedDocumentProvider.addSourceGeneratedFileWithoutInitialContent(symbolLocation.GeneratedFileInfo, symbolLocation.FileName);
+            return toLocationFromUri(uri, symbolLocation);
+        }
+
+        return toLocation(symbolLocation);
     }
 }

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -90,7 +90,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
         localDisposables.add(vscode.languages.registerCodeLensProvider(documentSelector, new CodeLensProvider(server, testManager, optionProvider, languageMiddlewareFeature)));
         localDisposables.add(vscode.languages.registerDocumentHighlightProvider(documentSelector, new DocumentHighlightProvider(server, languageMiddlewareFeature)));
         localDisposables.add(vscode.languages.registerDocumentSymbolProvider(documentSelector, new DocumentSymbolProvider(server, languageMiddlewareFeature)));
-        localDisposables.add(vscode.languages.registerReferenceProvider(documentSelector, new ReferenceProvider(server, languageMiddlewareFeature)));
+        localDisposables.add(vscode.languages.registerReferenceProvider(documentSelector, new ReferenceProvider(server, languageMiddlewareFeature, sourceGeneratedDocumentProvider)));
         localDisposables.add(vscode.languages.registerHoverProvider(documentSelector, new HoverProvider(server, languageMiddlewareFeature)));
         localDisposables.add(vscode.languages.registerRenameProvider(documentSelector, new RenameProvider(server, languageMiddlewareFeature)));
         if (options.useFormatting) {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -48,7 +48,7 @@ export async function getFixAll(server: OmniSharpServer, request: protocol.GetFi
 }
 
 export async function findUsages(server: OmniSharpServer, request: protocol.FindUsagesRequest, token: vscode.CancellationToken) {
-    return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.FindUsages, request, token);
+    return server.makeRequest<protocol.FindSymbolsResponse>(protocol.Requests.FindUsages, request, token);
 }
 
 export async function formatAfterKeystroke(server: OmniSharpServer, request: protocol.FormatAfterKeystrokeRequest, token: vscode.CancellationToken) {


### PR DESCRIPTION
Note that FAR _in_ a source generated file is not currently supported. But now, when a symbol location for a generated file is returned by FAR, we will ensure that the generated info is cached for use when the user attempts to navigate to it.
