### PR TITLE
Bump Razor to 10.0.0-preview.25552.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@
   * Completion for `#:project` paths in file based programs (PR: [#80844](https://github.com/dotnet/roslyn/pull/80844))
   * Allow semantic tokens in Razor to be better behaved (PR: [#80815](https://github.com/dotnet/roslyn/pull/80815))
   * When searching for the original file from a PDB, only allow absolute paths (PR: [#80804](https://github.com/dotnet/roslyn/pull/80804))
-* Bump Razor to 10.0.0-preview.25524.10 (PR: [#8721](https://github.com/dotnet/vscode-csharp/pull/8721))
+* Bump Razor to 10.0.0-preview.25552.2 (PR: [#8734](https://github.com/dotnet/vscode-csharp/pull/8734))
   * Add CodeAction to simplify fully-qualified component tags (PR: [#12379](https://github.com/dotnet/razor/pull/12379))
   * Fix component and component attribute rename in cohosting (PR: [#12374](https://github.com/dotnet/razor/pull/12374))
+  * Fix formatting of mixed indentation in VS Code (PR: [#12418](https://github.com/dotnet/razor/pull/12418))
+  * Allow cohosting quick info to show html tag information even when on a taghelper or component tag. (PR: [#12415](https://github.com/dotnet/razor/pull/12415))
+  * Fix(ish) formatting of RenderFragments (C# templates) (PR: [#12397](https://github.com/dotnet/razor/pull/12397))
+  * Drop Html edits that would split a C# literal across multiple lines (PR: [#12396](https://github.com/dotnet/razor/pull/12396))
+  * Fix completion resolve for provisional completion (PR: [#12403](https://github.com/dotnet/razor/pull/12403))
 
 # 2.96.x
 * Update Debugger to v2.95.0 (PR: [#8710](https://github.com/dotnet/vscode-csharp/pull/8710))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.3.0-1.25524.13",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25524.10",
+    "razor": "10.0.0-preview.25552.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.0.11023.10"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/0d4d79ba6469470c65e91c793968d2c6d3a4c3b7...191feab170b690f6a4923072d1b6f6e00272d8a7?w=1)
* Fix DI scoping violation in RazorSourceGeneratorTestsBase (PR: [#12432](https://github.com/dotnet/razor/pull/12432))
* Fix race condition in MemoryCache.Compact() (PR: [#12434](https://github.com/dotnet/razor/pull/12434))
* Don't put breakpoints on component start tags, end tags or attributes (PR: [#12422](https://github.com/dotnet/razor/pull/12422))
* Clean up object pools and improve PooledHashSet<T> (PR: [#12406](https://github.com/dotnet/razor/pull/12406))
* Use correct TF for remote components locally (PR: [#12425](https://github.com/dotnet/razor/pull/12425))
* PR feedback from https://github.com/dotnet/razor/pull/12415 which accidentally didn't get pushed (PR: [#12424](https://github.com/dotnet/razor/pull/12424))
* Fix formatting of mixed indentation in VS Code (PR: [#12418](https://github.com/dotnet/razor/pull/12418))
* Remove procdump for now (PR: [#12420](https://github.com/dotnet/razor/pull/12420))
* Allow cohosting quick info to show html tag information even when on a taghelper or component tag. (PR: [#12415](https://github.com/dotnet/razor/pull/12415))
* Enable R2R for servicehub components: (PR: [#12385](https://github.com/dotnet/razor/pull/12385))
* Tell copilot to prefer cohosting tests for tooling (PR: [#12412](https://github.com/dotnet/razor/pull/12412))
* Fix(ish) formatting of RenderFragments (C# templates) (PR: [#12397](https://github.com/dotnet/razor/pull/12397))
* Remove most direct calls to GetOrParseCSharpSyntaxTree (PR: [#12407](https://github.com/dotnet/razor/pull/12407))
* Drop Html edits that would split a C# literal across multiple lines (PR: [#12396](https://github.com/dotnet/razor/pull/12396))
* Add test coverage for completion in component parameters with leading @ (PR: [#12405](https://github.com/dotnet/razor/pull/12405))
* Fix completion resolve for provisional completion (PR: [#12403](https://github.com/dotnet/razor/pull/12403))
* Share hover and diagnostics tests withe VS Code (PR: [#12399](https://github.com/dotnet/razor/pull/12399))
* Don't create a new FormattingContext if there weren't any cleanup changes (PR: [#12400](https://github.com/dotnet/razor/pull/12400))
* Normalize line endings in on type formatting (PR: [#12398](https://github.com/dotnet/razor/pull/12398))