### PR TITLE
Bump Razor to 10.0.0-preview.25512.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.95.x
+* Bump Razor to 10.0.0-preview.25512.6 (PR: [#8694](https://github.com/dotnet/vscode-csharp/pull/8694))
+  * Provide a way for users to turn on logging for formatting, to help resolve bugs (PR: [#12304](https://github.com/dotnet/razor/pull/12304))
+  * Handle diagnostic spans that cover an entire attribute value (PR: [#12302](https://github.com/dotnet/razor/pull/12302))
+  * Map component start tags to C#, for better GTD, FAR, Hover, etc. (PR: [#12287](https://github.com/dotnet/razor/pull/12287))
 
 # 2.94.x
 * Add completion for razor components in settings (PR: [#8680](https://github.com/dotnet/vscode-csharp/pull/8680))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.1.0-1.25506.3",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25503.1",
+    "razor": "10.0.0-preview.25512.6",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.0.11023.10"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/b400e0402eed2002b5f78eff7152691af9d39bf7...f63acaae3950a2f5f834aa09181c1c466b63182d?w=1)
* Provide a way for users to turn on logging for formatting, to help resolve bugs (PR: [#12304](https://github.com/dotnet/razor/pull/12304))
* Revert "Revert "Revert "Default the cohosting option in the generator to on.""" (PR: [#12318](https://github.com/dotnet/razor/pull/12318))
* Modify Copilot setup workflow triggers and runner (PR: [#12314](https://github.com/dotnet/razor/pull/12314))
* Create a basic copilot instructions file. (PR: [#12311](https://github.com/dotnet/razor/pull/12311))
* Properly handle data for snippet completion items in cohosting (PR: [#12303](https://github.com/dotnet/razor/pull/12303))
* Handle diagnostic spans that cover an entire attribute value (PR: [#12302](https://github.com/dotnet/razor/pull/12302))
* Special case object pool redirection (PR: [#12308](https://github.com/dotnet/razor/pull/12308))
* Map component start tags to C#, for better GTD, FAR, Hover, etc. (PR: [#12287](https://github.com/dotnet/razor/pull/12287))
* Allow publishing to fail, and just report that we're not synchronized (PR: [#12301](https://github.com/dotnet/razor/pull/12301))
* Remove release configurations for older versions (PR: [#12299](https://github.com/dotnet/razor/pull/12299))
* update after snap (PR: [#12284](https://github.com/dotnet/razor/pull/12284))
* Create copilot setup file (PR: [#12294](https://github.com/dotnet/razor/pull/12294))
* Bring our in-memory logger to OOP (PR: [#12293](https://github.com/dotnet/razor/pull/12293))
* Fix syntax errors in test inputs (PR: [#12290](https://github.com/dotnet/razor/pull/12290))
* Revert "Revert "Fix some issues with our options in the new experience"" (PR: [#12292](https://github.com/dotnet/razor/pull/12292))
* Better handle attribute snippet completion in components (PR: [#12281](https://github.com/dotnet/razor/pull/12281))
* Update codeflow metadata to fix backflow (PR: [#12295](https://github.com/dotnet/razor/pull/12295))