### PR TITLE
Fix #5171

### DIFF
--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -16,7 +16,7 @@ import { TextDocument } from '../vscodeAdapter';
 import OptionProvider from '../observers/OptionProvider';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
-import { DiagnosticStatus } from '../omnisharp/protocol';
+import { BackgroundDiagnosticStatus } from '../omnisharp/protocol';
 import { LanguageMiddlewareFeature } from '../omnisharp/LanguageMiddlewareFeature';
 
 export class Advisor {
@@ -154,7 +154,7 @@ class DiagnosticsProvider extends AbstractSupport {
         this._disposable = new CompositeDisposable(this._diagnostics,
             this._server.onPackageRestore(() => this._validateAllPipe.next("onPackageRestore"), this),
             this._server.onProjectChange(() => this._validateAllPipe.next("onProjectChanged"), this),
-            this._server.onProjectDiagnosticStatus(this._onProjectAnalysis, this),
+            this._server.onBackgroundDiagnosticStatus(this._onBackgroundAnalysis, this),
             vscode.workspace.onDidOpenTextDocument(event => this._onDocumentOpenOrChange(event), this),
             vscode.workspace.onDidChangeTextDocument(event => this._onDocumentOpenOrChange(event.document), this),
             vscode.workspace.onDidCloseTextDocument(this._onDocumentClose, this),
@@ -210,9 +210,9 @@ class DiagnosticsProvider extends AbstractSupport {
         }
     }
 
-    private _onProjectAnalysis(event: protocol.ProjectDiagnosticStatus) {
-        if (event.Status == DiagnosticStatus.Ready &&
-            event.ProjectFilePath === "(100 %)") {
+    private _onBackgroundAnalysis(event: protocol.BackgroundDiagnosticStatusMessage) {
+        if (event.Status == BackgroundDiagnosticStatus.Finished &&
+            event.NumberFilesRemaining === 0) {
             this._validateAllPipe.next();
         }
     }

--- a/src/observers/BackgroundWorkStatusBarObserver.ts
+++ b/src/observers/BackgroundWorkStatusBarObserver.ts
@@ -4,18 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BaseStatusBarItemObserver } from './BaseStatusBarItemObserver';
-import { BaseEvent, OmnisharpProjectDiagnosticStatus } from '../omnisharp/loggingEvents';
+import { BaseEvent, OmnisharpBackgroundDiagnosticStatus } from '../omnisharp/loggingEvents';
 import { EventType } from '../omnisharp/EventType';
-import { DiagnosticStatus } from '../omnisharp/protocol';
+import { BackgroundDiagnosticStatus } from '../omnisharp/protocol';
 
 export class BackgroundWorkStatusBarObserver extends BaseStatusBarItemObserver {
     public post = (event: BaseEvent) => {
-        if (event.type === EventType.ProjectDiagnosticStatus) {
-            let asProjectEvent = <OmnisharpProjectDiagnosticStatus>event;
+        if (event.type === EventType.BackgroundDiagnosticStatus) {
+            let asProjectEvent = <OmnisharpBackgroundDiagnosticStatus>event;
 
-            if (asProjectEvent.message.Status === DiagnosticStatus.Processing) {
-                let projectFile = asProjectEvent.message.ProjectFilePath.replace(/^.*[\\\/]/, '');
-                this.SetAndShowStatusBar(`$(sync~spin) Analyzing ${projectFile}`, 'o.showOutput', undefined, `Analyzing ${projectFile}`);
+            if (asProjectEvent.message.Status !== BackgroundDiagnosticStatus.Finished) {
+                let {NumberFilesRemaining, NumberFilesTotal} = asProjectEvent.message;
+                let message = `Analyzing ${NumberFilesTotal} files - Remaining ${NumberFilesRemaining} files`;
+                this.SetAndShowStatusBar(`$(sync~spin) ${message}`, 'o.showOutput', null, `${message}`);
             }
             else {
                 this.ResetAndHideStatusBar();

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -79,7 +79,7 @@ export enum EventType {
     OmnisharpServerOnStart = 72,
     OmnisharpOnBeforeServerInstall = 73,
     ProjectConfigurationReceived = 74,
-    ProjectDiagnosticStatus = 75, // Obsolete, use BackgroundDiagnosticStatus
+    // ProjectDiagnosticStatus = 75, Obsolete, use BackgroundDiagnosticStatus
     DotNetTestRunInContextStart = 76,
     DotNetTestDebugInContextStart = 77,
     TelemetryErrorEvent = 78,

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -79,11 +79,12 @@ export enum EventType {
     OmnisharpServerOnStart = 72,
     OmnisharpOnBeforeServerInstall = 73,
     ProjectConfigurationReceived = 74,
-    ProjectDiagnosticStatus = 75,
+    ProjectDiagnosticStatus = 75, // Obsolete, use BackgroundDiagnosticStatus
     DotNetTestRunInContextStart = 76,
     DotNetTestDebugInContextStart = 77,
     TelemetryErrorEvent = 78,
     OmnisharpServerRequestCancelled = 79,
+    BackgroundDiagnosticStatus = 80,
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -98,9 +98,9 @@ export class OmnisharpServerOnError implements BaseEvent {
     constructor(public errorMessage: protocol.ErrorMessage) { }
 }
 
-export class OmnisharpProjectDiagnosticStatus implements BaseEvent {
-    type = EventType.ProjectDiagnosticStatus;
-    constructor(public message: protocol.ProjectDiagnosticStatus) { }
+export class OmnisharpBackgroundDiagnosticStatus implements BaseEvent {
+    type = EventType.BackgroundDiagnosticStatus;
+    constructor(public message: protocol.BackgroundDiagnosticStatusMessage) { }
 }
 
 export class OmnisharpServerMsBuildProjectDiagnostics implements BaseEvent {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -285,15 +285,17 @@ export interface ProjectInformationResponse {
     MsBuildProject: MSBuildProject;
 }
 
-export enum DiagnosticStatus {
-    Processing = 0,
-    Ready = 1
+export enum BackgroundDiagnosticStatus {
+    Started = 0,
+    Progress = 1,
+    Finished = 2
 }
 
-export interface ProjectDiagnosticStatus {
-    Status: DiagnosticStatus;
-    ProjectFilePath: string;
-    Type: "background";
+export interface BackgroundDiagnosticStatusMessage {
+    Status: BackgroundDiagnosticStatus;
+    NumberProjects: number;
+    NumberFilesTotal: number;
+    NumberFilesRemaining: number;
 }
 
 export interface WorkspaceInformationResponse {

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -69,7 +69,7 @@ module Events {
     export const ProjectAdded = 'ProjectAdded';
     export const ProjectRemoved = 'ProjectRemoved';
 
-    export const ProjectDiagnosticStatus = 'ProjectDiagnosticStatus';
+    export const BackgroundDiagnosticStatus = 'BackgroundDiagnosticStatus';
 
     export const MsBuildProjectDiagnostics = 'MsBuildProjectDiagnostics';
 
@@ -218,8 +218,8 @@ export class OmniSharpServer {
         return this._addListener(Events.ProjectRemoved, listener, thisArg);
     }
 
-    public onProjectDiagnosticStatus(listener: (e: protocol.ProjectDiagnosticStatus) => any, thisArg?: any) {
-        return this._addListener(Events.ProjectDiagnosticStatus, listener, thisArg);
+    public onBackgroundDiagnosticStatus(listener: (e: protocol.BackgroundDiagnosticStatusMessage) => any, thisArg?: any) {
+        return this._addListener(Events.BackgroundDiagnosticStatus, listener, thisArg);
     }
 
     public onMsBuildProjectDiagnostics(listener: (e: protocol.MSBuildProjectDiagnostics) => any, thisArg?: any) {
@@ -319,8 +319,8 @@ export class OmniSharpServer {
             this.eventStream.post(new ObservableEvents.OmnisharpServerOnStart());
         }));
 
-        disposables.add(this.onProjectDiagnosticStatus((message: protocol.ProjectDiagnosticStatus) =>
-            this.eventStream.post(new ObservableEvents.OmnisharpProjectDiagnosticStatus(message))
+        disposables.add(this.onBackgroundDiagnosticStatus((message: protocol.BackgroundDiagnosticStatusMessage) =>
+            this.eventStream.post(new ObservableEvents.OmnisharpBackgroundDiagnosticStatus(message))
         ));
 
         disposables.add(this.onProjectConfigurationReceived((message: protocol.ProjectConfigurationMessage) => {

--- a/test/integrationTests/testAssets/testAssets.ts
+++ b/test/integrationTests/testAssets/testAssets.ts
@@ -75,7 +75,7 @@ export class TestAssetWorkspace {
     async waitForIdle(stream: EventStream, timeout: number = 25 * 1000): Promise<void> {
         let event: BaseEvent = { type: 0 };
 
-        const subscription = stream.subscribe((e: BaseEvent) => e.type !== EventType.ProjectDiagnosticStatus && (event = e));
+        const subscription = stream.subscribe((e: BaseEvent) => e.type !== EventType.BackgroundDiagnosticStatus && (event = e));
 
         await poll(() => event, timeout, 500, e => !e || (event = null));
 

--- a/test/unitTests/logging/BackgroundWorkStatusBarObserver.test.ts
+++ b/test/unitTests/logging/BackgroundWorkStatusBarObserver.test.ts
@@ -5,9 +5,9 @@
 
 import { expect, should } from 'chai';
 import { StatusBarItem } from '../../../src/vscodeAdapter';
-import { OmnisharpProjectDiagnosticStatus } from '../../../src/omnisharp/loggingEvents';
+import { OmnisharpBackgroundDiagnosticStatus } from '../../../src/omnisharp/loggingEvents';
 import { BackgroundWorkStatusBarObserver } from '../../../src/observers/BackgroundWorkStatusBarObserver';
-import { DiagnosticStatus } from '../../../src/omnisharp/protocol';
+import { BackgroundDiagnosticStatus } from '../../../src/omnisharp/protocol';
 
 suite('BackgroundWorkStatusBarObserver', () => {
     suiteSetup(() => should());
@@ -25,16 +25,16 @@ suite('BackgroundWorkStatusBarObserver', () => {
         hideCalled = false;
     });
 
-    test('OmnisharpProjectDiagnosticStatus.Processing: Show processing message', () => {
-        let event = new OmnisharpProjectDiagnosticStatus({ Status: DiagnosticStatus.Processing, ProjectFilePath: "foo.csproj", Type: "background" });
+    test('OmnisharpBackgroundDiagnosticStatus.Processing: Show processing message', () => {
+        let event = new OmnisharpBackgroundDiagnosticStatus({ Status: BackgroundDiagnosticStatus.Progress, NumberFilesRemaining: 0, NumberFilesTotal: 0, NumberProjects: 0 });
         observer.post(event);
         expect(hideCalled).to.be.false;
         expect(showCalled).to.be.true;
         expect(statusBarItem.text).to.contain('Analyzing');
     });
 
-    test('OmnisharpProjectDiagnosticStatus.Ready: Hide processing message', () => {
-        let event = new OmnisharpProjectDiagnosticStatus({ Status: DiagnosticStatus.Ready, ProjectFilePath: "foo.csproj", Type: "background" });
+    test('OmnisharpBackgroundDiagnosticStatus.Ready: Hide processing message', () => {
+        let event = new OmnisharpBackgroundDiagnosticStatus({ Status: BackgroundDiagnosticStatus.Finished, NumberFilesRemaining: 0, NumberFilesTotal: 0, NumberProjects: 0 });
         observer.post(event);
         expect(hideCalled).to.be.true;
         expect(showCalled).to.be.false;


### PR DESCRIPTION
Replaced the deprecated ProjectDiagnosticStatus event with the newer BackgroundDiagnosticStatus.
Now BackgroundWorkStatusBarObserver no longer shows the path to the project file, but this shouldn't be a big deal.
This will fix #5171, without relying on obsolete protocol features, or workaround the discovered issue.