### PR TITLE
Use global.json with rollforward instead of pipeline versions

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -27,9 +27,6 @@ parameters:
   - auto
   default: auto
 
-variables:
-- template: /azure-pipelines/dotnet-variables.yml@self
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -66,4 +63,3 @@ extends:
         isOfficial: true
         channel: ${{ parameters.channel }}
         signType: ${{ parameters.signType }}
-        dotnetVersion: $(defaultDotnetVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,6 @@ schedules:
         - main
 
 variables:
-- template: /azure-pipelines/dotnet-variables.yml@self
 - name: testVSCodeVersion
   ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}: 
     value: insiders
@@ -67,11 +66,8 @@ stages:
   parameters:
     isOfficial: false
     signType: test
-    dotnetVersion: $(defaultDotnetVersion)
 
 - template: azure-pipelines/validate-build.yml
-  parameters:
-    dotnetVersion: $(defaultDotnetVersion)
 
 - stage:
   displayName: Test Linux (.NET 8)
@@ -81,7 +77,7 @@ stages:
     parameters:
       os: linux
       # Prefer the dotnet from the container.
-      dotnetVersion: ''
+      installDotNet: false
       testVSCodeVersion: $(testVSCodeVersion)
       installAdditionalLinuxDependencies: true
       pool:
@@ -97,7 +93,7 @@ stages:
     parameters:
       os: linux
       # Prefer the dotnet from the container.
-      dotnetVersion: ''
+      installDotNet: false
       testVSCodeVersion: $(testVSCodeVersion)
       installAdditionalLinuxDependencies: true
       pool:
@@ -112,7 +108,7 @@ stages:
   - template: azure-pipelines/test-matrix.yml
     parameters:
       os: windows
-      dotnetVersion: $(defaultDotnetVersion)
+      installDotNet: true
       testVSCodeVersion: $(testVSCodeVersion)
       pool:
         name: NetCore-Public
@@ -125,7 +121,7 @@ stages:
   - template: azure-pipelines/test-matrix.yml
     parameters:
       os: macos
-      dotnetVersion: $(defaultDotnetVersion)
+      installDotNet: true
       testVSCodeVersion: $(testVSCodeVersion)
       pool:
         name: Azure Pipelines
@@ -148,5 +144,5 @@ stages:
     steps:
     - template: azure-pipelines/test-omnisharp.yml
       parameters:
-        dotnetVersion: $(defaultDotnetVersion)
+        installDotNet: true
         testVSCodeVersion: $(testVSCodeVersion)

--- a/azure-pipelines/build-vsix.yml
+++ b/azure-pipelines/build-vsix.yml
@@ -4,8 +4,6 @@ parameters:
   default: 'default'
 - name: isOfficial
   type: boolean
-- name: dotnetVersion
-  type: string
 - name: channel
   values:
   - release
@@ -128,7 +126,7 @@ stages:
     - template: /azure-pipelines/prereqs.yml@self
       parameters:
         versionNumberOverride: ${{ parameters.versionNumberOverride }}
-        dotnetVersion: ${{ parameters.dotnetVersion}}
+        installDotNet: true
 
     - task: UsePythonVersion@0
       displayName: 'Use Python 3.11'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,6 +1,6 @@
 parameters:
-- name: dotnetVersion
-  type: string
+- name: installDotNet
+  type: boolean
 
 steps:
 - checkout: self
@@ -10,7 +10,7 @@ steps:
   fetchDepth: 0
 - template: /azure-pipelines/prereqs.yml@self
   parameters:
-    dotnetVersion: ${{ parameters.dotnetVersion}}
+    installDotNet: ${{ parameters.installDotNet }}
 
 - pwsh: npm run package
   displayName: 'Build'

--- a/azure-pipelines/dotnet-variables.yml
+++ b/azure-pipelines/dotnet-variables.yml
@@ -1,3 +1,0 @@
-variables:
-- name: defaultDotnetVersion
-  value: '8.0.403'

--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -2,8 +2,8 @@ parameters:
   - name: versionNumberOverride
     type: string
     default: 'default'
-  - name: dotnetVersion
-    type: string
+  - name: installDotNet
+    type: boolean
 
 steps:
 
@@ -14,11 +14,13 @@ steps:
 
 # Some tests use predefined docker images with a specific version of .NET installed.
 # So we avoid installing .NET in those cases.
-- ${{ if parameters.dotnetVersion }}:
+- ${{ if parameters.installDotNet }}:
   - task: UseDotNet@2
     displayName: 'Install .NET SDK'
     inputs:
-      version: ${{ parameters.dotnetVersion }}
+      useGlobalJson: true
+      workingDirectory: $(Build.SourcesDirectory)/msbuild
+      
 
 - script: dotnet --info
   displayName: Display dotnet info

