### PR TITLE
Fix file extension in debugger troubleshooting doc

### DIFF
--- a/docs/debugger/Troubleshoot-loading-the-.NET-Debug-Services.md
+++ b/docs/debugger/Troubleshoot-loading-the-.NET-Debug-Services.md
@@ -46,7 +46,7 @@ You can test for this condition by adding the following code to the start of you
             else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
             {
                 nativeLibraryPrefix = "lib";
-                nativeLibraryExtension = ".so";
+                nativeLibraryExtension = ".dylib";
             }
             else
             {


### PR DESCRIPTION
A debugger troubleshooting doc had the wrong file extension for macOS native libraries. This fixes it.

This resolves #8754 