### PR TITLE
Bump Razor to 10.0.0-preview.25564.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.102.x
+* Bump Razor to 10.0.0-preview.25564.2 (PR: [#8790](https://github.com/dotnet/vscode-csharp/pull/8790))
+  * Revert "Map component start tags to C#, for better GTD, FAR, Hover, etc. (#12287) (PR: [#12486](https://github.com/dotnet/razor/pull/12486))
+  * Rename code-behind and scoped CSS file when renaming component  (PR: [#12480](https://github.com/dotnet/razor/pull/12480))
+  * Better handle parameter attribute directive completion (PR: [#12473](https://github.com/dotnet/razor/pull/12473))
 
 # 2.101.x
 * Fix auto-insert ignoring language-specific editor.tabSize (PR: [#8768](https://github.com/dotnet/vscode-csharp/pull/8768))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.3.0-2.25557.6",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25557.2",
+    "razor": "10.0.0-preview.25564.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.3.11128.18"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/eeace1e0dc6bf2b1cfa3362c6e5711ba42ee1d76...763a361771dc544744cc5c19ae32d4878b4e0892?w=1)
* Update ubuntu image to 22.04 (PR: [#12495](https://github.com/dotnet/razor/pull/12495))
* Update VsSDK from 17.3.2094 to 17.14.1043-preview2 (PR: [#12493](https://github.com/dotnet/razor/pull/12493))
* Disable AzDO dependabot (PR: [#12490](https://github.com/dotnet/razor/pull/12490))
* [main] Revert "Map component start tags to C#, for better GTD, FAR, Hover, etc. (#12287) (PR: [#12486](https://github.com/dotnet/razor/pull/12486))
* More rename  (PR: [#12480](https://github.com/dotnet/razor/pull/12480))
* Only track steps when needed (PR: [#12479](https://github.com/dotnet/razor/pull/12479))
* Better handle parameter attribute directive completion (PR: [#12473](https://github.com/dotnet/razor/pull/12473))
* Small cleanup to completion tests (PR: [#12474](https://github.com/dotnet/razor/pull/12474))
* Move Tooling Tests out of the Tooling folder (PR: [#12472](https://github.com/dotnet/razor/pull/12472))