### PR TITLE
coreclr-debug nullability

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -168,14 +168,16 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
 
         // debugger has finished installation, kick off our debugger process
 
-        // Check for targetArchitecture
-        let dotNetInfo = await getDotnetInfo(this.options.dotNetCliPaths);
-        const targetArchitecture: string = getTargetArchitecture(this.platformInfo, _session.configuration.targetArchitecture, dotNetInfo);
-
         // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
         if (!executable) {
+            const dotNetInfo = await getDotnetInfo(this.options.dotNetCliPaths);
+            const targetArchitecture = getTargetArchitecture(this.platformInfo, _session.configuration.targetArchitecture, dotNetInfo);
             const command = path.join(common.getExtensionPath(), ".debugger", targetArchitecture, "vsdbg-ui" + CoreClrDebugUtil.getPlatformExeExtension());
-            executable = new vscode.DebugAdapterExecutable(command, [], { env: { 'DOTNET_ROOT' : dotNetInfo.CliPath ? path.dirname(dotNetInfo.CliPath) : '' } });
+            executable = new vscode.DebugAdapterExecutable(command, [], {
+                env: {
+                    DOTNET_ROOT: dotNetInfo.CliPath ? path.dirname(dotNetInfo.CliPath) : '',
+                }
+            });
         }
 
         // make VS Code launch the DA executable

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -12,16 +12,14 @@ import { DebuggerPrerequisiteWarning, DebuggerPrerequisiteFailure, DebuggerNotIn
 import { EventStream } from '../EventStream';
 import CSharpExtensionExports from '../CSharpExtensionExports';
 import { getRuntimeDependencyPackageWithId } from '../tools/RuntimeDependencyPackageUtils';
-import { getDotnetInfo, DotnetInfo } from '../utils/getDotnetInfo';
+import { getDotnetInfo } from '../utils/getDotnetInfo';
 import { DotnetDebugConfigurationProvider } from './debugConfigurationProvider';
 import { Options } from '../omnisharp/options';
 
-let _debugUtil: CoreClrDebugUtil = null;
-
 export async function activate(thisExtension: vscode.Extension<CSharpExtensionExports>, context: vscode.ExtensionContext, platformInformation: PlatformInformation, eventStream: EventStream, options: Options) {
-    _debugUtil = new CoreClrDebugUtil(context.extensionPath);
+    const debugUtil = new CoreClrDebugUtil(context.extensionPath);
 
-    if (!CoreClrDebugUtil.existsSync(_debugUtil.debugAdapterDir())) {
+    if (!CoreClrDebugUtil.existsSync(debugUtil.debugAdapterDir())) {
         let isValidArchitecture: boolean = await checkIsValidArchitecture(platformInformation, eventStream);
         // If this is a valid architecture, we should have had a debugger, so warn if we didn't, otherwise
         // a warning was already issued, so do nothing.
@@ -29,11 +27,11 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
             eventStream.post(new DebuggerPrerequisiteFailure("[ERROR]: C# Extension failed to install the debugger package."));
             showInstallErrorMessage(eventStream);
         }
-    } else if (!CoreClrDebugUtil.existsSync(_debugUtil.installCompleteFilePath())) {
-        completeDebuggerInstall(platformInformation, eventStream, options);
+    } else if (!CoreClrDebugUtil.existsSync(debugUtil.installCompleteFilePath())) {
+        completeDebuggerInstall(debugUtil, platformInformation, eventStream, options);
     }
 
-    const factory = new DebugAdapterExecutableFactory(platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath, options);
+    const factory = new DebugAdapterExecutableFactory(debugUtil, platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath, options);
     context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation)));
     context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation)));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
@@ -74,30 +72,29 @@ async function checkIsValidArchitecture(platformInformation: PlatformInformation
     return false;
 }
 
