### PR TITLE
Implement support for switching targetArchitecture on Windows ARM64

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,28 +402,29 @@
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
       "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-25-7/coreclr-debug-win7-x64.zip",
-      "installPath": ".debugger",
+      "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
       ],
       "architectures": [
-        "x86_64"
+        "x86_64",
+        "arm64"
       ],
-      "installTestPath": "./.debugger/vsdbg-ui.exe",
+      "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
       "integrity": "10F4DA0626D3BA8599FA27A6C1AE6293037158350A30B55501664DA56E4D7FC9"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
       "url": "https://vsdebugger.azureedge.net/coreclr-debug-1-25-7/coreclr-debug-win10-arm64.zip",
-      "installPath": ".debugger",
+      "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "arm64"
       ],
-      "installTestPath": "./.debugger/vsdbg-ui.exe",
+      "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
       "integrity": "85426D6D98DBCFA1220F5A74D51D8FDB530903F612BF95A406E95D18F67E4821"
     },
     {
@@ -888,7 +889,11 @@
             },
             "targetArchitecture": {
               "type": "string",
-              "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+              "enum": [
+                "x86_64",
+                "arm64"
+              ],
+              "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
             },
             "type": {
               "type": "string",
@@ -1981,7 +1986,11 @@
               },
               "targetArchitecture": {
                 "type": "string",
-                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "enum": [
+                  "x86_64",
+                  "arm64"
+                ],
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               },
               "checkForDevCert": {
                 "type": "boolean",
@@ -2417,7 +2426,11 @@
               },
               "targetArchitecture": {
                 "type": "string",
-                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "enum": [
+                  "x86_64",
+                  "arm64"
+                ],
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               }
             }
           }
@@ -3113,7 +3126,11 @@
               },
               "targetArchitecture": {
                 "type": "string",
-                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "enum": [
+                  "x86_64",
+                  "arm64"
+                ],
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               },
               "checkForDevCert": {
                 "type": "boolean",
@@ -3549,7 +3566,11 @@
               },
               "targetArchitecture": {
                 "type": "string",
-                "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "enum": [
+                  "x86_64",
+                  "arm64"
+                ],
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -893,7 +893,7 @@
                 "x86_64",
                 "arm64"
               ],
-              "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+              "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
             },
             "type": {
               "type": "string",
@@ -1990,7 +1990,7 @@
                   "x86_64",
                   "arm64"
                 ],
-                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
               },
               "checkForDevCert": {
                 "type": "boolean",
@@ -2430,7 +2430,7 @@
                   "x86_64",
                   "arm64"
                 ],
-                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
               }
             }
           }
@@ -3130,7 +3130,7 @@
                   "x86_64",
                   "arm64"
                 ],
-                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
               },
               "checkForDevCert": {
                 "type": "boolean",
@@ -3570,7 +3570,7 @@
                   "x86_64",
                   "arm64"
                 ],
-                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+                "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
               }
             }
           }

--- a/src/coreclr-debug/util.ts
+++ b/src/coreclr-debug/util.ts
@@ -99,16 +99,16 @@ export class CoreClrDebugUtil {
     }
 }
 
-const MINIMUM_SUPPORTED_OSX_ARM64_DOTNET_CLI: string = '6.0.0';
+const MINIMUM_SUPPORTED_ARM64_DOTNET_CLI: string = '6.0.0';
 
 export function getTargetArchitecture(platformInfo: PlatformInformation, launchJsonTargetArchitecture: string | undefined, dotnetInfo: DotnetInfo): string {
-    if (!platformInfo.isMacOS())
+    if (!platformInfo.isMacOS() && !platformInfo.isWindows())
     {
         // Nothing to do here.
         return '';
     }
 
-    // On Apple M1 Machines, we need to determine if we need to use the 'x86_64' or 'arm64' debugger.
+    // On Windows ARM64 and Apple M1 Machines, we need to determine if we need to use the 'x86_64' or 'arm64' debugger.
 
     // 'targetArchitecture' is specified in launch.json configuration, use that.
     if (launchJsonTargetArchitecture)
@@ -121,7 +121,7 @@ export function getTargetArchitecture(platformInfo: PlatformInformation, launchJ
     }
 
     // If we are lower than .NET 6, use 'x86_64' since 'arm64' was not supported until .NET 6.
-    if (semver.lt(dotnetInfo.Version, MINIMUM_SUPPORTED_OSX_ARM64_DOTNET_CLI))
+    if (semver.lt(dotnetInfo.Version, MINIMUM_SUPPORTED_ARM64_DOTNET_CLI))
     {
         return 'x86_64';
     }

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -410,7 +410,7 @@
             "x86_64",
             "arm64"
           ],
-          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
         },
         "checkForDevCert": {
           "type": "boolean",
@@ -507,7 +507,7 @@
             "x86_64",
             "arm64"
           ],
-          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64. This value is ignored on Linux."
         }
       }
     },

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -406,7 +406,11 @@
         },
         "targetArchitecture": {
           "type": "string",
-          "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+          "enum": [
+            "x86_64",
+            "arm64"
+          ],
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
         },
         "checkForDevCert": {
           "type": "boolean",
@@ -499,7 +503,11 @@
         },
         "targetArchitecture": {
           "type": "string",
-          "description": "[Only supported in local macOS debugging] The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
+          "enum": [
+            "x86_64",
+            "arm64"
+          ],
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86_64 or arm64."
         }
       }
     },

--- a/test/unitTests/coreclr-debug/targetArchitecture.test.ts
+++ b/test/unitTests/coreclr-debug/targetArchitecture.test.ts
@@ -23,7 +23,33 @@ suite("getTargetArchitecture Tests", () => {
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
 
-            assert.equal(targetArchitecture, "");
+            assert.equal(targetArchitecture, "x86_64");
+        });
+
+        test("Windows: X64 SDK on ARM64", () => {
+            const platformInfo = new PlatformInformation("win32", "arm64");
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "win10-x64",
+            };
+
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
+
+            assert.equal(targetArchitecture, "x86_64");
+        });
+
+        test("Windows: ARM64 SDK on ARM64", () => {
+            const platformInfo = new PlatformInformation("win32", "arm64");
+            const dotnetInfo: DotnetInfo = {
+                FullInfo: "Irrelevant",
+                Version: "6.0.0",
+                RuntimeId: "win10-arm64",
+            };
+
+            const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
+
+            assert.equal(targetArchitecture, "arm64");
         });
     });
 


### PR DESCRIPTION
**Changes:**
* Enable use of `targetArchitecture` property on Windows
* Update `targetArchitecture` to be an enum with properties `arm64` and `x86_64`
* Download both ARM64 and X86_64 `vsdbg-ui` when on Windows ARM64
* Update tests

Addresses #5004

Tested manually both on Windows X64 and ARM64. Can provide an ARM64 Windows VM for validation if needed.