### PR TITLE
Create Razor tags based on the razorExtension component

### DIFF
--- a/tasks/createTagsTasks.ts
+++ b/tasks/createTagsTasks.ts
@@ -45,7 +45,7 @@ gulp.task('createTags:razor', async (): Promise<void> => {
         options,
         'dotnet',
         'razor',
-        async () => getCommitFromNugetAsync(allNugetPackages.razor),
+        async () => getCommitFromNugetAsync(allNugetPackages.razorExtension),
         (releaseVersion: string, isPrerelease: boolean): [string, string] => {
             const prereleaseText = isPrerelease ? '-prerelease' : '';
             return [


### PR DESCRIPTION
Razor tagging failed during the last release ([see internal run](https://dnceng.visualstudio.com/internal/internal%20Team/_build/results?buildId=2853135&view=logs&j=eae1519e-01dd-5091-0dc6-059a342d7681&t=b250e2db-ed7e-526c-5243-1bc2a8f22d3d&l=33)). Ran with this change locally and tags created successfully.