### PR TITLE
Carlosguerravz/devcerts check

### DIFF
--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -338,3 +338,16 @@ Example:
 ```json
     "targetArchitecture": "arm64"
 ```
+
+## Check for DevCert
+If unspecified, it will be enabled when `serverReadyAction` is set AND when `pipeTransport` is NOT set.
+
+When `true` and if VS is runing on Windows or MacOS, the extension will try to find if your system contains development certificates by running `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating them. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create self signed certificates.
+
+You can override this behavior by setting `checkForDevCert` in your `launch.json`.
+
+Example:
+
+```json
+    "checkForDevCert": "false"
+```

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -342,9 +342,9 @@ Example:
 ## Check for DevCert
 If unspecified, it will be enabled when `serverReadyAction` is set AND when `pipeTransport` is NOT set.
 
-When `true` and if VS is runing on Windows or MacOS, the extension will try to find if your system contains development certificates by running `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating them. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create self signed certificates.
+When `true` and if VS is runing on Windows or MacOS, the extension will try to find if your system contains a development certificate by running `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating them. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create self signed certificates.
 
-You can override this behavior by setting `checkForDevCert` in your `launch.json`.
+You can override this behavior by setting `checkForDevCert` to false in your `launch.json`.
 
 Example:
 

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -341,7 +341,7 @@ Example:
 
 ## Check for DevCert
 
-This option controls if, on launch, the the debugger should check if the computer has a self-signed HTTPS certificate used to develop web projects running on https endpoints. For this it will try to run `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating one. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create a trusted self-signed certificate.
+This option controls if, on launch, the the debugger should check if the computer has a self-signed HTTPS certificate used to develop web projects running on https endpoints. For this it will try to run `dotnet dev-certs https --check --trust`, if no certs are found it will prompt the user to suggest creating one. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create a trusted self-signed certificate.
 
 If unspecified, defaults to true when `serverReadyAction` is set.
 This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios.

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -341,7 +341,7 @@ Example:
 
 ## Check for DevCert
 
-When `true` and if Visual Studio Code is runing on Windows or MacOS, the the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints, it will try to run `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating one. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create a trusted self-signed certificate.
+This option controls if, on launch, the the debugger should check if the computer has a self-signed HTTPS certificate used to develop web projects running on https endpoints. For this it will try to run `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating one. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create a trusted self-signed certificate.
 
 If unspecified, defaults to true when `serverReadyAction` is set.
 This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios.

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -340,9 +340,11 @@ Example:
 ```
 
 ## Check for DevCert
-If unspecified, it will be enabled when `serverReadyAction` is set AND when `pipeTransport` is NOT set.
 
-When `true` and if VS is runing on Windows or MacOS, the extension will try to find if your system contains a development certificate by running `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating them. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create self signed certificates.
+When `true` and if Visual Studio Code is runing on Windows or MacOS, the the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints, it will try to run `dotnet dev-certs https --check`, if no certs are found it will prompt the user to suggest creating one. If approved by the user, the extension will run `dotnet dev-certs https --trust` to create a trusted self-signed certificate.
+
+If unspecified, defaults to true when `serverReadyAction` is set.
+This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios.
 
 You can override this behavior by setting `checkForDevCert` to false in your `launch.json`.
 

--- a/package.json
+++ b/package.json
@@ -1985,7 +1985,7 @@
               },
               "checkForDevCert": {
                 "type": "boolean",
-                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
+                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
                 "default": true
               }
             }
@@ -3117,7 +3117,7 @@
               },
               "checkForDevCert": {
                 "type": "boolean",
-                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
+                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
                 "default": true
               }
             }

--- a/package.json
+++ b/package.json
@@ -1982,6 +1982,11 @@
               "targetArchitecture": {
                 "type": "string",
                 "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+              },
+              "checkForDevCert": {
+                "type": "boolean",
+                "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+                "default": true
               }
             }
           },
@@ -3109,6 +3114,11 @@
               "targetArchitecture": {
                 "type": "string",
                 "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+              },
+              "checkForDevCert": {
+                "type": "boolean",
+                "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+                "default": true
               }
             }
           },

