### PR TITLE
Remove ForceRuntimeCodeGeneration flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1528,16 +1528,6 @@
             "description": "%configuration.razor.languageServer.debug%",
             "order": 90
           },
-          "razor.languageServer.forceRuntimeCodeGeneration": {
-            "type": "boolean",
-            "scope": "machine-overridable",
-            "default": true,
-            "description": "%configuration.razor.languageServer.forceRuntimeCodeGeneration%",
-            "order": 90,
-            "tags": [
-              "experimental"
-            ]
-          },
           "razor.languageServer.suppressLspErrorToasts": {
             "type": "boolean",
             "default": true,

--- a/package.nls.cs.json
+++ b/package.nls.cs.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Povolte společné hostování Razor.",
   "configuration.razor.languageServer.debug": "Určuje, jestli se má při spouštění jazykového serveru čekat na připojení ladění.",
   "configuration.razor.languageServer.directory": "Přepíše cestu k adresáři jazykového serveru Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Povolit kombinované generování kódu v době návrhu / za běhu pro soubory Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Potlačí zobrazování informačních zpráv o chybách, pokud na serveru dojde k chybě, ze které se dá zotavit.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Použijte nový modul formátování Razor.",
   "configuration.razor.server.trace": "Určuje úroveň protokolování, která se má použít pro server Razor.",

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Razor-Cohosting aktivieren.",
   "configuration.razor.languageServer.debug": "Gibt an, ob beim Starten des Sprachservers auf die Debuganfügung gewartet werden soll.",
   "configuration.razor.languageServer.directory": "Überschreibt den Pfad zum Razor-Sprachserver-Verzeichnis.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Kombinierte Entwurfszeit-/Runtime-Codegenerierung für Razor-Dateien aktivieren",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Unterdrückt, dass Fehler-Popups angezeigt werden, wenn auf dem Server ein wiederherstellbarer Fehler auftritt.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Verwenden Sie das neue Razor-Formatierungsmodul.",
   "configuration.razor.server.trace": "Gibt den Protokolliergrad an, der für den Razor-Server verwendet werden soll.",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Habilite el cohospedaje de Razor.",
   "configuration.razor.languageServer.debug": "Especifica si se debe esperar a que se adjunte la depuración al iniciar el servidor de lenguaje.",
   "configuration.razor.languageServer.directory": "Invalida la ruta de acceso al directorio del servidor de lenguaje Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Habilitar la generación de código de runtime y tiempo de diseño combinado para archivos de Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Suprime la visualización de notificaciones del sistema de error si el servidor encuentra un error recuperable.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Use el nuevo motor de formato razor.",
   "configuration.razor.server.trace": "Especifica el nivel de registro que se va a usar para el servidor Razor.",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Activez la cohébergement Razor.",
   "configuration.razor.languageServer.debug": "Spécifie s’il faut attendre l’attachement du débogage au lancement du serveur de langage.",
   "configuration.razor.languageServer.directory": "Remplace le chemin d’accès au répertoire du serveur de langage Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Activer la génération combinée de code au moment de la conception/à l’exécution pour les fichiers Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Supprime l’affichage des notifications toast d’erreur si le serveur a rencontré une erreur récupérable.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Utilisez le nouveau moteur de mise en forme Razor.",
   "configuration.razor.server.trace": "Spécifie le niveau de journalisation à utiliser pour le serveur Razor.",

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Abilita il cohosting di Razor.",
   "configuration.razor.languageServer.debug": "Specifica se attendere il collegamento di debug all'avvio del server di linguaggio.",
   "configuration.razor.languageServer.directory": "Esegue l'override del percorso della directory del server di linguaggio Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Abilita la generazione combinata di codice in fase di progettazione/esecuzione per i file Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Impedisce la visualizzazione degli avvisi popup di errore se il server rileva un errore reversibile.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Usa il nuovo motore di formattazione Razor.",
   "configuration.razor.server.trace": "Specifica il livello di registrazione da utilizzare per il server Razor.",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Razor の共同ホストを有効にします。",
   "configuration.razor.languageServer.debug": "言語サーバーの起動時にデバッグ アタッチを待機するかどうかを指定します。",
   "configuration.razor.languageServer.directory": "Razor Language Server ディレクトリへのパスをオーバーライドします。",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Razor ファイルのデザイン時間/ランタイム コード生成の併用を有効にする",
   "configuration.razor.languageServer.suppressLspErrorToasts": "サーバーで回復可能なエラーが発生した場合に、エラー トーストが表示されないようにします。",
   "configuration.razor.languageServer.useNewFormattingEngine": "新しい Razor 書式設定エンジンを使用します。",
   "configuration.razor.server.trace": "Razor サーバーに使用するログ レベルを指定します。",

--- a/package.nls.json
+++ b/package.nls.json
@@ -130,7 +130,6 @@
   "configuration.razor.languageServer.directory": "Overrides the path to the Razor Language Server directory.",
   "configuration.razor.languageServer.debug": "Specifies whether to wait for debug attach when launching the language server.",
   "configuration.razor.server.trace": "Specifies the logging level to use for the Razor server.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Enable combined design time/runtime code generation for Razor files",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Suppresses error toasts from showing up if the server encounters a recoverable error.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Use the new Razor formatting engine.",
   "configuration.razor.languageServer.cohostingEnabled": "Enable Razor cohosting.",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Razor 공동 호스트를 사용하도록 설정합니다.",
   "configuration.razor.languageServer.debug": "언어 서버를 시작할 때 디버그 연결을 기다릴지 여부를 지정합니다.",
   "configuration.razor.languageServer.directory": "Razor 언어 서버 디렉터리의 경로를 재정의합니다.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Razor 파일에 대해 결합된 디자인 타임/런타임 코드 생성 사용",
   "configuration.razor.languageServer.suppressLspErrorToasts": "서버에서 복구 가능한 오류가 발생하는 경우 오류 알림이 표시되지 않도록 합니다.",
   "configuration.razor.languageServer.useNewFormattingEngine": "새 Razor 서식 엔진을 사용합니다.",
   "configuration.razor.server.trace": "Razor 서버에 사용할 로깅 수준을 지정합니다.",

--- a/package.nls.pl.json
+++ b/package.nls.pl.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Włącz współhosting Razor.",
   "configuration.razor.languageServer.debug": "Określa, czy czekać na dołączenie debugowania podczas uruchamiania serwera języka.",
   "configuration.razor.languageServer.directory": "Przesłania ścieżkę do katalogu serwera języka Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Włącz łączny czas projektowania/generowania kodu środowiska uruchomieniowego dla plików Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Pomija wyświetlanie wyskakujących powiadomień o błędach, jeśli serwer napotka błąd do odzyskania.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Użyj nowego aparatu formatowania Razor.",
   "configuration.razor.server.trace": "Określa poziom rejestrowania, który ma być używany dla serwera Razor.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Habilite a co-hospedagem do Razor.",
   "configuration.razor.languageServer.debug": "Especifica se é preciso aguardar o anexo de depuração ao iniciar o servidor de linguagem.",
   "configuration.razor.languageServer.directory": "Substitui o caminho para o diretório do Servidor de Linguagem Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Habilitar a geração combinada de código de tempo de design/runtime para arquivos Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Suprime a exibição de notificações do erro se o servidor encontrar um erro recuperável.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Use o novo mecanismo de formatação Razor.",
   "configuration.razor.server.trace": "Especifica o nível de log a ser usado para o servidor Razor.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Включите совместное размещение Razor.",
   "configuration.razor.languageServer.debug": "Указывает, следует ли ожидать подключения отладки при запуске языкового сервера.",
   "configuration.razor.languageServer.directory": "Переопределяет путь к каталогу языкового сервера Razor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Включить комбинированную генерацию кода во время разработки и во время выполнения для файлов Razor",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Подавляет появление всплывающих сообщений об ошибках, если сервер обнаруживает устранимую ошибку.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Используйте новый обработчик форматирования Razor.",
   "configuration.razor.server.trace": "Задает уровень ведения журнала, который будет использоваться для сервера Razor.",

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "Razor ile birlikte barındırmayı etkinleştirin.",
   "configuration.razor.languageServer.debug": "Dil sunucusunu başlatırken hata ayıklama eklemesinin beklenip beklenmeyeceğini belirtir.",
   "configuration.razor.languageServer.directory": "Razor Dil Sunucusu dizininin yolunu geçersiz kılıyor.",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "Razor dosyaları için birleşik tasarım zamanı/çalışma zamanı kodu oluşturmayı etkinleştirin",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Sunucu kurtarılabilir bir hatayla karşılaştığında hata bildirimlerinin görünmesini engeller.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Yeni Razor biçimlendirme altyapısını kullanın.",
   "configuration.razor.server.trace": "Razor sunucusu için kullanılacak günlük kaydı düzeyini belirtir.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "启用 Razor 共同托管。",
   "configuration.razor.languageServer.debug": "指定在启动语言服务器时是否等待调试附加。",
   "configuration.razor.languageServer.directory": "重写 Razor 语言服务器目录的路径。",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "为 Razor 文件启用组合设计时/运行时代码生成",
   "configuration.razor.languageServer.suppressLspErrorToasts": "当服务器遇到可恢复错误时，禁止显示错误 toast。",
   "configuration.razor.languageServer.useNewFormattingEngine": "使用新的 Razor 格式化引擎。",
   "configuration.razor.server.trace": "指定要用于 Razor 服务器的日志记录级别。",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -125,7 +125,6 @@
   "configuration.razor.languageServer.cohostingEnabled": "啟用 Razor 共同託管。",
   "configuration.razor.languageServer.debug": "指定啟動語言伺服器時，是否要等候偵錯附加。",
   "configuration.razor.languageServer.directory": "覆寫 Razor 語言伺服器目錄的路徑。",
-  "configuration.razor.languageServer.forceRuntimeCodeGeneration": "啟用適合 Razor 檔案的合併設計階段/執行階段程式碼產生",
   "configuration.razor.languageServer.suppressLspErrorToasts": "如果伺服器發生可復原的錯誤，隱藏不顯示錯誤快顯通知。",
   "configuration.razor.languageServer.useNewFormattingEngine": "使用新的 Razor 格式化引擎。",
   "configuration.razor.server.trace": "指定要用於 Razor 伺服器的記錄層級。",

--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -268,9 +268,6 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             args.push('--SingleServerCompletionSupport');
             args.push('true');
 
-            args.push('--ForceRuntimeCodeGeneration');
-            args.push(options.forceRuntimeCodeGeneration ? 'true' : 'false');
-
             if (options.useNewFormattingEngine) {
                 args.push('--UseNewFormattingEngine');
                 args.push('true');

--- a/src/razor/src/razorLanguageServerOptions.ts
+++ b/src/razor/src/razorLanguageServerOptions.ts
@@ -10,7 +10,6 @@ export interface RazorLanguageServerOptions {
     outputChannel?: vscode.OutputChannel;
     debug?: boolean;
     usingOmniSharp: boolean;
-    forceRuntimeCodeGeneration: boolean;
     suppressErrorToasts: boolean;
     useNewFormattingEngine: boolean;
     cohostingEnabled: boolean;

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -23,7 +23,6 @@ export function resolveRazorLanguageServerOptions(
     const usingOmniSharp =
         !getCSharpDevKit() && vscodeApi.workspace.getConfiguration().get<boolean>('dotnet.server.useOmnisharp');
 
-    const forceRuntimeCodeGeneration = serverConfig.get<boolean>('forceRuntimeCodeGeneration');
     const suppressErrorToasts = serverConfig.get<boolean>('suppressLspErrorToasts');
     const useNewFormattingEngine = serverConfig.get<boolean>('useNewFormattingEngine');
     const cohostingEnabled = serverConfig.get<boolean>('cohostingEnabled');
@@ -33,7 +32,6 @@ export function resolveRazorLanguageServerOptions(
         debug: debugLanguageServer,
         outputChannel: logger.outputChannel,
         usingOmniSharp,
-        forceRuntimeCodeGeneration,
         suppressErrorToasts,
         useNewFormattingEngine,
         cohostingEnabled,


### PR DESCRIPTION
Goes with https://github.com/dotnet/razor/pull/12007, which stops reading the value anyway.