### PR TITLE
Bump Razor to 10.0.0-preview.25524.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.97.x
+* Bump Razor to 10.0.0-preview.25524.10 (PR: [#8721](https://github.com/dotnet/vscode-csharp/pull/8721))
+  * Add CodeAction to simplify fully-qualified component tags (PR: [#12379](https://github.com/dotnet/razor/pull/12379))
+  * Fix component and component attribute rename in cohosting (PR: [#12374](https://github.com/dotnet/razor/pull/12374))
 
 # 2.96.x
 * Update Debugger to v2.95.0 (PR: [#8710](https://github.com/dotnet/vscode-csharp/pull/8710))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.3.0-1.25514.3",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25517.9",
+    "razor": "10.0.0-preview.25524.10",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.0.11023.10"
   },


### PR DESCRIPTION
Weekly bump, and one cool new code action

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/73622b728a3015c601aeada75eb8425bde7ba439...0d4d79ba6469470c65e91c793968d2c6d3a4c3b7?w=1)
* Add CodeAction to simplify fully-qualified component tags (PR: [#12379](https://github.com/dotnet/razor/pull/12379))
* Use the full file path as the target path when it's missing (PR: [#12355](https://github.com/dotnet/razor/pull/12355))
* Reduce the range walked for formatting content validation (PR: [#12384](https://github.com/dotnet/razor/pull/12384))
* Add test coverage and bug fix for RemoveUnusedVariable code action in Razor files (PR: [#12380](https://github.com/dotnet/razor/pull/12380))
* Remove syntax annotations from the Razor compiler (PR: [#12345](https://github.com/dotnet/razor/pull/12345))
* Use shared instances of NodeWriter classes (PR: [#12362](https://github.com/dotnet/razor/pull/12362))
* Reduce allocated strings in CodeWriter (PR: [#12366](https://github.com/dotnet/razor/pull/12366))
* Remove SyntaxTokenCache.Entry (PR: [#12370](https://github.com/dotnet/razor/pull/12370))
* Init semantic token refresh, and queue on request (PR: [#12367](https://github.com/dotnet/razor/pull/12367))
* Throw an exception in OOP if an error is logged. (PR: [#12376](https://github.com/dotnet/razor/pull/12376))
* Update generator type check to use FullName (PR: [#12378](https://github.com/dotnet/razor/pull/12378))
* Share cohost code action tests with C# extension tests (PR: [#12354](https://github.com/dotnet/razor/pull/12354))
* Fix component and component attribute rename in cohosting (PR: [#12374](https://github.com/dotnet/razor/pull/12374))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2820946 (PR: [#12369](https://github.com/dotnet/razor/pull/12369))
* Improve GreenNode.ToString() implementation for efficiency (PR: [#12344](https://github.com/dotnet/razor/pull/12344))