--- a/azure-pipelines/profiling.yml
+++ b/azure-pipelines/profiling.yml
@@ -14,8 +14,6 @@ variables:
   value: $(Build.SourcesDirectory)/out/profiling/merged/
 - name: LOGS_DIRECTORY
   value: $(Build.SourcesDirectory)/out/logs/
-- template: /azure-pipelines/dotnet-variables.yml@self
-
 
 resources:
   repositories:
@@ -54,7 +52,7 @@ extends:
         steps:
         - template: /azure-pipelines/test.yml@self
           parameters:
-            dotnetVersion: $(defaultDotnetVersion)
+            installDotNet: true
             npmCommand: profiling
             testVSCodeVersion: stable
             isIntegration: true

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -6,8 +6,8 @@ parameters:
   - name: containerName
     type: string
     default: ''
-  - name: dotnetVersion
-    type: string
+  - name: installDotNet
+    type: boolean
   - name: installAdditionalLinuxDependencies
     type: boolean
     default: false
@@ -40,7 +40,7 @@ jobs:
   steps:
   - template: /azure-pipelines/test.yml@self
     parameters:
-      dotnetVersion: ${{ parameters.dotnetVersion }}
+      installDotNet: ${{ parameters.installDotNet }}
       installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}

--- a/azure-pipelines/test-omnisharp.yml
+++ b/azure-pipelines/test-omnisharp.yml
@@ -1,5 +1,5 @@
 parameters:
-  - name: dotnetVersion
+  - name: installDotNet
     type: string
   - name: testVSCodeVersion
     type: string
@@ -13,7 +13,7 @@ steps:
 
 - template: prereqs.yml
   parameters:
-    dotnetVersion: ${{ parameters.dotnetVersion }}
+    installDotNet: ${{ parameters.installDotNet }}
 
 - template: test-prereqs.yml
 

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -1,6 +1,6 @@
 parameters:
-  - name: dotnetVersion
-    type: string
+  - name: installDotNet
+    type: boolean
   - name: installAdditionalLinuxDependencies
     type: boolean
     default: false
@@ -20,7 +20,7 @@ steps:
 
 - template: prereqs.yml
   parameters:
-    dotnetVersion: ${{ parameters.dotnetVersion }}
+    installDotNet: ${{ parameters.installDotNet }}
 
 - ${{ if eq(parameters.installAdditionalLinuxDependencies, true) }}:
   - template: test-linux-docker-prereqs.yml

--- a/azure-pipelines/validate-build.yml
+++ b/azure-pipelines/validate-build.yml
@@ -1,7 +1,3 @@
-parameters:
-- name: dotnetVersion
-  type: string
-
 stages:
 - stage: ValidateBuild
   displayName: 'Validate Build'
@@ -16,7 +12,7 @@ stages:
     steps:
       - template: /azure-pipelines/build.yml@self
         parameters:
-          dotnetVersion: ${{ parameters.dotnetVersion }}
+          installDotNet: true
 
   - job: 'BuildLinux'
     displayName: 'Build Linux'
@@ -27,7 +23,7 @@ stages:
     steps:
       - template: /azure-pipelines/build.yml@self
         parameters:
-          dotnetVersion: ${{ parameters.dotnetVersion }}
+          installDotNet: true
 
   - job: 'BuildDarwin'
     displayName: 'Build Darwin'
@@ -38,4 +34,4 @@ stages:
     steps:
       - template: /azure-pipelines/build.yml@self
         parameters:
-          dotnetVersion: ${{ parameters.dotnetVersion }}
+          installDotNet: true

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-      "Microsoft.Build.NoTargets": "3.7.0"
-    }
-}

--- a/msbuild/global.json
+++ b/msbuild/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "8.0.415",
+    "rollForward": "latestMajor"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.0"
+  }
+}


### PR DESCRIPTION
Our pipelines need to support running on multiple different major versions of .NET as we run tests against different SDKs.

To do this, we run some of our CI legs in isolated docker containers with a specific version of .NET installed.  These legs should not install another SDK.  However, other legs run on general azdo machines and require us to install a compatible SDK.

To resolve this, we previously defined a `dotnetVersion` variable in the pipeline that we would pass around when we wanted the pipeline to install a matching SDK.   Additionally, we avoided specifying an SDK version in the global.json to ensure our tests could run against multiple SDKs (the test workspaces are in the repo and would inherit the global global.json).

However, we can simplify this.  Firstly, I moved the global.json into the msbuild/ folder.  This means it can no longer affect the test projects and we can now specify an SDK version in it (used to acquire server components and sign).
To make it compatible with CI legs with only a specific SDK installed, we pick the lowest supported version and allow rolling forward to the latest version on the machine.

This has a few benefits
1.  We define the default SDK version in a standard location instead of a random pipeline variable.  Pipeline can just install it based on the global.json instead of passing around the version.
2.  The global.json is now more regular and hopefully more compatible with CG (CG seems to get confused when the global.json exists without an SDK).