-async function completeDebuggerInstall(platformInformation: PlatformInformation, eventStream: EventStream, options: Options): Promise<boolean> {
-    return _debugUtil.checkDotNetCli(options.dotNetCliPaths)
-        .then(async (dotnetInfo: DotnetInfo) => {
-
-            let isValidArchitecture: boolean = await checkIsValidArchitecture(platformInformation, eventStream);
-
-            if (!isValidArchitecture) {
-                eventStream.post(new DebuggerNotInstalledFailure());
-                vscode.window.showErrorMessage('Failed to complete the installation of the C# extension. Please see the error in the output window below.');
-                return false;
-            }
-
-            // Write install.complete
-            CoreClrDebugUtil.writeEmptyFile(_debugUtil.installCompleteFilePath());
-
-            return true;
-        }, (err) => {
-            // Check for dotnet tools failed. pop the UI
-            // err is a DotNetCliError but use defaults in the unexpected case that it's not
-            showDotnetToolsWarning(err.ErrorMessage || _debugUtil.defaultDotNetCliErrorMessage());
-            eventStream.post(new DebuggerPrerequisiteWarning(err.ErrorString || err));
-            // TODO: log telemetry?
+async function completeDebuggerInstall(debugUtil: CoreClrDebugUtil, platformInformation: PlatformInformation, eventStream: EventStream, options: Options): Promise<boolean> {
+    try {
+        await debugUtil.checkDotNetCli(options.dotNetCliPaths);
+        const isValidArchitecture = await checkIsValidArchitecture(platformInformation, eventStream);
+        if (!isValidArchitecture) {
+            eventStream.post(new DebuggerNotInstalledFailure());
+            vscode.window.showErrorMessage('Failed to complete the installation of the C# extension. Please see the error in the output window below.');
             return false;
-        });
+        }
+
+        // Write install.complete
+        CoreClrDebugUtil.writeEmptyFile(debugUtil.installCompleteFilePath());
+
+        return true;
+    } catch (err) {
+        const error = err as Error;
+
+        // Check for dotnet tools failed. pop the UI
+        showDotnetToolsWarning(error.message);
+        eventStream.post(new DebuggerPrerequisiteWarning(error.message));
+        // TODO: log telemetry?
+        return false;
+    }
 }
 
 function showInstallErrorMessage(eventStream: EventStream) {
@@ -133,7 +130,7 @@ function showDotnetToolsWarning(message: string): void {
 // Else it will launch the debug adapter
 export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescriptorFactory {
 
-    constructor(private readonly platformInfo: PlatformInformation, private readonly eventStream: EventStream, private readonly packageJSON: any, private readonly extensionPath: string, private readonly options: Options) {
+    constructor(private readonly debugUtil: CoreClrDebugUtil, private readonly platformInfo: PlatformInformation, private readonly eventStream: EventStream, private readonly packageJSON: any, private readonly extensionPath: string, private readonly options: Options) {
     }
 
     async createDebugAdapterDescriptor(_session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): Promise<vscode.DebugAdapterDescriptor> {
@@ -161,8 +158,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
             }
             // install.complete does not exist, check dotnetCLI to see if we can complete.
             else if (!CoreClrDebugUtil.existsSync(util.installCompleteFilePath())) {
-                let success: boolean = await completeDebuggerInstall(this.platformInfo, this.eventStream, this.options);
-
+                let success = await completeDebuggerInstall(this.debugUtil, this.platformInfo, this.eventStream, this.options);
                 if (!success) {
                     this.eventStream.post(new DebuggerNotInstalledFailure());
                     throw new Error('Failed to complete the installation of the C# extension. Please see the error in the output window below.');

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -11,7 +11,7 @@ import { PlatformInformation } from '../platform';
 export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(public platformInformation: PlatformInformation) {}
 
-    public async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration>
+    public async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration | null | undefined>
     {
         if (!debugConfiguration)
         {
@@ -21,7 +21,7 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
         // Process Id is empty, handle Attach to Process Dialog.
         if (debugConfiguration.request === "attach" && !debugConfiguration.processId && !debugConfiguration.processName)
         {
-            let process: AttachItem = undefined;
+            let process: AttachItem | undefined;
             if (debugConfiguration.pipeTransport)
             {
                 process = await RemoteAttachPicker.ShowAttachEntries(debugConfiguration, this.platformInformation);
@@ -33,15 +33,15 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                 process = await attacher.ShowAttachEntries();
             }
 
-            if (process)
+            if (process !== undefined)
             {
                 debugConfiguration.processId = process.id;
 
-                if (debugConfiguration.type == "coreclr" && 
-                    this.platformInformation.isMacOS() && 
+                if (debugConfiguration.type == "coreclr" &&
+                    this.platformInformation.isMacOS() &&
                     this.platformInformation.architecture == 'arm64')
                 {
-                    // For Apple Silicon M1, it is possible that the process we are attaching to is being emulated as x86_64. 
+                    // For Apple Silicon M1, it is possible that the process we are attaching to is being emulated as x86_64.
                     // The process is emulated if it has process flags has P_TRANSLATED (0x20000).
                     if (process.flags & 0x20000)
                     {

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -83,10 +83,11 @@ export class CoreClrDebugUtil {
             fs.accessSync(path, fs.constants.F_OK);
             return true;
         } catch (err) {
-            if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+            const error = err as NodeJS.ErrnoException;
+            if (error.code === 'ENOENT' || error.code === 'ENOTDIR') {
                 return false;
             } else {
-                throw Error(err.code);
+                throw Error(error.code);
             }
         }
     }

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as semver from 'semver';
 import * as os from 'os';
 import { PlatformInformation } from './../platform';
-import { getDotnetInfo, DotnetInfo, DOTNET_MISSING_MESSAGE } from '../utils/getDotnetInfo';
+import { getDotnetInfo, DotnetInfo } from '../utils/getDotnetInfo';
 
 const MINIMUM_SUPPORTED_DOTNET_CLI: string = '1.0.0';
 
@@ -59,16 +59,14 @@ export class CoreClrDebugUtil {
     // This function checks for the presence of dotnet on the path and ensures the Version
     // is new enough for us.
     public async checkDotNetCli(dotNetCliPaths: string[]): Promise<void> {
-        let dotnetInfo = await getDotnetInfo(dotNetCliPaths);
-
-        if (dotnetInfo.FullInfo === DOTNET_MISSING_MESSAGE) {
-            // something went wrong with spawning 'dotnet --info'
-            throw new Error('The .NET Core SDK cannot be located. .NET Core debugging will not be enabled. Make sure the .NET Core SDK is installed and is on the path.');
-        }
-
-        // succesfully spawned 'dotnet --info', check the Version
-        if (semver.lt(dotnetInfo.Version, MINIMUM_SUPPORTED_DOTNET_CLI)) {
-            throw new Error(`The .NET Core SDK located on the path is too old. .NET Core debugging will not be enabled. The minimum supported version is ${MINIMUM_SUPPORTED_DOTNET_CLI}.`);
+        try {
+            const dotnetInfo = await getDotnetInfo(dotNetCliPaths);
+            if (semver.lt(dotnetInfo.Version, MINIMUM_SUPPORTED_DOTNET_CLI)) {
+                throw new Error(`The .NET Core SDK located on the path is too old. .NET Core debugging will not be enabled. The minimum supported version is ${MINIMUM_SUPPORTED_DOTNET_CLI}.`);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : `${error}`;
+            throw new Error(`The .NET Core SDK cannot be located: ${message}. .NET Core debugging will not be enabled. Make sure the .NET Core SDK is installed and is on the path.`);
         }
     }
 

--- a/src/features/reportIssue.ts
+++ b/src/features/reportIssue.ts
@@ -15,7 +15,15 @@ const issuesUrl = "https://github.com/OmniSharp/omnisharp-vscode/issues/new";
 
 export default async function reportIssue(vscode: vscode, csharpExtVersion: string, eventStream: EventStream, getDotnetInfo: IGetDotnetInfo, isValidPlatformForMono: boolean, options: Options, dotnetResolver: IHostExecutableResolver, monoResolver: IHostExecutableResolver) {
     // Get info for the dotnet that the Omnisharp executable is run on, not the dotnet Omnisharp will execute user code on.
-    const dotnetInfo = await getDotnetInfo([ dirname((await dotnetResolver.getHostExecutableInfo(options)).path) ]);
+    let fullDotnetInfo: string | undefined;
+    try {
+        const dotnetInfo = await getDotnetInfo([ dirname((await dotnetResolver.getHostExecutableInfo(options)).path) ]);
+        fullDotnetInfo = dotnetInfo.FullInfo;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : `${error}`;
+        fullDotnetInfo = message;
+    }
+
     const monoInfo = await getMonoIfPlatformValid(isValidPlatformForMono, options, monoResolver);
     let extensions = getInstalledExtensions(vscode);
 
@@ -41,7 +49,7 @@ export default async function reportIssue(vscode: vscode, csharpExtVersion: stri
 
 ${monoInfo}
 <details><summary>Dotnet Information</summary>
-${dotnetInfo.FullInfo}</details>
+${fullDotnetInfo}</details>
 <details><summary>Visual Studio Code Extensions</summary>
 ${generateExtensionTable(extensions)}
 </details>

--- a/src/utils/getDotnetInfo.ts
+++ b/src/utils/getDotnetInfo.ts
@@ -15,7 +15,7 @@ export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInf
         return _dotnetInfo;
     }
 
-    let dotnetExeName = join('dotnet', CoreClrDebugUtil.getPlatformExeExtension());
+    let dotnetExeName = `dotnet${CoreClrDebugUtil.getPlatformExeExtension()}`;
     let dotnetExecutablePath: string | undefined;
 
     for (const dotnetPath of dotNetCliPaths) {

--- a/test/unitTests/Fakes/FakeGetDotnetInfo.ts
+++ b/test/unitTests/Fakes/FakeGetDotnetInfo.ts
@@ -9,7 +9,6 @@ import { DotnetInfo } from "../../../src/utils/getDotnetInfo";
 export const fakeDotnetInfo: DotnetInfo = {
     FullInfo: "myDotnetInfo",
     Version: "1.0.x",
-    OsVersion: "Fake86",
     RuntimeId: "1.1.x"
 };
 export const FakeGetDotnetInfo: IGetDotnetInfo = async () => Promise.resolve(fakeDotnetInfo);

--- a/test/unitTests/ParsedEnvironmentFile.test.ts
+++ b/test/unitTests/ParsedEnvironmentFile.test.ts
@@ -11,28 +11,25 @@ suite("ParsedEnvironmentFile", () => {
 
     test("Add single variable", () => {
         const content = `MyName=VALUE`;
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName"].should.equal("VALUE");
     });
 
     test("Handle quoted values", () => {
         const content = `MyName="VALUE"`;
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName"].should.equal("VALUE");
     });
 
     test("Handle BOM", () => {
         const content = "\uFEFFMyName=VALUE";
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName"].should.equal("VALUE");
     });
 
@@ -42,10 +39,9 @@ MyName1=Value1
 MyName2=Value2
 
 `;
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName1"].should.equal("Value1");
         result.Env["MyName2"].should.equal("Value2");
     });
@@ -56,13 +52,13 @@ MyName1=Value1
 MyName2=Value2
 
 `;
-        const initialEnv: { [key: string]: any } = {
+        const initialEnv = {
             "MyName1": "Value7",
             "ThisShouldNotChange": "StillHere"
         };
         const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", initialEnv);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName1"].should.equal("Value1");
         result.Env["MyName2"].should.equal("Value2");
         result.Env["ThisShouldNotChange"].should.equal("StillHere");
@@ -74,10 +70,9 @@ MyName1=Value1
 # This is a comment in the middle of the file
 MyName2=Value2
 `;
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        expect(result.Warning).to.be.null;
+        expect(result.Warning).to.be.undefined;
         result.Env["MyName1"].should.equal("Value1");
         result.Env["MyName2"].should.equal("Value2");
     });
@@ -89,10 +84,10 @@ MyName1=Value1
 MyName2=Value2
 
 `;
-        const fakeConfig: { [key: string]: any } = {};
-        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", fakeConfig["env"]);
+        const result = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", undefined);
 
-        result.Warning.should.startWith("Ignoring non-parseable lines in envFile TestEnvFileName");
+        expect(result.Warning).not.to.be.undefined;
+        result.Warning!.should.startWith("Ignoring non-parseable lines in envFile TestEnvFileName");
         result.Env["MyName1"].should.equal("Value1");
         result.Env["MyName2"].should.equal("Value2");
     });

--- a/test/unitTests/coreclr-debug/targetArchitecture.test.ts
+++ b/test/unitTests/coreclr-debug/targetArchitecture.test.ts
@@ -43,9 +43,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 5", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "5.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-x64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "5.0.0",
+                RuntimeId: "osx.11.0-x64",
+            };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
 
@@ -54,9 +56,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-arm64", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-arm64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-arm64",
+            };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
 
@@ -65,9 +69,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-x64", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-x64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-x64",
+            };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
 
@@ -76,9 +82,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-arm64 with targetArchitecture: 'arm64'", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-arm64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-arm64",
+            };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, "arm64", dotnetInfo);
 
@@ -87,9 +95,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-arm64 with targetArchitecture: 'x86_64'", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-x86_64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-x86_64",
+            };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, "x86_64", dotnetInfo);
 
@@ -98,9 +108,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-arm64 with invalid targetArchitecture", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-x86_64";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-x86_64",
+            };
 
             let fn = function () { getTargetArchitecture(platformInfo, "x64", dotnetInfo); };
 
@@ -109,9 +121,11 @@ suite("getTargetArchitecture Tests", () => {
 
         test("Apple ARM64 on .NET 6 osx-arm64 with invalid RuntimeId", () => {
             const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
-            const dotnetInfo: DotnetInfo = new DotnetInfo();
-            dotnetInfo.Version = "6.0.0";
-            dotnetInfo.RuntimeId = "osx.11.0-FUTURE_ISA";
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "osx.11.0-FUTURE_ISA",
+            };
 
             let fn = function () { getTargetArchitecture(platformInfo, null, dotnetInfo); };
 

--- a/test/unitTests/coreclr-debug/targetArchitecture.test.ts
+++ b/test/unitTests/coreclr-debug/targetArchitecture.test.ts
@@ -14,9 +14,14 @@ suite("getTargetArchitecture Tests", () => {
 
     suite("Windows", () => {
         test("Windows x86_64", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("win32", "x86_64", null);
+            const platformInfo = new PlatformInformation("win32", "x86_64");
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "5.0.0",
+                RuntimeId: "win10-x64",
+            };
 
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, null);
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
             assert.equal(targetArchitecture, "");
         });
@@ -24,9 +29,14 @@ suite("getTargetArchitecture Tests", () => {
 
     suite("Linux", () => {
         test("getTargetArchitecture on Linux", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("linux", "x86_64", null);
+            const platformInfo = new PlatformInformation("linux", "x86_64");
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "5.0.0",
+                RuntimeId: "linux-x64",
+            };
 
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, null);
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
             assert.equal(targetArchitecture, "");
         });
@@ -34,54 +44,59 @@ suite("getTargetArchitecture Tests", () => {
 
     suite("macOS", () => {
         test("Apple x86_64", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "x86_64", null);
-
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, null);
-
-            assert.equal(targetArchitecture, "x86_64");
-        });
-
-        test("Apple ARM64 on .NET 5", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "x86_64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "5.0.0",
                 RuntimeId: "osx.11.0-x64",
             };
 
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
+
+            assert.equal(targetArchitecture, "x86_64");
+        });
+
+        test("Apple ARM64 on .NET 5", () => {
+            const platformInfo = new PlatformInformation("darwin", "arm64");
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "5.0.0",
+                RuntimeId: "osx.11.0-x64",
+            };
+
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
             assert.equal(targetArchitecture, "x86_64");
         });
 
         test("Apple ARM64 on .NET 6 osx-arm64", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
                 RuntimeId: "osx.11.0-arm64",
             };
 
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
             assert.equal(targetArchitecture, "arm64");
         });
 
         test("Apple ARM64 on .NET 6 osx-x64", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
                 RuntimeId: "osx.11.0-x64",
             };
 
-            const targetArchitecture = getTargetArchitecture(platformInfo, null, dotnetInfo);
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
             assert.equal(targetArchitecture, "x86_64");
         });
 
         test("Apple ARM64 on .NET 6 osx-arm64 with targetArchitecture: 'arm64'", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
@@ -94,7 +109,7 @@ suite("getTargetArchitecture Tests", () => {
         });
 
         test("Apple ARM64 on .NET 6 osx-arm64 with targetArchitecture: 'x86_64'", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
@@ -107,7 +122,7 @@ suite("getTargetArchitecture Tests", () => {
         });
 
         test("Apple ARM64 on .NET 6 osx-arm64 with invalid targetArchitecture", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
@@ -120,14 +135,14 @@ suite("getTargetArchitecture Tests", () => {
         });
 
         test("Apple ARM64 on .NET 6 osx-arm64 with invalid RuntimeId", () => {
-            const platformInfo: PlatformInformation = new PlatformInformation("darwin", "arm64", null);
+            const platformInfo = new PlatformInformation("darwin", "arm64");
             const dotnetInfo: DotnetInfo = {
                 FullInfo: "Irrelevant",
                 Version: "6.0.0",
                 RuntimeId: "osx.11.0-FUTURE_ISA",
             };
 
-            let fn = function () { getTargetArchitecture(platformInfo, null, dotnetInfo); };
+            let fn = function () { getTargetArchitecture(platformInfo, undefined, dotnetInfo); };
 
             expect(fn).to.throw(`Unexpected RuntimeId 'osx.11.0-FUTURE_ISA'.`);
         });


### PR DESCRIPTION
This handles the coreclr-debug folder. This is the last src folder that needs to be converted; one more PR will follow to address recent changes to the other folders & enable strict mode for all of src.

Behavior changes:
* DotNetCliError has been removed. We now show the complete error string in both the notification and the output channel. (This isn't strictly necessary - I can always add the error back, just didn't think the overhead of a custom error type was worth it here.)
* getDotnetInfo now throws if version info can't be parsed.
* ❗Fixed dotnetExeName using `path.join` instead of just string concatenation, resulting in a Windows executable of `dotnet\.exe` rather than `dotnet.exe`.
* Converted DotnetInfo from a class to an interface and removed the unused OsVersion property.

Impact:
22 strict violations in src, down from 43 in master. (Fun fact: including test, we're now at 198 strict violations. Below 200!)