--- a/package.json
+++ b/package.json
@@ -1985,7 +1985,7 @@
               },
               "checkForDevCert": {
                 "type": "boolean",
-                "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
                 "default": true
               }
             }
@@ -3117,7 +3117,7 @@
               },
               "checkForDevCert": {
                 "type": "boolean",
-                "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+                "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
                 "default": true
               }
             }

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -32,8 +32,8 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
     }
 
     const factory = new DebugAdapterExecutableFactory(debugUtil, platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath, options);
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation)));
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation, options)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation, options)));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
 }

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -32,8 +32,8 @@ export async function activate(thisExtension: vscode.Extension<CSharpExtensionEx
     }
 
     const factory = new DebugAdapterExecutableFactory(debugUtil, platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath, options);
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation, options)));
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation, options)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('coreclr', new DotnetDebugConfigurationProvider(platformInformation, eventStream, options)));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('clr', new DotnetDebugConfigurationProvider(platformInformation, eventStream, options)));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
 }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -75,16 +75,17 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
 
             if (debugConfiguration.checkForDevCert)
             {
-                hasDotnetDevCertsHttps(this.options.dotNetCliPaths).then(async (hasDevCert) => {
-                    if(!hasDevCert)
+                hasDotnetDevCertsHttps(this.options.dotNetCliPaths).then(async (returnData) => {
+                    if(returnData.error) //if the prcess returns 0 error is null, otherwise the return code can ba acessed in returnData.error.code
                     {
                         const result = await vscode.window.showInformationMessage(
                             "The selected launch configuration is configured to launch a web browser but no trusted development certificate was found. Create a trusted self-signed certificate?", 
-                            'Yes', 'Not Now', "Don't Ask Again", 
+                            { title:"Yes"}, { title:'Not Now', isCloseAffordance: true }, { title:"Don't Ask Again"}
                             ); 
-                        if (result === 'Yes')
+                        if (result?.title === 'Yes')
                         {
-                            if (await createSelfSignedCert(this.options.dotNetCliPaths))
+                            let returnData = await createSelfSignedCert(this.options.dotNetCliPaths);
+                            if (!returnData.error)
                             {
                                 vscode.window.showInformationMessage('Self-signed certificate sucessfully created');
                             }
@@ -93,7 +94,7 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                                 vscode.window.showWarningMessage("Couldn't create self-signed certificate");
                             }
                         }
-                        else if (result === "Don't Ask Again")
+                        if (result?.title === "Don't Ask Again") //TODO: change option to More information and redirect to debugger-launchjson.md
                         {
                             await vscode.window.showInformationMessage("To don't see this message again set launch option 'checkForDevCert' to 'false' in launch.json", { modal: true });
                         }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -80,12 +80,12 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                     {
                         const result = await vscode.window.showInformationMessage(
                             "The selected launch configuration is configured to launch a web browser but no trusted development certificate was found. Create a trusted self-signed certificate?", 
-                            { title:"Yes"}, { title:'Not Now', isCloseAffordance: true }, { title:"Don't Ask Again"}
+                            { title:"Yes"}, { title:'Not Now', isCloseAffordance: true }, { title:"More Information"}
                             ); 
                         if (result?.title === 'Yes')
                         {
                             let returnData = await createSelfSignedCert(this.options.dotNetCliPaths);
-                            if (!returnData.error)
+                            if (returnData.error === null)
                             {
                                 vscode.window.showInformationMessage('Self-signed certificate sucessfully created');
                             }
@@ -94,9 +94,10 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                                 vscode.window.showWarningMessage("Couldn't create self-signed certificate");
                             }
                         }
-                        if (result?.title === "Don't Ask Again") //TODO: change option to More information and redirect to debugger-launchjson.md
+                        if (result?.title === "More Information")
                         {
-                            await vscode.window.showInformationMessage("To don't see this message again set launch option 'checkForDevCert' to 'false' in launch.json", { modal: true });
+                            const launchjsonDescriptionURL = 'https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#check-for-devcert';
+                            vscode.env.openExternal(vscode.Uri.parse(launchjsonDescriptionURL));
                         }
                     }
                 });

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -80,7 +80,7 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                     {
                         const result = await vscode.window.showInformationMessage(
                             "The selected launch configuration is configured to launch a web browser but no trusted development certificate was found. Create a trusted self-signed certificate?", 
-                            'Yes', "Don't Ask Again", 'Not Now'
+                            'Yes', 'Not Now', "Don't Ask Again", 
                             ); 
                         if (result === 'Yes')
                         {

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -75,35 +75,44 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
 
             if (debugConfiguration.checkForDevCert)
             {
-                hasDotnetDevCertsHttps(this.options.dotNetCliPaths).then(async (returnData) => {
-                    if(returnData.error) //if the prcess returns 0 error is null, otherwise the return code can ba acessed in returnData.error.code
-                    {
-                        const result = await vscode.window.showInformationMessage(
-                            "The selected launch configuration is configured to launch a web browser but no trusted development certificate was found. Create a trusted self-signed certificate?", 
-                            { title:"Yes"}, { title:'Not Now', isCloseAffordance: true }, { title:"More Information"}
-                            ); 
-                        if (result?.title === 'Yes')
-                        {
-                            let returnData = await createSelfSignedCert(this.options.dotNetCliPaths);
-                            if (returnData.error === null)
-                            {
-                                vscode.window.showInformationMessage('Self-signed certificate sucessfully created');
-                            }
-                            else
-                            {
-                                vscode.window.showWarningMessage("Couldn't create self-signed certificate");
-                            }
-                        }
-                        if (result?.title === "More Information")
-                        {
-                            const launchjsonDescriptionURL = 'https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#check-for-devcert';
-                            vscode.env.openExternal(vscode.Uri.parse(launchjsonDescriptionURL));
-                        }
-                    }
-                });
+                checkForDevCerts(this.options.dotNetCliPaths);
             }
         }
 
         return debugConfiguration;
     }
+}
+
+function checkForDevCerts(dotNetCliPaths: string[]){
+    hasDotnetDevCertsHttps(dotNetCliPaths).then(async (returnData) => {
+        if(returnData.error) //if the prcess returns 0 error is null, otherwise the return code can ba acessed in returnData.error.code
+        {
+            const labelYes: string = "Yes";
+            const labelNotNow: string = "Not Now";
+            const labelMoreInfo: string = "More Information";
+
+            const result = await vscode.window.showInformationMessage(
+                "The selected launch configuration is configured to launch a web browser but no trusted development certificate was found. Create a trusted self-signed certificate?", 
+                { title:labelYes}, { title:labelNotNow, isCloseAffordance: true }, { title:labelMoreInfo}
+                ); 
+            if (result?.title === labelYes)
+            {
+                let returnData = await createSelfSignedCert(dotNetCliPaths);
+                if (returnData.error === null)
+                {
+                    vscode.window.showInformationMessage('Self-signed certificate sucessfully created');
+                }
+                else
+                {
+                    vscode.window.showWarningMessage("Couldn't create self-signed certificate");
+                }
+            }
+            if (result?.title === labelMoreInfo)
+            {
+                const launchjsonDescriptionURL = 'https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#check-for-devcert';
+                vscode.env.openExternal(vscode.Uri.parse(launchjsonDescriptionURL));
+                checkForDevCerts(dotNetCliPaths);
+            }
+        }
+    });
 }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -91,7 +91,7 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
                         }
                         else if (result === "Don't Ask Again")
                         {
-                            await vscode.window.showInformationMessage("To don't see this message again set launch option `checkForDevCert` to `false` at .vscode/launch.json", { modal: true });
+                            await vscode.window.showInformationMessage("To don't see this message again set launch option `checkForDevCert` to `false` in launch.json", { modal: true });
                         }
                     }
                 });

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -10,7 +10,7 @@ import { Options } from '../omnisharp/options';
 import { PlatformInformation } from '../platform';
 import { hasDotnetDevCertsHttps, createSelfSignedCert } from '../utils/DotnetDevCertsHttps';
 import { EventStream } from '../EventStream';
