### PR TITLE
Handle custom OmniSharp launch paths

### DIFF
--- a/src/omnisharp/launcher.ts
+++ b/src/omnisharp/launcher.ts
@@ -340,10 +340,16 @@ function getConfigurationValue(globalConfig: vscode.WorkspaceConfiguration, csha
 
 async function launchDotnet(launchPath: string, cwd: string, args: string[], platformInfo: PlatformInformation, options: Options, dotnetResolver: IHostExecutableResolver): Promise<IntermediateLaunchResult> {
     const dotnetInfo = await dotnetResolver.getHostExecutableInfo(options);
-    const command = platformInfo.isWindows() ? 'dotnet.exe' : 'dotnet';
-    const argsCopy = args.slice(0);
 
-    argsCopy.unshift(launchPath);
+    let command: string;
+    const argsCopy = args.slice(0);
+    if (!launchPath.endsWith('.dll')) {
+        // If a custom path was set that's not a dll, assume whatever we're given is an executable
+        command = launchPath;
+    } else {
+        command = platformInfo.isWindows() ? 'dotnet.exe' : 'dotnet';
+        argsCopy.unshift(launchPath);
+    }
 
     const process = spawn(command, argsCopy, { detached: false, cwd, env: dotnetInfo.env });
 


### PR DESCRIPTION
This restores the .dll check that was removed in 6a538af974588104683d8f3f345b5113865c21ba, to properly handle when a custom OmniSharp path is specified in settings. Thanks to @prettybits for reporting the regression!

Fixes #5449. I walked through the other code paths and I _believe_ they still handle custom paths correctly.