### PR TITLE
Fix merge prerelease branch update

### DIFF
--- a/.github/workflows/branch-snap.yml
+++ b/.github/workflows/branch-snap.yml
@@ -64,10 +64,10 @@ jobs:
         run: npm ci
       - name: Update version.json for release
         run: npx gulp updateVersionForStableRelease
-      - name: Create PR with version update
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update version for stable release
-          branch: merge/prerelease-to-release
-          base: release
+      - name: Commit and push version update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update version for stable release"
+          git push origin merge/prerelease-to-release


### PR DESCRIPTION
The prerelease branch snap failed for two reasons
1.  bug in the create pull request action which failed the task
2.  the create pull request action does not behave as we desire for update.  It resets the branch to the remote base branch and commits the unstaged changes on top (deleting all of the merge changes). 

instead just push the changes to the branch.
tested https://github.com/dibarbet/vscode-csharp/actions/runs/19309923461/job/55227638944