-import { DevCertCreationFailure } from '../omnisharp/loggingEvents';
+import { DevCertCreationFailure, ShowChannel } from '../omnisharp/loggingEvents';
  
 export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     constructor(public platformInformation: PlatformInformation, private readonly eventStream: EventStream, private options: Options) {}
@@ -111,7 +111,7 @@ function checkForDevCerts(dotNetCliPaths: string[], eventStream: EventStream){
                     const labelShowOutput: string = "Show Output";
                     const result = await vscode.window.showWarningMessage("Couldn't create self-signed certificate. See output for more information.", labelShowOutput);
                     if (result === labelShowOutput){
-                        vscode.commands.executeCommand("workbench.action.output.show.extension-output-ms-dotnettools.csharp-#3-C#");
+                        eventStream.post(new ShowChannel());
                     }
                 }
             }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -87,7 +87,7 @@ export class DotnetDebugConfigurationProvider implements vscode.DebugConfigurati
 
 function checkForDevCerts(dotNetCliPaths: string[], eventStream: EventStream){
     hasDotnetDevCertsHttps(dotNetCliPaths).then(async (returnData) => {
-        if(returnData.error) //if the prcess returns 0 error is null, otherwise the return code can ba acessed in returnData.error.code
+        if(returnData.error?.code === 6) // the process returns 6 if no dev certificate is found.
         {
             const labelYes: string = "Yes";
             const labelNotNow: string = "Not Now";
@@ -100,7 +100,7 @@ function checkForDevCerts(dotNetCliPaths: string[], eventStream: EventStream){
             if (result?.title === labelYes)
             {
                 let returnData = await createSelfSignedCert(dotNetCliPaths);
-                if (returnData.error === null)
+                if (returnData.error === null) //if the prcess returns 0, returnData.error is null, otherwise the return code can be acessed in returnData.error.code
                 {
                     vscode.window.showInformationMessage('Self-signed certificate sucessfully created.');
                 }

--- a/src/coreclr-debug/debugConfigurationProvider.ts
+++ b/src/coreclr-debug/debugConfigurationProvider.ts
@@ -109,7 +109,7 @@ function checkForDevCerts(dotNetCliPaths: string[], eventStream: EventStream){
                     eventStream.post(new DevCertCreationFailure(`${returnData.error.message}\ncode: ${returnData.error.code}\nstdout: ${returnData.stdout}`));
 
                     const labelShowOutput: string = "Show Output";
-                    const result = await vscode.window.showWarningMessage("Couldn't create self-signed certificate. See for more information.", labelShowOutput);
+                    const result = await vscode.window.showWarningMessage("Couldn't create self-signed certificate. See output for more information.", labelShowOutput);
                     if (result === labelShowOutput){
                         vscode.commands.executeCommand("workbench.action.output.show.extension-output-ms-dotnettools.csharp-#3-C#");
                     }

--- a/src/observers/CsharpChannelObserver.ts
+++ b/src/observers/CsharpChannelObserver.ts
@@ -18,6 +18,9 @@ export class CsharpChannelObserver extends BaseChannelObserver {
             case EventType.ProjectJsonDeprecatedWarning:
                 this.showChannel(true);
                 break;
+            case EventType.ShowChannel:
+                this.showChannel(false);
+                break;
         }
     }
 }

--- a/src/observers/CsharpLoggerObserver.ts
+++ b/src/observers/CsharpLoggerObserver.ts
@@ -68,6 +68,9 @@ export class CsharpLoggerObserver extends BaseLoggerObserver {
             case EventType.IntegrityCheckSuccess:
                 this.handleIntegrityCheckSuccess(<Event.IntegrityCheckSuccess>event);
                 break;
+            case EventType.DevCertCreationFailure:
+                this.handleDevCertCreationFailure(<Event.DevCertCreationFailure>event);
+                break;
         }
     }
 
@@ -145,5 +148,9 @@ export class CsharpLoggerObserver extends BaseLoggerObserver {
 
     private handleDocumentSynchronizationFailure(event: Event.DocumentSynchronizationFailure) {
         this.logger.appendLine(`Failed to synchronize document '${event.documentPath}': ${event.errorMessage}`);
+    }
+
+    private handleDevCertCreationFailure(event: Event.DevCertCreationFailure) {
+        this.logger.appendLine(`Couldn't create self-signed certificate. ${event.errorMessage}`);
     }
 }

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -85,6 +85,7 @@ export enum EventType {
     TelemetryErrorEvent = 78,
     OmnisharpServerRequestCancelled = 79,
     BackgroundDiagnosticStatus = 80,
+    DevCertCreationFailure = 81,
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/EventType.ts
+++ b/src/omnisharp/EventType.ts
@@ -86,6 +86,7 @@ export enum EventType {
     OmnisharpServerRequestCancelled = 79,
     BackgroundDiagnosticStatus = 80,
     DevCertCreationFailure = 81,
+    ShowChannel = 82,
 }
 
 //Note that the EventType protocol is shared with Razor.VSCode and the numbers here should not be altered

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -350,3 +350,7 @@ export class DotNetTestDebugComplete implements BaseEvent {
 export class DownloadValidation implements BaseEvent {
     type = EventType.DownloadValidation;
 }
+export class DevCertCreationFailure implements BaseEvent {
+    type = EventType.DevCertCreationFailure;
+    constructor(public errorMessage: string) { }
+}

--- a/src/omnisharp/loggingEvents.ts
+++ b/src/omnisharp/loggingEvents.ts
@@ -354,3 +354,6 @@ export class DevCertCreationFailure implements BaseEvent {
     type = EventType.DevCertCreationFailure;
     constructor(public errorMessage: string) { }
 }
+export class ShowChannel implements BaseEvent {
+    type = EventType.ShowChannel;
+}

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -410,7 +410,7 @@
         },
         "checkForDevCert": {
           "type": "boolean",
-          "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
+          "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
           "default": true
         }
       }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -410,7 +410,7 @@
         },
         "checkForDevCert": {
           "type": "boolean",
-          "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
+          "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
           "default": true
         }
       }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -410,7 +410,7 @@
         },
         "checkForDevCert": {
           "type": "boolean",
-          "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+          "description": "When true, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found, the user will be prompted to install it.",
           "default": true
         }
       }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -407,6 +407,11 @@
         "targetArchitecture": {
           "type": "string",
           "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+        },
+        "checkForDevCert": {
+          "type": "boolean",
+          "description": "When true, the presence of dev certificates will be checked by runing dotnet `dev-certs https --check`, and if that fails the user will be prompted to create dev certs by running `dotnet dev-certs https --trust`",
+          "default": true
         }
       }
     },

