### PR TITLE
Update VM image to macOS-15 in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
       testVSCodeVersion: $(testVSCodeVersion)
       pool:
         name: Azure Pipelines
-        vmImage: macOS-13
+        vmImage: macOS-15
 
 - stage: Test_OmniSharp
   displayName: Test OmniSharp


### PR DESCRIPTION
Seeing the following error in CI
```
##[error]This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.
##[warning]The macOS-13 based runner images are being deprecated, consider switching to macOS-14 (macos-14) or macOS-15 (macos-latest) instead. For more details see https://aka.ms/azdo-macOS.
```