### PR TITLE
Disable file based programs in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1507,7 +1507,7 @@
           },
           "dotnet.projects.enableFileBasedPrograms": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%configuration.dotnet.projects.enableFileBasedPrograms%",
             "tags": [
               "preview"


### PR DESCRIPTION
There are a few lingering issues with FBP causing problems with C#DK.  Has been requested that we turn this off in release until we can fix issues

1. Noisy restore notifications for files in an actual project
2. https://github.com/microsoft/vscode-dotnettools/issues/2443
(pending rest of the list)