--- a/src/utils/DotnetDevCertsHttps.ts
+++ b/src/utils/DotnetDevCertsHttps.ts
@@ -13,10 +13,10 @@ export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     try {
-        const data = await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --check`, process.cwd(), process.env);
-        return (/A valid certificate was found/.test(data));
+        await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --check`, process.cwd(), process.env);
+        return true;
     }
-    catch (err) {
+    catch (err) { // execChildProcess will throw if the process returns anything but 0
         return false;
     }
 }
@@ -27,10 +27,10 @@ export async function createSelfSignedCert(dotNetCliPaths: string[]): Promise<Bo
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     try {
-        const data = await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
-        return (/Successfully created and trusted a new HTTPS certificate/.test(data));
+        await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
+        return true; 
     }
-    catch (err) {
+    catch (err) { // execChildProcess will throw if the process returns anything but 0
         return false;
     }
 }

--- a/src/utils/DotnetDevCertsHttps.ts
+++ b/src/utils/DotnetDevCertsHttps.ts
@@ -7,15 +7,15 @@ import * as cp from 'child_process';
 import { getExtensionPath } from "../common";
 import { getDotNetExecutablePath } from "./getDotnetInfo";
 
-// Will return true if `dotnet dev-certs https --check` succesfully finds a development certificate. 
+// Will return true if `dotnet dev-certs https --check` succesfully finds a trusted development certificate. 
 export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<ExecReturnData> {
 
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
-    return await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --check`, process.cwd(), process.env);
+    return await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --check --trust`, process.cwd(), process.env);
 }
 
