### PR TITLE
Feature nullability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1195,7 +1195,8 @@
       {
         "command": "o.reanalyze.currentProject",
         "title": "Analyze current project",
-        "category": "OmniSharp"
+        "category": "OmniSharp",
+        "enablement": "editorFocus"
       },
       {
         "command": "dotnet.generateAssets",

--- a/package.json
+++ b/package.json
@@ -1175,17 +1175,20 @@
       {
         "command": "o.fixAll.solution",
         "title": "Fix all occurrences of a code issue within solution",
-        "category": "OmniSharp"
+        "category": "OmniSharp",
+        "enablement": "editorFocus"
       },
       {
         "command": "o.fixAll.project",
         "title": "Fix all occurrences of a code issue within project",
-        "category": "OmniSharp"
+        "category": "OmniSharp",
+        "enablement": "editorFocus"
       },
       {
         "command": "o.fixAll.document",
         "title": "Fix all occurrences of a code issue within document",
-        "category": "OmniSharp"
+        "category": "OmniSharp",
+        "enablement": "editorFocus"
       },
       {
         "command": "o.reanalyze.allProjects",

--- a/src/features/codeActionProvider.ts
+++ b/src/features/codeActionProvider.ts
@@ -23,7 +23,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         this.addDisposables(new CompositeDisposable(registerCommandDisposable));
     }
 
-    public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[]> {
+    public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.CodeAction[] | undefined> {
         const options = this.optionProvider.GetLatestOptions();
         if (options.disableCodeActions) {
             return;
@@ -75,7 +75,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         }
     }
 
-    private mapOmniSharpCodeActionKindToVSCodeCodeActionKind(kind: string): vscode.CodeActionKind {
+    private mapOmniSharpCodeActionKindToVSCodeCodeActionKind(kind: string | undefined): vscode.CodeActionKind {
         switch (kind) {
             case 'QuickFix':
                 return vscode.CodeActionKind.QuickFix;
@@ -90,7 +90,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         }
     }
 
-    private async _runCodeAction(req: protocol.V2.RunCodeActionRequest, token: vscode.CancellationToken): Promise<boolean | string | {}> {
+    private async _runCodeAction(req: protocol.V2.RunCodeActionRequest, token: vscode.CancellationToken): Promise<boolean | string | undefined> {
         try {
             const response = await serverUtils.runCodeAction(this._server, req);
             if (response) {
@@ -99,5 +99,7 @@ export default class CodeActionProvider extends AbstractProvider implements vsco
         } catch (error) {
             return Promise.reject(`Problem invoking 'RunCodeAction' on OmniSharp server: ${error}`);
         }
+
+        return undefined;
     }
 }

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -100,7 +100,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         return [];
     }
 
-    async resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens> {
+    async resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens | undefined> {
         if (codeLens instanceof ReferencesCodeLens) {
             return this.resolveReferencesCodeLens(codeLens, token);
         }
@@ -110,9 +110,11 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         else if (codeLens instanceof DebugTestsCodeLens) {
             return this.resolveTestCodeLens(codeLens, 'Debug Test', 'dotnet.test.debug', 'Debug All Tests', 'dotnet.classTests.debug');
         }
+
+        return undefined;
     }
 
-    private async resolveReferencesCodeLens(codeLens: ReferencesCodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens> {
+    private async resolveReferencesCodeLens(codeLens: ReferencesCodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens | undefined> {
         const request: protocol.FindUsagesRequest = {
             FileName: codeLens.fileName,
             Line: codeLens.range.start.line,
@@ -147,7 +149,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
         }
     }
 
-    private async resolveTestCodeLens(codeLens: TestCodeLens, singularTitle: string, singularCommandName: string, pluralTitle: string, pluralCommandName: string): Promise<vscode.CodeLens> {
+    private async resolveTestCodeLens(codeLens: TestCodeLens, singularTitle: string, singularCommandName: string, pluralTitle: string, pluralCommandName: string): Promise<vscode.CodeLens | undefined> {
         if (!codeLens.isTestContainer) {
             // This is just a single test method, not a container.
             codeLens.command = {

--- a/src/features/codeLensProvider.ts
+++ b/src/features/codeLensProvider.ts
@@ -144,7 +144,7 @@ export default class OmniSharpCodeLensProvider extends AbstractProvider implemen
             codeLens.command = {
                 title: count === 1 ? '1 reference' : `${count} references`,
                 command: 'editor.action.showReferences',
-                arguments: [vscode.Uri.file(request.FileName), codeLens.range.start, remappedLocations]
+                arguments: [vscode.Uri.file(codeLens.fileName), codeLens.range.start, remappedLocations]
             };
 
             return codeLens;

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -53,7 +53,7 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));
 
-    disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver)));
+    disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, context.extension.packageJSON.version, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver)));
 
     disposable.add(vscode.commands.registerCommand('csharp.showDecompilationTerms', async () => showDecompilationTerms(context, server, optionProvider)));
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -154,8 +154,13 @@ async function reAnalyzeAllProjects(server: OmniSharpServer, eventStream: EventS
 }
 
 async function reAnalyzeCurrentProject(server: OmniSharpServer, eventStream: EventStream): Promise<void> {
+    const activeTextEditor = vscode.window.activeTextEditor;
+    if (activeTextEditor === undefined) {
+        return;
+    }
+
     await serverUtils.reAnalyze(server, {
-        fileName: vscode.window.activeTextEditor.document.uri.fsPath
+        FileName: activeTextEditor.document.uri.fsPath,
     });
 }
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -53,7 +53,7 @@ export default function registerCommands(context: vscode.ExtensionContext, serve
     // Register command for generating tasks.json and launch.json assets.
     disposable.add(vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) => generateAssets(server, selectedIndex)));
 
-    disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, context.extension.packageJSON.version, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), monoResolver, dotnetResolver)));
+    disposable.add(vscode.commands.registerCommand('csharp.reportIssue', async () => reportIssue(vscode, context.extension.packageJSON.version, eventStream, getDotnetInfo, platformInfo.isValidPlatformForMono(), optionProvider.GetLatestOptions(), dotnetResolver, monoResolver)));
 
     disposable.add(vscode.commands.registerCommand('csharp.showDecompilationTerms', async () => showDecompilationTerms(context, server, optionProvider)));
 

--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -23,7 +23,7 @@ export default class OmnisharpCompletionProvider extends AbstractProvider implem
         super(server, languageMiddlewareFeature);
     }
 
-    public async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionList> {
+    public async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionList | undefined> {
         let request = createRequest<protocol.CompletionRequest>(document, position);
         request.CompletionTrigger = (context.triggerKind + 1) as LspCompletionTriggerKind;
         request.TriggerCharacter = context.triggerCharacter;
@@ -92,7 +92,7 @@ export default class OmnisharpCompletionProvider extends AbstractProvider implem
             return this._convertToVscodeCompletionItem(response.Item);
         }
         catch (error) {
-            return;
+            return item;
         }
     }
 

--- a/src/features/definitionMetadataDocumentProvider.ts
+++ b/src/features/definitionMetadataDocumentProvider.ts
@@ -9,7 +9,7 @@ import { IDisposable } from '../Disposable';
 
 export default class DefinitionMetadataDocumentProvider implements TextDocumentContentProvider, IDisposable {
     readonly scheme = "omnisharp-metadata";
-    private _registration: IDisposable;
+    private _registration?: IDisposable;
     private _documents: Map<string, MetadataResponse>;
     private _documentClosedSubscription: IDisposable;
 
@@ -23,7 +23,7 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
     }
 
     public dispose(): void {
-        this._registration.dispose();
+        this._registration?.dispose();
         this._documentClosedSubscription.dispose();
         this._documents.clear();
     }
@@ -48,7 +48,7 @@ export default class DefinitionMetadataDocumentProvider implements TextDocumentC
         this._registration = workspace.registerTextDocumentContentProvider(this.scheme, this);
     }
 
