### PR TITLE
fixed MSBuild requirement check

### DIFF
--- a/src/omnisharp/requirementCheck.ts
+++ b/src/omnisharp/requirementCheck.ts
@@ -84,7 +84,7 @@ async function checkRequirements(options: Options): Promise<RequirementResult> {
         return {
             needsMono: monoError,
             needsDotNetSdk: false,
-            needsMSBuildTools: msbuildVersion !== undefined,
+            needsMSBuildTools: msbuildVersion === undefined,
         };
     }
 }


### PR DESCRIPTION
The current requirements check contains invalid comparison. 

When MsBuild is discovered, a string version is returned, while if it is not discovered, `undefined` is returned.

Fixes #5443 