-// Will run `dotnet dev-certs https --trust` to prompt the user to create self signed certificates. Retruns true if sucessfull.
+// Will run `dotnet dev-certs https --trust` to prompt the user to create a trusted self signed certificates. Retruns true if sucessfull.
 export async function createSelfSignedCert(dotNetCliPaths: string[]): Promise<ExecReturnData> {
 
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
@@ -35,4 +35,19 @@ interface ExecReturnData {
     error: cp.ExecException | null;
     stdout: string;
     stderr: string;
+}
+
+export enum CertToolStatusCodes
+{
+    CriticalError = -1,
+    Success = 0,
+    // Following are from trusting the certificate (dotnet dev-certs https --trust)
+    ErrorCreatingTheCertificate = 1,
+    ErrorSavingTheCertificate = 2,
+    ErrorExportingTheCertificate = 3,
+    ErrorTrustingTheCertificate = 4,
+    UserCancel = 5,
+    // Following two are from checking for trust (dotnet dev-certs https --check --trust)
+    ErrorNoValidCertificateFound = 6,
+    CertificateNotTrusted = 7,
 }

--- a/src/utils/DotnetDevCertsHttps.ts
+++ b/src/utils/DotnetDevCertsHttps.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 import { execChildProcess } from "../common";
 import { CoreClrDebugUtil } from "../coreclr-debug/util";
 
-// Will return true if `dotnet dev-certs https --check` succesfully finds a development certificate. Returns false if it can't find one or fails.
+// Will return true if `dotnet dev-certs https --check` succesfully finds a development certificate. 
 export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<Boolean> {
 
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
@@ -22,13 +22,13 @@ export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<
 }
 
 // Will run `dotnet dev-certs https --trust` to prompt the user to create self signed certificates. Retruns true if sucessfull.
-export async function createSelfSignedCerts(dotNetCliPaths: string[]): Promise<Boolean> {
+export async function createSelfSignedCert(dotNetCliPaths: string[]): Promise<Boolean> {
     
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     try {
-        await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
-        return true;
+        const data = await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
+        return (/Successfully created and trusted a new HTTPS certificate/.test(data));
     }
     catch (err) {
         return false;

--- a/src/utils/DotnetDevCertsHttps.ts
+++ b/src/utils/DotnetDevCertsHttps.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from "path";
+import { execChildProcess } from "../common";
+import { CoreClrDebugUtil } from "../coreclr-debug/util";
+
+// Will return true if `dotnet dev-certs https --check` succesfully finds a development certificate. Returns false if it can't find one or fails.
+export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<Boolean> {
+
+    let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
+
+    try {
+        const data = await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --check`, process.cwd(), process.env);
+        return (/A valid certificate was found/.test(data));
+    }
+    catch (err) {
+        return false;
+    }
+}
+
+// Will run `dotnet dev-certs https --trust` to prompt the user to create self signed certificates. Retruns true if sucessfull.
+export async function createSelfSignedCerts(dotNetCliPaths: string[]): Promise<Boolean> {
+    
+    let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
+
+    try {
+        await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
+        return true;
+    }
+    catch (err) {
+        return false;
+    }
+}
+
+function getDotNetExecutablePath(dotNetCliPaths: string[]): string | undefined{
+    let dotnetExeName = `dotnet${CoreClrDebugUtil.getPlatformExeExtension()}`;
+    let dotnetExecutablePath: string | undefined;
+
+    for (const dotnetPath of dotNetCliPaths) {
+        let dotnetFullPath = join(dotnetPath, dotnetExeName);
+        if (CoreClrDebugUtil.existsSync(dotnetFullPath)) {
+            dotnetExecutablePath = dotnetFullPath;
+            break;
+        }
+    }
+    return dotnetExecutablePath;
+}

--- a/src/utils/DotnetDevCertsHttps.ts
+++ b/src/utils/DotnetDevCertsHttps.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { join } from "path";
 import * as cp from 'child_process';
 import { getExtensionPath } from "../common";
-import { CoreClrDebugUtil } from "../coreclr-debug/util";
+import { getDotNetExecutablePath } from "./getDotnetInfo";
 
 // Will return true if `dotnet dev-certs https --check` succesfully finds a development certificate. 
 export async function hasDotnetDevCertsHttps(dotNetCliPaths: string[]): Promise<ExecReturnData> {
@@ -22,20 +21,6 @@ export async function createSelfSignedCert(dotNetCliPaths: string[]): Promise<Ex
     let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     return await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} dev-certs https --trust`, process.cwd(), process.env);
-}
-
-function getDotNetExecutablePath(dotNetCliPaths: string[]): string | undefined{
-    let dotnetExeName = `dotnet${CoreClrDebugUtil.getPlatformExeExtension()}`;
-    let dotnetExecutablePath: string | undefined;
-
-    for (const dotnetPath of dotNetCliPaths) {
-        let dotnetFullPath = join(dotnetPath, dotnetExeName);
-        if (CoreClrDebugUtil.existsSync(dotnetFullPath)) {
-            dotnetExecutablePath = dotnetFullPath;
-            break;
-        }
-    }
-    return dotnetExecutablePath;
 }
 
 async function execChildProcess(command: string, workingDirectory: string = getExtensionPath(), env: NodeJS.ProcessEnv = {}): Promise<ExecReturnData> {

--- a/src/utils/getDotnetInfo.ts
+++ b/src/utils/getDotnetInfo.ts
@@ -15,16 +15,7 @@ export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInf
         return _dotnetInfo;
     }
 
-    let dotnetExeName = `dotnet${CoreClrDebugUtil.getPlatformExeExtension()}`;
-    let dotnetExecutablePath: string | undefined;
-
-    for (const dotnetPath of dotNetCliPaths) {
-        let dotnetFullPath = join(dotnetPath, dotnetExeName);
-        if (CoreClrDebugUtil.existsSync(dotnetFullPath)) {
-            dotnetExecutablePath = dotnetFullPath;
-            break;
-        }
-    }
+    let dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     try {
         const data = await execChildProcess(`${dotnetExecutablePath ?? 'dotnet'} --info`, process.cwd(), process.env);
@@ -62,6 +53,20 @@ export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInf
         // something went wrong with spawning 'dotnet --info'
         throw new Error('A valid dotnet installation could not be found');
     }
+}
+
+export function getDotNetExecutablePath(dotNetCliPaths: string[]): string | undefined{
+    let dotnetExeName = `dotnet${CoreClrDebugUtil.getPlatformExeExtension()}`;
+    let dotnetExecutablePath: string | undefined;
+
+    for (const dotnetPath of dotNetCliPaths) {
+        let dotnetFullPath = join(dotnetPath, dotnetExeName);
+        if (CoreClrDebugUtil.existsSync(dotnetFullPath)) {
+            dotnetExecutablePath = dotnetFullPath;
+            break;
+        }
+    }
+    return dotnetExecutablePath;
 }
 
 export interface DotnetInfo {


### PR DESCRIPTION
This commit fixes #3187 by implementing the proposal in the [comments](https://github.com/OmniSharp/omnisharp-vscode/issues/3187#issuecomment-1402914194).

- Added launch option `checkForDevCert` and documented it on `debugger-launchjson.md`.
- When debugging, if not on Linux, on remote, or on a browser, the extension runs `dotnet dev-certs https --check` to check for dev-certs.
- If not found, it displays the following message:
<img width="447" alt="image" src="https://user-images.githubusercontent.com/119355875/220765095-e764895c-fd5b-4fcf-aa99-75a9c7477e0c.png">

- Selecting yes will run `dotnet dev-certs https --trust`
- More information will redirect to the page containing `the description for the `checkForDevCert` launch option.
- If certificate creation fails it will log the failure to the C# output and will display a message offering to show the error output.
- Tested on Windows and MacOS