-    public provideTextDocumentContent(uri: Uri): string {
+    public provideTextDocumentContent(uri: Uri): string | undefined {
         return this._documents.get(uri.toString())?.Source;
     }
 

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -301,7 +301,7 @@ class DiagnosticsProvider extends AbstractSupport {
 
         // Clear diagnostics for files that no longer have any diagnostics.
         this._diagnostics.forEach((uri) => {
-            if (!entries.find(tuple => tuple[0].toString() === uri.toString())) {
+            if (entries.find(tuple => tuple[0].toString() === uri.toString()) === undefined) {
                 this._diagnostics.delete(uri);
             }
         });
@@ -332,12 +332,12 @@ class DiagnosticsProvider extends AbstractSupport {
 
     private _getDiagnosticDisplay(quickFix: protocol.QuickFix, severity: vscode.DiagnosticSeverity | "hidden"): { severity: vscode.DiagnosticSeverity | "hidden", isFadeout: boolean } {
         // These hard coded values bring the goodness of fading even when analyzers are disabled.
-        let isFadeout = (quickFix.Tags && !!quickFix.Tags.find(x => x.toLowerCase() == 'unnecessary'))
+        let isFadeout = (quickFix.Tags?.find(x => x.toLowerCase() === 'unnecessary') !== undefined)
             || quickFix.Id == "CS0162"  // CS0162: Unreachable code
             || quickFix.Id == "CS0219"  // CS0219: Unused variable
             || quickFix.Id == "CS8019"; // CS8019: Unnecessary using
 
-        if (isFadeout && quickFix.LogLevel.toLowerCase() === 'hidden' || quickFix.LogLevel.toLowerCase() === 'none') {
+        if (isFadeout && ['hidden', 'none'].includes(quickFix.LogLevel)) {
             // Theres no such thing as hidden severity in VSCode,
             // however roslyn uses commonly analyzer with hidden to fade out things.
             // Without this any of those doesn't fade anything in vscode.

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -337,7 +337,7 @@ class DiagnosticsProvider extends AbstractSupport {
             || quickFix.Id == "CS0219"  // CS0219: Unused variable
             || quickFix.Id == "CS8019"; // CS8019: Unnecessary using
 
-        if (isFadeout && ['hidden', 'none'].includes(quickFix.LogLevel)) {
+        if (isFadeout && ['hidden', 'none'].includes(quickFix.LogLevel.toLowerCase())) {
             // Theres no such thing as hidden severity in VSCode,
             // however roslyn uses commonly analyzer with hidden to fade out things.
             // Without this any of those doesn't fade anything in vscode.

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -276,7 +276,7 @@ class DiagnosticsProvider extends AbstractSupport {
     }
 
     private async _validateEntireWorkspace() {
-        let value = await serverUtils.codeCheck(this._server, { FileName: null }, new vscode.CancellationTokenSource().token);
+        let value = await serverUtils.codeCheck(this._server, {}, new vscode.CancellationTokenSource().token);
 
         let quickFixes = value.QuickFixes
             .sort((a, b) => a.FileName.localeCompare(b.FileName));

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -272,7 +272,7 @@ class DiagnosticsProvider extends AbstractSupport {
     private _mapQuickFixesAsDiagnosticsInFile(quickFixes: protocol.QuickFix[]): { diagnostic: vscode.Diagnostic, fileName: string }[] {
         return quickFixes
             .map(quickFix => this._asDiagnosticInFileIfAny(quickFix))
-            .filter(diagnosticInFile => diagnosticInFile !== undefined) as { diagnostic: vscode.Diagnostic, fileName: string }[];
+            .filter((diagnosticInFile): diagnosticInFile is NonNullable<typeof diagnosticInFile> => diagnosticInFile !== undefined);
     }
 
     private async _validateEntireWorkspace() {

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -281,13 +281,13 @@ class DiagnosticsProvider extends AbstractSupport {
         let quickFixes = value.QuickFixes
             .sort((a, b) => a.FileName.localeCompare(b.FileName));
 
-        let entries: [vscode.Uri, vscode.Diagnostic[]][] = [];
-        let lastEntry: [vscode.Uri, vscode.Diagnostic[]];
+        let entries: [vscode.Uri, vscode.Diagnostic[] | undefined][] = [];
+        let lastEntry: [vscode.Uri, vscode.Diagnostic[]] | undefined;
 
         for (let diagnosticInFile of this._mapQuickFixesAsDiagnosticsInFile(quickFixes)) {
             let uri = vscode.Uri.file(diagnosticInFile.fileName);
 
-            if (lastEntry && lastEntry[0].toString() === uri.toString()) {
+            if (lastEntry !== undefined && lastEntry[0].toString() === uri.toString()) {
                 lastEntry[1].push(diagnosticInFile.diagnostic);
             } else {
                 // We're replacing all diagnostics in this file. Pushing an entry with undefined for

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -189,9 +189,9 @@ class DiagnosticsProvider extends AbstractSupport {
         }
     }
 
-    private _onDidChangeActiveTextEditor(textEditor: vscode.TextEditor): void {
+    private _onDidChangeActiveTextEditor(textEditor: vscode.TextEditor | undefined): void {
         // active text editor can be undefined.
-        if (textEditor != undefined && textEditor.document != null) {
+        if (textEditor !== undefined) {
             this._onDocumentOpenOrChange(textEditor.document);
         }
     }
@@ -272,7 +272,7 @@ class DiagnosticsProvider extends AbstractSupport {
     private _mapQuickFixesAsDiagnosticsInFile(quickFixes: protocol.QuickFix[]): { diagnostic: vscode.Diagnostic, fileName: string }[] {
         return quickFixes
             .map(quickFix => this._asDiagnosticInFileIfAny(quickFix))
-            .filter(diagnosticInFile => diagnosticInFile !== undefined);
+            .filter(diagnosticInFile => diagnosticInFile !== undefined) as { diagnostic: vscode.Diagnostic, fileName: string }[];
     }
 
     private async _validateEntireWorkspace() {
@@ -310,7 +310,7 @@ class DiagnosticsProvider extends AbstractSupport {
         this._diagnostics.set(entries);
     }
 
-    private _asDiagnosticInFileIfAny(quickFix: protocol.QuickFix): { diagnostic: vscode.Diagnostic, fileName: string } {
+    private _asDiagnosticInFileIfAny(quickFix: protocol.QuickFix): { diagnostic: vscode.Diagnostic, fileName: string } | undefined {
         let display = this._getDiagnosticDisplay(quickFix, this._asDiagnosticSeverity(quickFix));
 
         if (display.severity === "hidden") {

--- a/src/features/documentHighlightProvider.ts
+++ b/src/features/documentHighlightProvider.ts
@@ -24,9 +24,9 @@ export default class OmnisharpDocumentHighlightProvider extends AbstractSupport 
                 return res.QuickFixes.map(OmnisharpDocumentHighlightProvider._asDocumentHighlight);
             }
         }
-        catch (error) {
-            return [];
-        }
+        catch {}
+
+        return [];
     }
 
     private static _asDocumentHighlight(quickFix: protocol.QuickFix): DocumentHighlight {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -574,8 +574,8 @@ class DebugEventListener {
 
         DebugEventListener.s_activeInstance = this;
 
-        this._serverSocket = net.createServer((socket: net.Socket) => {
-            socket.on('data', (buffer: Buffer) => {
+        this._serverSocket = net.createServer(socket => {
+            socket.on('data', buffer => {
                 let event: DebuggerEventsProtocol.DebuggerEvent;
                 try {
                     event = DebuggerEventsProtocol.decodePacket(buffer);
@@ -605,10 +605,9 @@ class DebugEventListener {
         });
 
         await this.removeSocketFileIfExists();
-        return new Promise<void>((resolve, reject) => {
-            let isStarted: boolean = false;
-            this._serverSocket.on('error', (err: Error) => {
-                if (!isStarted) {
+        return new Promise((resolve, reject) => {
+            this._serverSocket.on('error', err => {
+                if (!this._serverSocket.listening) {
                     reject(err.message);
                 } else {
                     this._eventStream.post(new DotNetTestDebugWarning(`Communications error on debugger event channel. ${err.message}`));
@@ -616,7 +615,6 @@ class DebugEventListener {
             });
 
             this._serverSocket.listen(this._pipePath, () => {
-                isStarted = true;
                 resolve();
             });
         });

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -127,7 +127,7 @@ export default class TestManager extends AbstractProvider {
             vscode.workspace.saveAll(/*includeUntitled*/ false));
     }
 
-    private async _runTest(fileName: string, testMethod: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string, noBuild: boolean): Promise<protocol.V2.DotNetTestResult[] | undefined> {
+    private async _runTest(fileName: string, testMethod: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string | undefined, noBuild: boolean): Promise<protocol.V2.DotNetTestResult[] | undefined> {
         const request: protocol.V2.RunTestRequest = {
             FileName: fileName,
             MethodName: testMethod,
@@ -256,7 +256,7 @@ export default class TestManager extends AbstractProvider {
         }
     }
 
-    private async _runTestsInClass(fileName: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string, methodsToRun: string[], noBuild: boolean): Promise<protocol.V2.DotNetTestResult[]> {
+    private async _runTestsInClass(fileName: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string | undefined, methodsToRun: string[], noBuild: boolean): Promise<protocol.V2.DotNetTestResult[]> {
         const request: protocol.V2.RunTestsInClassRequest = {
             FileName: fileName,
             RunSettings: runSettings,
@@ -344,11 +344,11 @@ export default class TestManager extends AbstractProvider {
     private async _getLaunchConfigurationForVSTest(
         fileName: string,
         testMethod: string,
-        runSettings: string,
+        runSettings: string | undefined,
         testFrameworkName: string,
-        targetFrameworkVersion: string,
+        targetFrameworkVersion: string | undefined,
         debugEventListener: DebugEventListener,
-        noBuild: boolean): Promise<LaunchConfiguration> {
+        noBuild: boolean | undefined): Promise<LaunchConfiguration> {
 
         // Listen for test messages while getting start info.
         const listener = this._server.onTestMessage(e => {
@@ -474,11 +474,11 @@ export default class TestManager extends AbstractProvider {
     private async _getLaunchConfigurationForVSTestClass(
         fileName: string,
         methodsToRun: string[],
-        runSettings: string,
+        runSettings: string | undefined,
         testFrameworkName: string,
-        targetFrameworkVersion: string,
+        targetFrameworkVersion: string | undefined,
         debugEventListener: DebugEventListener,
-        noBuild: boolean): Promise<LaunchConfiguration> {
+        noBuild: boolean | undefined): Promise<LaunchConfiguration> {
 
         const listener = this._server.onTestMessage(e => {
             this._eventStream.post(new DotNetTestMessage(e.Message));
@@ -506,8 +506,8 @@ export default class TestManager extends AbstractProvider {
         fileName: string,
         line: number,
         column: number,
-        runSettings: string,
-        targetFrameworkVersion: string,
+        runSettings: string | undefined,
+        targetFrameworkVersion: string | undefined,
         debugEventListener: DebugEventListener): Promise<LaunchConfiguration | null> {
 
         const listener = this._server.onTestMessage(e => {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -25,9 +25,9 @@ const TelemetryReportingDelay = 2 * 60 * 1000; // two minutes
 
 export default class TestManager extends AbstractProvider {
 
-    private _runCounts: { [testFrameworkName: string]: number };
-    private _debugCounts: { [testFrameworkName: string]: number };
-    private _telemetryIntervalId: NodeJS.Timer = undefined;
+    private _runCounts?: { [testFrameworkName: string]: number };
+    private _debugCounts?: { [testFrameworkName: string]: number };
+    private _telemetryIntervalId?: NodeJS.Timer = undefined;
     private _eventStream: EventStream;
 
     constructor(private optionProvider: OptionProvider, server: OmniSharpServer, eventStream: EventStream, languageMiddlewareFeature: LanguageMiddlewareFeature) {

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -205,6 +205,9 @@ export default class TestManager extends AbstractProvider {
         // Path is relative to the workspace. Create absolute path.
         const fileUri = vscode.Uri.file(filename);
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
+        if (workspaceFolder === undefined) {
+            return undefined;
+        }
 
         return path.join(workspaceFolder.uri.fsPath, testSettingsPath);
     }

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -127,7 +127,7 @@ export default class TestManager extends AbstractProvider {
             vscode.workspace.saveAll(/*includeUntitled*/ false));
     }
 
-    private async _runTest(fileName: string, testMethod: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string | undefined, noBuild: boolean): Promise<protocol.V2.DotNetTestResult[] | undefined> {
+    private async _runTest(fileName: string, testMethod: string, runSettings: string | undefined, testFrameworkName: string, targetFrameworkVersion: string | undefined, noBuild: boolean): Promise<protocol.V2.DotNetTestResult[]> {
         const request: protocol.V2.RunTestRequest = {
             FileName: fileName,
             MethodName: testMethod,
@@ -137,13 +137,8 @@ export default class TestManager extends AbstractProvider {
             NoBuild: noBuild
         };
 
-        try {
-            let response = await serverUtils.runTest(this._server, request);
-            return response.Results;
-        }
-        catch {}
-
-        return undefined;
+        let response = await serverUtils.runTest(this._server, request);
+        return response.Results;
     }
 
     private async _recordRunAndGetFrameworkVersion(fileName: string, testFrameworkName?: string): Promise<string | undefined> {
@@ -227,8 +222,9 @@ export default class TestManager extends AbstractProvider {
             let results = await this._runTest(fileName, testMethod, runSettings, testFrameworkName, targetFrameworkVersion, noBuild);
             this._eventStream.post(new ReportDotNetTestResults(results));
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestRunFailure(reason));
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestRunFailure(message));
         }
         finally {
             listener.dispose();
@@ -251,8 +247,9 @@ export default class TestManager extends AbstractProvider {
             let results = await this._runTestsInClass(fileName, runSettings, testFrameworkName, targetFrameworkVersion, methodsInClass, noBuild);
             this._eventStream.post(new ReportDotNetTestResults(results));
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestRunFailure(reason));
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestRunFailure(message));
         }
         finally {
             listener.dispose();
@@ -308,8 +305,9 @@ export default class TestManager extends AbstractProvider {
                 this._eventStream.post(new ReportDotNetTestResults(response.Results));
             }
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestRunFailure(reason));
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestRunFailure(message));
         }
         finally {
             listener.dispose();
@@ -416,11 +414,10 @@ export default class TestManager extends AbstractProvider {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName));
             return vscode.debug.startDebugging(workspaceFolder, config);
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestDebugStartFailure(reason));
-            if (debugEventListener !== null) {
-                debugEventListener.close();
-            }
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestDebugStartFailure(message));
+            debugEventListener.close();
         }
     }
 
@@ -436,11 +433,10 @@ export default class TestManager extends AbstractProvider {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fileName));
             return vscode.debug.startDebugging(workspaceFolder, config);
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestDebugStartFailure(reason));
-            if (debugEventListener != null) {
-                debugEventListener.close();
-            }
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestDebugStartFailure(message));
+            debugEventListener.close();
         }
     }
 
@@ -465,11 +461,10 @@ export default class TestManager extends AbstractProvider {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
             return vscode.debug.startDebugging(workspaceFolder, config);
         }
-        catch (reason) {
-            this._eventStream.post(new DotNetTestRunFailure(reason));
-            if (debugEventListener !== null) {
-                debugEventListener.close();
-            }
+        catch (error) {
+            const message = (error as Error).message;
+            this._eventStream.post(new DotNetTestRunFailure(message));
+            debugEventListener.close();
         }
     }
 

--- a/src/features/fixAllProvider.ts
+++ b/src/features/fixAllProvider.ts
@@ -17,7 +17,7 @@ import { CancellationToken } from 'vscode-languageserver-protocol';
 export class FixAllProvider extends AbstractProvider implements vscode.CodeActionProvider {
     public static fixAllCodeActionKind =
       vscode.CodeActionKind.SourceFixAll.append('csharp');
-  
+
     public static metadata: vscode.CodeActionProviderMetadata = {
       providedCodeActionKinds: [FixAllProvider.fixAllCodeActionKind]
     };
@@ -62,7 +62,7 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
             matchOnDescription: true,
             placeHolder: `Select fix all action`
         }).then(async selectedAction => {
-            let filter: FixAllItem[] = undefined;
+            let filter: FixAllItem[] | undefined;
 
             if (selectedAction === undefined) {
                 return;
@@ -77,7 +77,7 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
         });
     }
 
-    private async applyFixes(fileName: string, scope: FixAllScope, fixAllFilter: FixAllItem[]): Promise<boolean | string | {}> {
+    private async applyFixes(fileName: string, scope: FixAllScope, fixAllFilter: FixAllItem[] | undefined): Promise<boolean | string | undefined> {
         let response = await serverUtils.runFixAll(this.server, {
             FileName: fileName,
             Scope: scope,

--- a/src/features/fixAllProvider.ts
+++ b/src/features/fixAllProvider.ts
@@ -50,7 +50,13 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
     }
 
     private async fixAllMenu(server: OmniSharpServer, scope: protocol.FixAllScope): Promise<void> {
-        let availableFixes = await serverUtils.getFixAll(server, { FileName: vscode.window.activeTextEditor.document.fileName, Scope: scope });
+        const fileName = vscode.window.activeTextEditor?.document.fileName;
+        if (fileName === undefined) {
+            vscode.window.showWarningMessage('Text editor must be focused to fix all issues');
+            return;
+        }
+
+        let availableFixes = await serverUtils.getFixAll(server, { FileName: fileName, Scope: scope });
 
         let targets = availableFixes.Items.map(x => `${x.Id}: ${x.Message}`);
 
@@ -58,26 +64,25 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
             targets = ["Fix all issues", ...targets];
         }
 
-        return vscode.window.showQuickPick(targets, {
+        const action = await vscode.window.showQuickPick(targets, {
             matchOnDescription: true,
             placeHolder: `Select fix all action`
-        }).then(async selectedAction => {
-            let filter: FixAllItem[] | undefined;
-
-            if (selectedAction === undefined) {
-                return;
-            }
-
-            if (selectedAction !== "Fix all issues") {
-                let actionTokens = selectedAction.split(":");
-                filter = [{ Id: actionTokens[0], Message: actionTokens[1] }];
-            }
-
-            await this.applyFixes(vscode.window.activeTextEditor.document.fileName, scope, filter);
         });
+
+        if (action === undefined) {
+            return;
+        }
+
+        let filter: FixAllItem[] | undefined;
+        if (action !== "Fix all issues") {
+            let actionTokens = action.split(":");
+            filter = [{ Id: actionTokens[0], Message: actionTokens[1] }];
+        }
+
+        await this.applyFixes(fileName, scope, filter);
     }
 
-    private async applyFixes(fileName: string, scope: FixAllScope, fixAllFilter: FixAllItem[] | undefined): Promise<boolean | string | undefined> {
+    private async applyFixes(fileName: string, scope: FixAllScope, fixAllFilter: FixAllItem[] | undefined): Promise<void> {
         let response = await serverUtils.runFixAll(this.server, {
             FileName: fileName,
             Scope: scope,
@@ -88,7 +93,7 @@ export class FixAllProvider extends AbstractProvider implements vscode.CodeActio
         });
 
         if (response) {
-            return buildEditForResponse(response.Changes, this._languageMiddlewareFeature, CancellationToken.None);
+            await buildEditForResponse(response.Changes, this._languageMiddlewareFeature, CancellationToken.None);
         }
     }
 }

--- a/src/features/formattingEditProvider.ts
+++ b/src/features/formattingEditProvider.ts
@@ -26,9 +26,9 @@ export default class FormattingSupport extends AbstractSupport implements Docume
                 return res.Changes.map(FormattingSupport._asEditOptionation);
             }
         }
-        catch (error) {
-            return [];
-        }
+        catch {}
+
+        return [];
     }
 
     public async provideOnTypeFormattingEdits(document: TextDocument, position: Position, ch: string, options: FormattingOptions, token: CancellationToken): Promise<TextEdit[]> {
@@ -46,9 +46,9 @@ export default class FormattingSupport extends AbstractSupport implements Docume
                 return res.Changes.map(FormattingSupport._asEditOptionation);
             }
         }
-        catch (error) {
-            return [];
-        }
+        catch {}
+
+        return [];
     }
 
     private static _asEditOptionation(change: protocol.TextChange): TextEdit {

--- a/src/features/hoverProvider.ts
+++ b/src/features/hoverProvider.ts
@@ -11,7 +11,7 @@ import { HoverProvider, Hover, TextDocument, CancellationToken, Position, Markdo
 
 export default class OmniSharpHoverProvider extends AbstractSupport implements HoverProvider {
 
-    public async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover> {
+    public async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover | undefined> {
         let request = createRequest<protocol.QuickInfoRequest>(document, position);
         try {
             const response = await serverUtils.getQuickInfo(this._server, request, token);

--- a/src/features/inlayHintProvider.ts
+++ b/src/features/inlayHintProvider.ts
@@ -60,11 +60,13 @@ export default class CSharpInlayHintProvider extends AbstractProvider implements
     }
 
     async resolveInlayHint?(hint: vscode.InlayHint, token: vscode.CancellationToken): Promise<vscode.InlayHint> {
-        if (!this._hintsMap.has(hint)) {
+        const inlayHint = this._hintsMap.get(hint);
+        if (inlayHint === undefined) {
             return Promise.reject(`Outdated inlay hint was requested to be resolved, aborting.`);
+
         }
 
-        const request: InlayHintResolveRequest = { Hint: this._hintsMap.get(hint) };
+        const request: InlayHintResolveRequest = { Hint: inlayHint };
 
         try {
             const result = await serverUtils.resolveInlayHints(this._server, request, token);
@@ -82,8 +84,8 @@ export default class CSharpInlayHintProvider extends AbstractProvider implements
             textEdits: toVSCodeTextEdits(inlayHint.TextEdits),
         };
 
-        function toVSCodeTextEdits(textEdits: LinePositionSpanTextChange[]): vscode.TextEdit[] {
-            return textEdits ? textEdits.map(toVSCodeTextEdit) : undefined;
+        function toVSCodeTextEdits(textEdits: LinePositionSpanTextChange[] | undefined): vscode.TextEdit[] | undefined {
+            return textEdits?.map(toVSCodeTextEdit) ?? undefined;
         }
     }
 }

--- a/src/features/inlayHintProvider.ts
+++ b/src/features/inlayHintProvider.ts
@@ -63,7 +63,6 @@ export default class CSharpInlayHintProvider extends AbstractProvider implements
         const inlayHint = this._hintsMap.get(hint);
         if (inlayHint === undefined) {
             return Promise.reject(`Outdated inlay hint was requested to be resolved, aborting.`);
-
         }
 
         const request: InlayHintResolveRequest = { Hint: inlayHint };

--- a/src/features/json/jsonContributions.ts
+++ b/src/features/json/jsonContributions.ts
@@ -22,11 +22,11 @@ export interface ISuggestionsCollector {
 
 export interface IJSONContribution {
     getDocumentSelector(): DocumentSelector;
-    getInfoContribution(fileName: string, location: Location): Thenable<MarkedString[]>;
-    collectPropertySuggestions(fileName: string, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Thenable<void>;
-    collectValueSuggestions(fileName: string, location: Location, result: ISuggestionsCollector): Thenable<void>;
-    collectDefaultSuggestions(fileName: string, result: ISuggestionsCollector): Thenable<void>;
-    resolveSuggestion?(item: CompletionItem): Thenable<CompletionItem>;
+    getInfoContribution(fileName: string, location: Location): Promise<MarkedString[] | undefined>;
+    collectPropertySuggestions(fileName: string, location: Location, currentWord: string, addValue: boolean, isLast: boolean, result: ISuggestionsCollector): Promise<void>;
+    collectValueSuggestions(fileName: string, location: Location, result: ISuggestionsCollector): Promise<void>;
+    collectDefaultSuggestions(fileName: string, result: ISuggestionsCollector): Promise<void>;
+    resolveSuggestion?(item: CompletionItem): Promise<CompletionItem | undefined>;
 }
 
 export function addJSONProviders(): CompositeDisposable {
@@ -35,7 +35,7 @@ export function addJSONProviders(): CompositeDisposable {
     // configure the XHR library with the latest proxy settings
     function configureHttpRequest() {
         let httpSettings = workspace.getConfiguration('http');
-        configureXHR(httpSettings.get<string>('proxy'), httpSettings.get<boolean>('proxyStrictSSL'));
+        configureXHR(httpSettings.get<string>('proxy', ''), httpSettings.get<boolean>('proxyStrictSSL', false));
     }
 
     configureHttpRequest();
@@ -58,24 +58,22 @@ export class JSONHoverProvider implements HoverProvider {
     constructor(private jsonContribution: IJSONContribution) {
     }
 
-    public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
+    public async provideHover(document: TextDocument, position: Position, token: CancellationToken): Promise<Hover | undefined> {
         let offset = document.offsetAt(position);
         let location = getLocation(document.getText(), offset);
         let node = location.previousNode;
-        if (node && node.offset <= offset && offset <= node.offset + node.length) {
-            let promise = this.jsonContribution.getInfoContribution(document.fileName, location);
-            if (promise) {
-                return promise.then(htmlContent => {
-                    let range = new Range(document.positionAt(node.offset), document.positionAt(node.offset + node.length));
-                    let result: Hover = {
-                        contents: htmlContent,
-                        range: range
-                    };
-                    return result;
-                });
+        if (node !== undefined && node.offset <= offset && offset <= node.offset + node.length) {
+            let htmlContent = await this.jsonContribution.getInfoContribution(document.fileName, location);
+            if (htmlContent !== undefined) {
+                let range = new Range(document.positionAt(node.offset), document.positionAt(node.offset + node.length));
+                let result: Hover = {
+                    contents: htmlContent,
+                    range: range
+                };
+                return result;
             }
         }
-        return null;
+        return undefined;
     }
 }
 
@@ -84,19 +82,19 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
     constructor(private jsonContribution: IJSONContribution) {
     }
 
-    public resolveCompletionItem(item: CompletionItem, token: CancellationToken): Thenable<CompletionItem> {
+    public async resolveCompletionItem(item: CompletionItem, token: CancellationToken): Promise<CompletionItem> {
         if (this.jsonContribution.resolveSuggestion) {
-            let resolver = this.jsonContribution.resolveSuggestion(item);
-            if (resolver) {
+            let resolver = await this.jsonContribution.resolveSuggestion(item);
+            if (resolver !== undefined) {
                 return resolver;
             }
         }
-        return Promise.resolve(item);
+        return item;
     }
 
-    public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Thenable<CompletionList> {
+    public async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionList | undefined> {
         let currentWord = this.getCurrentWord(document, position);
-        let overwriteRange: Range = null;
+        let overwriteRange: Range | undefined;
         let items: CompletionItem[] = [];
         let isIncomplete = false;
 
@@ -115,7 +113,7 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
             add: (suggestion: CompletionItem) => {
                 if (!proposed[<string>suggestion.label]) {
                     proposed[<string>suggestion.label] = true;
-                    if (overwriteRange) {
+                    if (overwriteRange !== undefined) {
                         suggestion.insertText = suggestion.insertText;
                         suggestion.range = overwriteRange;
                     }
@@ -128,7 +126,7 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
             log: (message: string) => console.log(message)
         };
 
-        let collectPromise: Thenable<void> = null;
+        let collectPromise: Promise<void> | undefined;
 
         if (location.isAtPropertyKey) {
             let addValue = !location.previousNode || !location.previousNode.colonOffset && (offset == (location.previousNode.offset + location.previousNode.length));
@@ -144,15 +142,12 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
                 collectPromise = this.jsonContribution.collectValueSuggestions(document.fileName, location, collector);
             }
         }
-        if (collectPromise) {
-            return collectPromise.then(() => {
-                if (items.length > 0) {
-                    return new CompletionList(items, isIncomplete);
-                }
-                return null;
-            });
+
+        await collectPromise;
+        if (items.length > 0) {
+            return new CompletionList(items, isIncomplete);
         }
-        return null;
+        return undefined;
     }
 
     private getCurrentWord(document: TextDocument, position: Position) {

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -21,15 +21,12 @@ const FEED_INDEX_URL = 'https://api.nuget.org/v3/index.json';
 const LIMIT = 30;
 
 interface NugetServices {
-    'SearchQueryService'?: string;
-    'SearchAutocompleteService'?: string;
-    'PackageBaseAddress/3.0.0'?: string;
     [key: string]: string;
 }
 
 export class ProjectJSONContribution implements IJSONContribution {
 
-    private nugetIndexPromise: Thenable<NugetServices>;
+    private nugetIndexPromise?: Promise<NugetServices>;
 
     public constructor(private requestService: XHRRequest) {
     }
@@ -38,135 +35,129 @@ export class ProjectJSONContribution implements IJSONContribution {
         return [{ language: 'json', pattern: '**/project.json' }];
     }
 
-    private getNugetIndex(): Thenable<NugetServices> {
-        if (!this.nugetIndexPromise) {
-            this.nugetIndexPromise = this.makeJSONRequest<NuGetIndexResponse>(FEED_INDEX_URL).then(indexContent => {
-                let services: NugetServices = {};
-                if (indexContent && Array.isArray(indexContent.resources)) {
-                    let resources = indexContent.resources;
-                    for (let i = resources.length - 1; i >= 0; i--) {
-                        let type = resources[i]['@type'];
-                        let id = resources[i]['@id'];
-                        if (type && id) {
-                            services[type] = id;
-                        }
+    private async getNugetIndex(): Promise<NugetServices> {
+        if (this.nugetIndexPromise === undefined) {
+            const indexContent = await this.makeJSONRequest<NuGetIndexResponse>(FEED_INDEX_URL);
+            let services: NugetServices = {};
+            if (indexContent && Array.isArray(indexContent.resources)) {
+                let resources = indexContent.resources;
+                for (let i = resources.length - 1; i >= 0; i--) {
+                    let type = resources[i]['@type'];
+                    let id = resources[i]['@id'];
+                    if (type && id) {
+                        services[type] = id;
                     }
                 }
-                return services;
-            });
+            }
+            return services;
         }
         return this.nugetIndexPromise;
     }
 
-    private getNugetService(serviceType: string): Thenable<string> {
-        return this.getNugetIndex().then(services => {
-            let serviceURL = services[serviceType];
-            if (!serviceURL) {
-                return Promise.reject<string>(localize('json.nugget.error.missingservice', 'NuGet index document is missing service {0}', serviceType));
-            }
-            return serviceURL;
-        });
+    private async getNugetService(serviceType: string): Promise<string> {
+        const services = await this.getNugetIndex();
+        let serviceURL = services[serviceType];
+        if (!serviceURL) {
+            return Promise.reject(localize('json.nugget.error.missingservice', 'NuGet index document is missing service {0}', serviceType));
+        }
+        return serviceURL;
     }
 
-    private makeJSONRequest<T>(url: string): Thenable<T> {
-        return this.requestService({
+    private async makeJSONRequest<T>(url: string): Promise<T> {
+        const response = await this.requestService({
             url: url
-        }).then(success => {
-            if (success.status === 200) {
+        });
+
+        try {
+            if (response.status === 200) {
                 try {
-                    return <T>JSON.parse(success.responseText);
+                    return JSON.parse(response.responseText) as T;
                 } catch (e) {
-                    return Promise.reject<T>(localize('json.nugget.error.invalidformat', '{0} is not a valid JSON document', url));
+                    return Promise.reject(localize('json.nugget.error.invalidformat', '{0} is not a valid JSON document', url));
                 }
             }
-            return Promise.reject<T>(localize('json.nugget.error.indexaccess', 'Request to {0} failed: {1}', url, success.responseText));
-        }, async (error: XHRResponse) => {
-            return Promise.reject<T>(localize('json.nugget.error.access', 'Request to {0} failed: {1}', url, getErrorStatusDescription(error.status)));
-        });
+            return Promise.reject(localize('json.nugget.error.indexaccess', 'Request to {0} failed: {1}', url, response.responseText));
+        } catch (error) {
+            return Promise.reject(localize('json.nugget.error.access', 'Request to {0} failed: {1}', url, getErrorStatusDescription((error as XHRResponse).status)));
+        }
     }
 
-    public collectPropertySuggestions(
+    public async collectPropertySuggestions(
         resource: string,
         location: Location,
         currentWord: string,
         addValue: boolean,
         isLast: boolean,
-        result: ISuggestionsCollector): Thenable<void> {
+        result: ISuggestionsCollector): Promise<void> {
         if ((location.matches(['dependencies']) || location.matches(['frameworks', '*', 'dependencies']) || location.matches(['frameworks', '*', 'frameworkAssemblies']))) {
-
-            return this.getNugetService('SearchAutocompleteService').then(service => {
+            try {
+                const service = await this.getNugetService('SearchAutocompleteService');
                 let queryUrl: string;
                 if (currentWord.length > 0) {
                     queryUrl = service + '?q=' + encodeURIComponent(currentWord) + '&take=' + LIMIT;
                 } else {
                     queryUrl = service + '?take=' + LIMIT;
                 }
-                return this.makeJSONRequest<NuGetSearchAutocompleteServiceResponse>(queryUrl).then(resultObj => {
-                    if (Array.isArray(resultObj.data)) {
-                        let results = resultObj.data;
-                        for (let i = 0; i < results.length; i++) {
-                            let name = results[i];
-                            let insertText = JSON.stringify(name);
-                            if (addValue) {
-                                insertText += ': "{{}}"';
-                                if (!isLast) {
-                                    insertText += ',';
-                                }
+
+                const response = await this.makeJSONRequest<NuGetSearchAutocompleteServiceResponse>(queryUrl);
+                if (Array.isArray(response.data)) {
+                    let results = response.data;
+                    for (let i = 0; i < results.length; i++) {
+                        let name = results[i];
+                        let insertText = JSON.stringify(name);
+                        if (addValue) {
+                            insertText += ': "{{}}"';
+                            if (!isLast) {
+                                insertText += ',';
                             }
+                        }
+                        let proposal = new CompletionItem(name);
+                        proposal.kind = CompletionItemKind.Property;
+                        proposal.insertText = insertText;
+                        proposal.filterText = JSON.stringify(name);
+                        result.add(proposal);
+                    }
+                    if (results.length === LIMIT) {
+                        result.setAsIncomplete();
+                    }
+                }
+            } catch (error) {
+                result.error(error as string);
+            }
+        }
+    }
+
+    public async collectValueSuggestions(resource: string, location: Location, result: ISuggestionsCollector): Promise<void> {
+        if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
+            try {
+                const service = await this.getNugetService('PackageBaseAddress/3.0.0');
+                let currentKey = location.path[location.path.length - 1];
+                if (typeof currentKey === 'string') {
+                    let queryUrl = service + currentKey + '/index.json';
+                    const response = await this.makeJSONRequest<NuGetFlatContainerPackageResponse>(queryUrl);
+                    if (Array.isArray(response.versions)) {
+                        let results = response.versions;
+                        for (let i = 0; i < results.length; i++) {
+                            let curr = results[i];
+                            let name = JSON.stringify(curr);
                             let proposal = new CompletionItem(name);
-                            proposal.kind = CompletionItemKind.Property;
-                            proposal.insertText = insertText;
-                            proposal.filterText = JSON.stringify(name);
+                            proposal.kind = CompletionItemKind.Class;
+                            proposal.insertText = name;
+                            proposal.documentation = '';
                             result.add(proposal);
                         }
                         if (results.length === LIMIT) {
                             result.setAsIncomplete();
                         }
                     }
-                }, error => {
-                    result.error(error);
-                });
-            }, error => {
-                result.error(error);
-            });
-        }
-        return null;
-    }
-
-    public collectValueSuggestions(resource: string, location: Location, result: ISuggestionsCollector): Thenable<void> {
-        if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
-            return this.getNugetService('PackageBaseAddress/3.0.0').then(service => {
-                let currentKey = location.path[location.path.length - 1];
-                if (typeof currentKey === 'string') {
-                    let queryUrl = service + currentKey + '/index.json';
-                    return this.makeJSONRequest<NuGetFlatContainerPackageResponse>(queryUrl).then(obj => {
-                        if (Array.isArray(obj.versions)) {
-                            let results = obj.versions;
-                            for (let i = 0; i < results.length; i++) {
-                                let curr = results[i];
-                                let name = JSON.stringify(curr);
-                                let proposal = new CompletionItem(name);
-                                proposal.kind = CompletionItemKind.Class;
-                                proposal.insertText = name;
-                                proposal.documentation = '';
-                                result.add(proposal);
-                            }
-                            if (results.length === LIMIT) {
-                                result.setAsIncomplete();
-                            }
-                        }
-                    }, error => {
-                        result.error(error);
-                    });
                 }
-            }, error => {
-                result.error(error);
-            });
+            } catch (error) {
+                result.error(error as string);
+            }
         }
-        return null;
     }
 
-    public collectDefaultSuggestions(resource: string, result: ISuggestionsCollector): Thenable<null> {
+    public async collectDefaultSuggestions(resource: string, result: ISuggestionsCollector): Promise<void> {
         let defaultValue = {
             'version': '{{1.0.0-*}}',
             'dependencies': {},
@@ -179,69 +170,62 @@ export class ProjectJSONContribution implements IJSONContribution {
         proposal.kind = CompletionItemKind.Module;
         proposal.insertText = JSON.stringify(defaultValue, null, '\t');
         result.add(proposal);
-        return null;
     }
 
-    public resolveSuggestion(item: CompletionItem): Thenable<CompletionItem> {
+    public async resolveSuggestion(item: CompletionItem): Promise<CompletionItem | undefined> {
         if (item.kind === CompletionItemKind.Property) {
             let pack = item.label;
-            return this.getInfo(<string>pack).then(info => {
-                if (info.description) {
-                    item.documentation = info.description;
-                }
-                if (info.version) {
-                    item.detail = info.version;
-                    item.insertText = (<string>item.insertText).replace(/\{\{\}\}/, '{{' + info.version + '}}');
-                }
-                return item;
-            });
+            const info = await this.getInfo(<string>pack);
+            if (info !== undefined) {
+                item.documentation = info.description;
+                item.detail = info.version;
+                item.insertText = (<string>item.insertText).replace(/\{\{\}\}/, '{{' + info.version + '}}');
+            }
+            return item;
         }
-        return null;
+        return undefined;
     }
 
-    private getInfo(pack: string): Thenable<{ description?: string; version?: string }> {
-        return this.getNugetService('SearchQueryService').then(service => {
+    private async getInfo(pack: string): Promise<{ description: string; version: string } | undefined> {
+        try {
+            const service = await this.getNugetService('SearchQueryService');
             let queryUrl = service + '?q=' + encodeURIComponent(pack) + '&take=' + 5;
-            return this.makeJSONRequest<NuGetSearchQueryServiceResponse>(queryUrl).then(resultObj => {
-                if (Array.isArray(resultObj.data)) {
-                    let results = resultObj.data;
-                    let info: { description?: string; version?: string } = {};
-                    for (let i = 0; i < results.length; i++) {
-                        let res = results[i];
-                        if (res.id === pack) {
-                            info.description = res.description;
-                            info.version = localize('json.nugget.version.hover', 'Latest version: {0}', res.version);
-                        }
+            const response = await this.makeJSONRequest<NuGetSearchQueryServiceResponse>(queryUrl);
+            if (Array.isArray(response.data)) {
+                let results = response.data;
+                let info: { description: string; version: string } | undefined;
+                for (let i = 0; i < results.length; i++) {
+                    let res = results[i];
+                    if (res.id === pack) {
+                        info = {
+                            description: res.description,
+                            version: localize('json.nugget.version.hover', 'Latest version: {0}', res.version),
+                        };
                     }
-                    return info;
                 }
-                return null;
-            }, (error) => {
-                return null;
-            });
-        }, (error) => {
-            return null;
-        });
+                return info;
+            }
+            return undefined;
+        } catch (error) {
+            return undefined;
+        };
     }
 
 
-    public getInfoContribution(resource: string, location: Location): Thenable<MarkedString[]> {
+    public async getInfoContribution(resource: string, location: Location): Promise<MarkedString[] | undefined> {
         if ((location.matches(['dependencies', '*']) || location.matches(['frameworks', '*', 'dependencies', '*']) || location.matches(['frameworks', '*', 'frameworkAssemblies', '*']))) {
             let pack = location.path[location.path.length - 1];
             if (typeof pack === 'string') {
-                return this.getInfo(pack).then(info => {
+                const info = await this.getInfo(pack);
+                if (info !== undefined) {
                     let htmlContent: MarkedString[] = [];
                     htmlContent.push(localize('json.nugget.package.hover', '{0}', pack));
-                    if (info.description) {
-                        htmlContent.push(info.description);
-                    }
-                    if (info.version) {
-                        htmlContent.push(info.version);
-                    }
+                    htmlContent.push(info.description);
+                    htmlContent.push(info.version);
                     return htmlContent;
-                });
+                }
             }
         }
-        return null;
+        return undefined;
     }
 }

--- a/src/features/json/projectJSONContribution.ts
+++ b/src/features/json/projectJSONContribution.ts
@@ -122,7 +122,8 @@ export class ProjectJSONContribution implements IJSONContribution {
                     }
                 }
             } catch (error) {
-                result.error(error as string);
+                const message = (error as Error).message;
+                result.error(message);
             }
         }
     }
@@ -152,7 +153,8 @@ export class ProjectJSONContribution implements IJSONContribution {
                     }
                 }
             } catch (error) {
-                result.error(error as string);
+                const message = (error as Error).message;
+                result.error(message);
             }
         }
     }

--- a/src/features/referenceProvider.ts
+++ b/src/features/referenceProvider.ts
@@ -34,9 +34,9 @@ export default class OmnisharpReferenceProvider extends AbstractSupport implemen
                 return result;
             }
         }
-        catch (error) {
-            return [];
-        }
+        catch {}
+
+        return [];
     }
 
     private mapToLocationWithGeneratedInfoPopulation(symbolLocation: protocol.SymbolLocation): Location {

--- a/src/features/renameProvider.ts
+++ b/src/features/renameProvider.ts
@@ -11,7 +11,7 @@ import { RenameProvider, WorkspaceEdit, TextDocument, Uri, CancellationToken, Po
 
 export default class OmnisharpRenameProvider extends AbstractSupport implements RenameProvider {
 
-    public async provideRenameEdits(document: TextDocument, position: Position, newName: string, token: CancellationToken): Promise<WorkspaceEdit> {
+    public async provideRenameEdits(document: TextDocument, position: Position, newName: string, token: CancellationToken): Promise<WorkspaceEdit | undefined> {
 
         let req = createRequest<protocol.RenameRequest>(document, position);
         req.WantsTextChanges = true;

--- a/src/features/reportIssue.ts
+++ b/src/features/reportIssue.ts
@@ -3,9 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { vscode } from "../vscodeAdapter";
-import { Extension } from "../vscodeAdapter";
-import { CSharpExtensionId } from "../constants/CSharpExtensionId";
+import { vscode, Extension } from "../vscodeAdapter";
 import { EventStream } from "../EventStream";
 import { OpenURL } from "../omnisharp/loggingEvents";
 import { Options } from "../omnisharp/options";
@@ -14,11 +12,10 @@ import { IGetDotnetInfo } from "../constants/IGetDotnetInfo";
 
 const issuesUrl = "https://github.com/OmniSharp/omnisharp-vscode/issues/new";
 
-export default async function reportIssue(vscode: vscode, eventStream: EventStream, getDotnetInfo: IGetDotnetInfo, isValidPlatformForMono: boolean, options: Options, monoResolver: IHostExecutableResolver) {
+export default async function reportIssue(vscode: vscode, csharpExtVersion: string, eventStream: EventStream, getDotnetInfo: IGetDotnetInfo, isValidPlatformForMono: boolean, options: Options, monoResolver: IHostExecutableResolver) {
     const dotnetInfo = await getDotnetInfo();
     const monoInfo = await getMonoIfPlatformValid(isValidPlatformForMono, options, monoResolver);
     let extensions = getInstalledExtensions(vscode);
-    let csharpExtVersion = getCsharpExtensionVersion(vscode);
 
     const body = `## Issue Description ##
 ## Steps to Reproduce ##
@@ -83,7 +80,7 @@ ${tableHeader}\n${table};
 
 async function getMonoIfPlatformValid(isValidPlatformForMono: boolean, options: Options, monoResolver: IHostExecutableResolver): Promise<string> {
     if (isValidPlatformForMono) {
-        let monoVersion: string;
+        let monoVersion = "Unknown Mono version";
         try {
             let monoInfo = await monoResolver.getHostExecutableInfo(options);
             if (monoInfo) {
@@ -108,9 +105,4 @@ function getInstalledExtensions(vscode: vscode) {
         .filter(extension => extension.packageJSON.isBuiltin === false);
 
     return extensions.sort(sortExtensions);
-}
-
-function getCsharpExtensionVersion(vscode: vscode): string {
-    const extension = vscode.extensions.getExtension(CSharpExtensionId);
-    return extension.packageJSON.version;
 }

--- a/src/features/reportIssue.ts
+++ b/src/features/reportIssue.ts
@@ -84,10 +84,8 @@ async function getMonoIfPlatformValid(isValidPlatformForMono: boolean, options: 
     if (isValidPlatformForMono) {
         let monoVersion = "Unknown Mono version";
         try {
-            let monoInfo = await monoResolver.getHostExecutableInfo(options);
-            if (monoInfo) {
-                monoVersion = `OmniSharp using mono :${monoInfo.version}`;
-            }
+            const monoInfo = await monoResolver.getHostExecutableInfo(options);
+            monoVersion = `OmniSharp using mono: ${monoInfo.version}`;
         }
         catch (error) {
             monoVersion = `There is a problem with running OmniSharp on mono: ${error}`;

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -171,7 +171,7 @@ export default class SemanticTokensProvider extends AbstractProvider implements 
 
     async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens | null> {
 
-        return this._provideSemanticTokens(document, null, token);
+        return this._provideSemanticTokens(document, undefined, token);
     }
 
     async provideDocumentRangeSemanticTokens(document: vscode.TextDocument, range: vscode.Range, token: vscode.CancellationToken): Promise<vscode.SemanticTokens | null> {
@@ -189,7 +189,7 @@ export default class SemanticTokensProvider extends AbstractProvider implements 
         return this._provideSemanticTokens(document, v2Range, token);
     }
 
-    async _provideSemanticTokens(document: vscode.TextDocument, range: protocol.V2.Range, token: vscode.CancellationToken): Promise<vscode.SemanticTokens | null> {
+    async _provideSemanticTokens(document: vscode.TextDocument, range: protocol.V2.Range | undefined, token: vscode.CancellationToken): Promise<vscode.SemanticTokens | null> {
         // We can only semantically highlight file from disk.
         if (document.uri.scheme !== "file") {
             return null;

--- a/src/features/semanticTokensProvider.ts
+++ b/src/features/semanticTokensProvider.ts
@@ -312,7 +312,7 @@ tokenModifiers[DefaultTokenModifier.modification] = 'modification';
 tokenModifiers[DefaultTokenModifier.async] = 'async';
 tokenModifiers[DefaultTokenModifier.readonly] = 'readonly';
 
-const tokenTypeMap: number[] = [];
+const tokenTypeMap: (number | undefined)[] = [];
 tokenTypeMap[SemanticHighlightClassification.Comment] = DefaultTokenType.comment;
 tokenTypeMap[SemanticHighlightClassification.ExcludedCode] = CustomTokenType.excludedCode;
 tokenTypeMap[SemanticHighlightClassification.Identifier] = DefaultTokenType.variable;

--- a/src/features/signatureHelpProvider.ts
+++ b/src/features/signatureHelpProvider.ts
@@ -12,7 +12,7 @@ import { SignatureHelpParameter } from '../omnisharp/protocol';
 
 export default class OmniSharpSignatureHelpProvider extends AbstractSupport implements SignatureHelpProvider {
 
-    public async provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp> {
+    public async provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp | undefined> {
 
         let req = createRequest(document, position);
 

--- a/src/features/sourceGeneratedDocumentProvider.ts
+++ b/src/features/sourceGeneratedDocumentProvider.ts
@@ -81,32 +81,18 @@ export default class SourceGeneratedDocumentProvider implements TextDocumentCont
         this._documents.clear();
     }
 
-    public tryGetExistingSourceGeneratedFile(fileInfo: SourceGeneratedFileInfo): Uri | undefined {
-        const sourceName = this._documents.get(fileInfo)?.SourceName;
-        if (sourceName !== undefined) {
-            return this.getUriForName(sourceName);
-        }
-
-        return undefined;
-    }
-
     public addSourceGeneratedFileWithoutInitialContent(fileInfo: SourceGeneratedFileInfo, fileName: string): Uri {
-        if (this._documents.has(fileInfo)) {
+        const response = this._documents.get(fileInfo);
+        if (response !== undefined) {
             // Raced with something, return the existing one.
-            // Bang is validated via has.
-            return this.tryGetExistingSourceGeneratedFile(fileInfo)!;
+            return this.getUriForName(response.SourceName);
         }
 
         const uri = this.getUriForName(fileName);
         const uriString = uri.toString();
 
-        if (this._uriToDocumentInfo.has(uriString)) {
-            this._documents.delete(fileInfo);
-            this._uriToDocumentInfo.delete(uriString);
-        }
-
-        // Provide will see the null and retrieve the file when asked.
-        this._documents.set(fileInfo, null);
+        // Provide will see that the document doesn't exist and retrieve the file when asked.
+        this._documents.delete(fileInfo);
         this._uriToDocumentInfo.set(uriString, fileInfo);
 
         return uri;

--- a/src/features/sourceGeneratedDocumentProvider.ts
+++ b/src/features/sourceGeneratedDocumentProvider.ts
@@ -11,7 +11,7 @@ import { OmniSharpServer } from '../omnisharp/server';
 
 export default class SourceGeneratedDocumentProvider implements TextDocumentContentProvider, IDisposable {
     readonly scheme = "omnisharp-source-generated";
-    private _registration: IDisposable;
+    private _registration?: IDisposable;
     private _documents: Map<SourceGeneratedFileInfo, SourceGeneratedFileResponse>;
     private _uriToDocumentInfo: Map<string, SourceGeneratedFileInfo>;
     private _documentClosedSubscription: IDisposable;
@@ -30,21 +30,21 @@ export default class SourceGeneratedDocumentProvider implements TextDocumentCont
 
     private async onTextDocumentClosed(document: TextDocument) {
         const uriString = document.uri.toString();
-        if (this._uriToDocumentInfo.has(uriString)) {
-            const info = this._uriToDocumentInfo.get(uriString);
+        const info = this._uriToDocumentInfo.get(uriString);
+        if (info !== undefined) {
             this._documents.delete(info);
             this._uriToDocumentInfo.delete(uriString);
             await serverUtils.sourceGeneratedFileClosed(this.server, info);
         }
     }
 
-    private async onVisibleTextEditorsChanged(editors?: TextEditor[]) {
+    private async onVisibleTextEditorsChanged(editors: readonly TextEditor[]) {
         for (const editor of editors) {
             const documentUri = editor.document.uri;
             const uriString = documentUri.toString();
-            if (this._uriToDocumentInfo.has(uriString)) {
+            const existingInfo = this._uriToDocumentInfo.get(uriString);
+            if (existingInfo !== undefined) {
                 try {
-                    const existingInfo = this._uriToDocumentInfo.get(uriString);
                     const existingResponse = this._documents.get(existingInfo);
                     const update = await serverUtils.getUpdatedSourceGeneratedFile(this.server, existingInfo);
                     if (!update) {
@@ -75,15 +75,16 @@ export default class SourceGeneratedDocumentProvider implements TextDocumentCont
     }
 
     public dispose() {
-        this._registration.dispose();
+        this._registration?.dispose();
         this._documentClosedSubscription.dispose();
         this._visibleTextEditorsChangedSubscription.dispose();
         this._documents.clear();
     }
 
     public tryGetExistingSourceGeneratedFile(fileInfo: SourceGeneratedFileInfo): Uri | undefined {
-        if (this._documents.has(fileInfo)) {
-            return this.getUriForName(this._documents.get(fileInfo).SourceName);
+        const sourceName = this._documents.get(fileInfo)?.SourceName;
+        if (sourceName !== undefined) {
+            return this.getUriForName(sourceName);
         }
 
         return undefined;
@@ -91,8 +92,9 @@ export default class SourceGeneratedDocumentProvider implements TextDocumentCont
 
     public addSourceGeneratedFileWithoutInitialContent(fileInfo: SourceGeneratedFileInfo, fileName: string): Uri {
         if (this._documents.has(fileInfo)) {
-            // Raced with something, return the existing one
-            return this.tryGetExistingSourceGeneratedFile(fileInfo);
+            // Raced with something, return the existing one.
+            // Bang is validated via has.
+            return this.tryGetExistingSourceGeneratedFile(fileInfo)!;
         }
 
         const uri = this.getUriForName(fileName);
@@ -114,7 +116,7 @@ export default class SourceGeneratedDocumentProvider implements TextDocumentCont
         const fileInfo = this._uriToDocumentInfo.get(uri.toString());
         let response = this._documents.get(fileInfo);
 
-        if (response === null) {
+        if (response === undefined) {
             // No content yet, get it
             response = await serverUtils.getSourceGeneratedFile(this.server, fileInfo, token);
             this._documents.set(fileInfo, response);

--- a/src/features/structureProvider.ts
+++ b/src/features/structureProvider.ts
@@ -6,11 +6,11 @@
 import { FoldingRangeProvider, TextDocument, FoldingContext, CancellationToken, FoldingRange, FoldingRangeKind } from "vscode";
 import AbstractSupport from './abstractProvider';
 import { blockStructure } from "../omnisharp/utils";
-import { Request } from "../omnisharp/protocol";
+import { V2 } from "../omnisharp/protocol";
 
 export class StructureProvider extends AbstractSupport implements FoldingRangeProvider {
     async provideFoldingRanges(document: TextDocument, context: FoldingContext, token: CancellationToken): Promise<FoldingRange[]> {
-        let request: Request = {
+        let request: V2.BlockStructureRequest = {
             FileName: document.fileName,
         };
 

--- a/src/features/structureProvider.ts
+++ b/src/features/structureProvider.ts
@@ -28,7 +28,7 @@ export class StructureProvider extends AbstractSupport implements FoldingRangePr
         }
     }
 
-    GetType(type: string): FoldingRangeKind {
+    GetType(type: string): FoldingRangeKind | undefined {
         switch (type) {
             case "Comment":
                 return FoldingRangeKind.Comment;
@@ -37,7 +37,7 @@ export class StructureProvider extends AbstractSupport implements FoldingRangePr
             case "Region":
                 return FoldingRangeKind.Region;
             default:
-                return null;
+                return undefined;
         }
     }
 

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -35,7 +35,7 @@ export default class OmnisharpWorkspaceSymbolProvider extends AbstractSupport im
         }
 
         try {
-            const res = await serverUtils.findSymbols(this._server, { Filter: search, MaxItemsToReturn: maxItemsToReturn, FileName: '' }, token);
+            const res = await serverUtils.findSymbols(this._server, { Filter: search, MaxItemsToReturn: maxItemsToReturn }, token);
             if (Array.isArray(res?.QuickFixes)) {
                 return res.QuickFixes.map(symbol => this._asSymbolInformation(symbol));
             }

--- a/src/features/workspaceSymbolProvider.ts
+++ b/src/features/workspaceSymbolProvider.ts
@@ -26,23 +26,23 @@ export default class OmnisharpWorkspaceSymbolProvider extends AbstractSupport im
 
     public async provideWorkspaceSymbols(search: string, token: CancellationToken): Promise<SymbolInformation[]> {
 
-        let options = this.optionProvider.GetLatestOptions();
-        let minFilterLength = options.minFindSymbolsFilterLength > 0 ? options.minFindSymbolsFilterLength : undefined;
-        let maxItemsToReturn = options.maxFindSymbolsItems > 0 ? options.maxFindSymbolsItems : undefined;
+        const options = this.optionProvider.GetLatestOptions();
+        const minFilterLength = options.minFindSymbolsFilterLength > 0 ? options.minFindSymbolsFilterLength : undefined;
+        const maxItemsToReturn = options.maxFindSymbolsItems > 0 ? options.maxFindSymbolsItems : undefined;
 
-        if (minFilterLength != undefined && search.length < minFilterLength) {
+        if (minFilterLength !== undefined && search.length < minFilterLength) {
             return [];
         }
 
         try {
-            let res = await serverUtils.findSymbols(this._server, { Filter: search, MaxItemsToReturn: maxItemsToReturn, FileName: '' }, token);
-            if (res && Array.isArray(res.QuickFixes)) {
+            const res = await serverUtils.findSymbols(this._server, { Filter: search, MaxItemsToReturn: maxItemsToReturn, FileName: '' }, token);
+            if (Array.isArray(res?.QuickFixes)) {
                 return res.QuickFixes.map(symbol => this._asSymbolInformation(symbol));
             }
         }
-        catch (error) {
-            return [];
-        }
+        catch {}
+
+        return [];
     }
 
     private _asSymbolInformation(symbolInfo: protocol.SymbolLocation): SymbolInformation {

--- a/src/omnisharp/extension.ts
+++ b/src/omnisharp/extension.ts
@@ -98,7 +98,7 @@ export async function activate(context: vscode.ExtensionContext, packageJSON: an
             localDisposables.add(vscode.languages.registerOnTypeFormattingEditProvider(documentSelector, new FormatProvider(server, languageMiddlewareFeature), '}', '/', '\n', ';'));
         }
         localDisposables.add(vscode.languages.registerCompletionItemProvider(documentSelector, completionProvider, '.', ' '));
-        localDisposables.add(vscode.commands.registerCommand(CompletionAfterInsertCommand, async (item) => completionProvider.afterInsert(item)));
+        localDisposables.add(vscode.commands.registerCommand(CompletionAfterInsertCommand, async (item, document) => completionProvider.afterInsert(item, document)));
         localDisposables.add(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(server, optionProvider, languageMiddlewareFeature, sourceGeneratedDocumentProvider)));
         localDisposables.add(vscode.languages.registerSignatureHelpProvider(documentSelector, new SignatureHelpProvider(server, languageMiddlewareFeature), '(', ','));
         // Since the CodeActionProvider registers its own commands, we must instantiate it and add it to the localDisposables

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -90,7 +90,7 @@ export class OmnisharpRequestMessage implements BaseEvent {
 
 export class TestExecutionCountReport implements BaseEvent {
     type = EventType.TestExecutionCountReport;
-    constructor(public debugCounts: { [testFrameworkName: string]: number }, public runCounts: { [testFrameworkName: string]: number }) { }
+    constructor(public debugCounts: { [testFrameworkName: string]: number } | undefined, public runCounts: { [testFrameworkName: string]: number } | undefined) { }
 }
 
 export class OmnisharpServerOnError implements BaseEvent {
@@ -185,7 +185,7 @@ export class ZipError implements BaseEvent {
 
 export class ReportDotNetTestResults implements BaseEvent {
     type = EventType.ReportDotNetTestResults;
-    constructor(public results: protocol.V2.DotNetTestResult[]) { }
+    constructor(public results: protocol.V2.DotNetTestResult[] | undefined) { }
 }
 
 export class DotNetTestRunStart implements BaseEvent {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -749,9 +749,9 @@ export namespace V2 {
 
     // dotnet-test endpoints
     interface BaseTestRequest extends Request {
-        RunSettings: string;
+        RunSettings?: string;
         TestFrameworkName: string;
-        TargetFrameworkVersion: string;
+        TargetFrameworkVersion?: string;
         NoBuild?: boolean;
     }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -71,7 +71,7 @@ export namespace WireProtocol {
 }
 
 export interface FileBasedRequest {
-    FileName: string;
+    FileName?: string;
 }
 
 export interface Request extends FileBasedRequest {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -505,6 +505,12 @@ export interface RunFixAllRequest extends FileBasedRequest {
     ApplyChanges: boolean;
 }
 
+export interface ReAnalyzeRequest extends FileBasedRequest {
+}
+
+export interface ReAnalyzeReponse {
+}
+
 export interface QuickInfoRequest extends Request {
 }
 

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -580,10 +580,16 @@ export interface SourceGeneratedFileResponse {
 export interface UpdateSourceGeneratedFileRequest extends SourceGeneratedFileInfo {
 }
 
-export interface UpdateSourceGeneratedFileResponse {
-    UpdateType: UpdateType;
-    Source?: string;
+interface UpdateSourceGeneratedFileNotModifiedResponse {
+    UpdateType: Exclude<UpdateType, UpdateType.Modified>;
 }
+
+interface UpdateSourceGeneratedFileModifiedResponse {
+    UpdateType: UpdateType.Modified;
+    Source: string;
+}
+
+export type UpdateSourceGeneratedFileResponse = UpdateSourceGeneratedFileNotModifiedResponse | UpdateSourceGeneratedFileModifiedResponse;
 
 export enum UpdateType {
     Unchanged,

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -137,8 +137,8 @@ export async function getMetadata(server: OmniSharpServer, request: protocol.Met
     return server.makeRequest<protocol.MetadataResponse>(protocol.Requests.Metadata, request);
 }
 
-export async function reAnalyze(server: OmniSharpServer, request: any) {
-    return server.makeRequest<any>(protocol.Requests.ReAnalyze, request);
+export async function reAnalyze(server: OmniSharpServer, request: protocol.ReAnalyzeRequest) {
+    return server.makeRequest<protocol.ReAnalyzeReponse>(protocol.Requests.ReAnalyze, request);
 }
 
 export async function getTestStartInfo(server: OmniSharpServer, request: protocol.V2.GetTestStartInfoRequest) {

--- a/src/statusBarItemAdapter.ts
+++ b/src/statusBarItemAdapter.ts
@@ -32,11 +32,11 @@ export class StatusBarItemAdapter implements vscodeAdapter.StatusBarItem {
         this.statusBarItem.tooltip = value;
     }
 
-    get color(): string {
-        return this.statusBarItem.color as string;
+    get color(): string | vscode.ThemeColor | undefined {
+        return this.statusBarItem.color;
     }
 
-    set color(value: string) {
+    set color(value: string | vscode.ThemeColor | undefined) {
         this.statusBarItem.color = value;
     }
 

--- a/src/vscodeAdapter.ts
+++ b/src/vscodeAdapter.ts
@@ -982,7 +982,6 @@ export interface vscode {
         onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
     };
     extensions: {
-        getExtension(extensionId: string): Extension<any> | undefined;
         all: ReadonlyArray<Extension<any>>;
     };
     Uri: {

--- a/src/vscodeAdapter.ts
+++ b/src/vscodeAdapter.ts
@@ -223,6 +223,18 @@ export interface Command {
     arguments?: any[];
 }
 
+/**
+ * A reference to one of the workbench colors as defined in https://code.visualstudio.com/docs/getstarted/theme-color-reference.
+ * Using a theme color is preferred over a custom color as it gives theme authors and users the possibility to change the color.
+ */
+declare class ThemeColor {
+    /**
+     * Creates a reference to a theme color.
+     * @param id of the color. The available colors are listed in https://code.visualstudio.com/docs/getstarted/theme-color-reference.
+     */
+    constructor(id: string);
+}
+
 export interface StatusBarItem {
 
     /**
@@ -254,7 +266,7 @@ export interface StatusBarItem {
     /**
      * The foreground color for this entry.
      */
-    color: string | undefined;
+    color: string | ThemeColor | undefined;
 
     /**
      * The identifier of a command to run on click. The command must be

--- a/test/unitTests/features/reportIssue.test.ts
+++ b/test/unitTests/features/reportIssue.test.ts
@@ -50,14 +50,6 @@ suite(`${reportIssue.name}`, () => {
 
     setup(() => {
         vscode = getFakeVsCode();
-        vscode.extensions.getExtension = () => {
-            return {
-                packageJSON: {
-                    version: csharpExtVersion
-                },
-                id: ""
-            };
-        };
 
         vscode.env.clipboard.writeText = (body: string) => {
             issueBody = body;

--- a/test/unitTests/features/reportIssue.test.ts
+++ b/test/unitTests/features/reportIssue.test.ts
@@ -61,7 +61,7 @@ suite(`${reportIssue.name}`, () => {
 
         vscode.env.clipboard.writeText = (body: string) => {
             issueBody = body;
-            return undefined;
+            return Promise.resolve();
         };
 
         vscode.version = vscodeVersion;
@@ -73,52 +73,52 @@ suite(`${reportIssue.name}`, () => {
     });
 
     test(`${OpenURL.name} event is created`, async () => {
-        await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
         let events = eventBus.getEvents();
         expect(events).to.have.length(1);
         expect(events[0].constructor.name).to.be.equal(`${OpenURL.name}`);
     });
 
     test(`${OpenURL.name} event is created with the omnisharp-vscode github repo issues url`, async () => {
-        await reportIssue(vscode, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
+        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
         let url = (<OpenURL>eventBus.getEvents()[0]).url;
         expect(url).to.include("https://github.com/OmniSharp/omnisharp-vscode/issues/new?body=Please paste the output from your clipboard");
     });
 
     suite("The body is passed to the vscode clipboard and", () => {
         test("it contains the vscode version", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(issueBody).to.include(`**VSCode version**: ${vscodeVersion}`);
         });
 
         test("it contains the csharp extension version", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(issueBody).to.include(`**C# Extension**: ${csharpExtVersion}`);
         });
 
         test("it contains dotnet info", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(issueBody).to.contain(fakeDotnetInfo.FullInfo);
         });
 
         test("mono information is obtained when it is a valid mono platform", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(true);
         });
 
         test("mono version is put in the body when it is a valid mono platform", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(true);
             expect(issueBody).to.contain(fakeMonoInfo.version);
         });
 
         test("mono information is not obtained when it is not a valid mono platform", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(false);
         });
 
         test("The url contains the name, publisher and version for all the extensions that are not builtin", async () => {
-            await reportIssue(vscode, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
             expect(issueBody).to.contain(extension2.packageJSON.name);
             expect(issueBody).to.contain(extension2.packageJSON.publisher);
             expect(issueBody).to.contain(extension2.packageJSON.version);

--- a/test/unitTests/features/reportIssue.test.ts
+++ b/test/unitTests/features/reportIssue.test.ts
@@ -65,52 +65,52 @@ suite(`${reportIssue.name}`, () => {
     });
 
     test(`${OpenURL.name} event is created`, async () => {
-        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
         let events = eventBus.getEvents();
         expect(events).to.have.length(1);
         expect(events[0].constructor.name).to.be.equal(`${OpenURL.name}`);
     });
 
     test(`${OpenURL.name} event is created with the omnisharp-vscode github repo issues url`, async () => {
-        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
+        await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeDotnetResolver, fakeMonoResolver);
         let url = (<OpenURL>eventBus.getEvents()[0]).url;
         expect(url).to.include("https://github.com/OmniSharp/omnisharp-vscode/issues/new?body=Please paste the output from your clipboard");
     });
 
     suite("The body is passed to the vscode clipboard and", () => {
         test("it contains the vscode version", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(issueBody).to.include(`**VSCode version**: ${vscodeVersion}`);
         });
 
         test("it contains the csharp extension version", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(issueBody).to.include(`**C# Extension**: ${csharpExtVersion}`);
         });
 
         test("it contains dotnet info", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(issueBody).to.contain(fakeDotnetInfo.FullInfo);
         });
 
         test("mono information is obtained when it is a valid mono platform", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(true);
         });
 
         test("mono version is put in the body when it is a valid mono platform", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(true);
             expect(issueBody).to.contain(fakeMonoInfo.version);
         });
 
         test("mono information is not obtained when it is not a valid mono platform", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, false, options, fakeDotnetResolver, fakeMonoResolver);
             expect(fakeMonoResolver.getMonoCalled).to.be.equal(false);
         });
 
         test("The url contains the name, publisher and version for all the extensions that are not builtin", async () => {
-            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeMonoResolver, fakeDotnetResolver);
+            await reportIssue(vscode, csharpExtVersion, eventStream, getDotnetInfo, isValidForMono, options, fakeDotnetResolver, fakeMonoResolver);
             expect(issueBody).to.contain(extension2.packageJSON.name);
             expect(issueBody).to.contain(extension2.packageJSON.publisher);
             expect(issueBody).to.contain(extension2.packageJSON.version);

--- a/test/unitTests/testAssets/Fakes.ts
+++ b/test/unitTests/testAssets/Fakes.ts
@@ -134,9 +134,6 @@ export function getFakeVsCode(): vscode.vscode {
             }
         },
         extensions: {
-            getExtension: () => {
-                throw new Error("Not Implemented");
-            },
             all: []
         },
         Uri: {


### PR DESCRIPTION
Note: I'm aware of #5276 and that the feature/ folder may well become obsolete in the near future.
Nevertheless, given there's no set timeline yet, I figure the sooner strict mode can be turned on globally, the better, and I also got to learn some new TypeScript tricks along the way (like type guards).

**Note that none of these changes have been validated on an actual codebase.**

A good chunk of the fixes fall into one of two buckets: a) simply explicitly returning undefined (or an empty array) when we have nothing to return to VS Code or b) reducing a `has` check on a Map followed by a `get` to just `get` and then a check against undefined.

Otherwise:
* Significant refactoring around creating codelens for tests. Mostly removing helper methods and checking for things inline, where we have more context on whether something can be nullable or not.
* For commands that need to act on active text editors, added various guards to make sure there _is_ an active editor in the first place.
* For autocomplete, pass the document that the initial autocomplete acted upon to afterInsert, to avoid race conditions where a) the active text editor changed, or b) the active text editor was closed between the time it took to insert the completion and call afterInsert.
* Changed Process in processPicker from a class to an interface - there is still some manual casting needed when we add a finalized process to the array, but at least we're no longer creating invalid Process classes anymore.

Impact:
Brings strict errors down to 234 from 377 when compared to master @ 9336244b129c7ca3a451e634514632fc2e764379.
(If we ignore tests, the number of violations goes down further to just 40, 27 of which are in folders I haven't looked at yet.)