### PR TITLE
Bump Razor to 10.0.0-preview.25613.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.112.x
+* Update Razor to 10.0.0-preview.25613.1 (PR: [#8858](https://github.com/dotnet/vscode-csharp/pull/8858))
+  * Encode double slash as underscore slash in hint names (PR: [#12597](https://github.com/dotnet/razor/pull/12597))
+  * Navigate to a Razor file when GTD/FAR/GTI is run in C# on the class name (PR: [#12580](https://github.com/dotnet/razor/pull/12580))
+  * Fix rename of components in the global namespace (PR: [#12577](https://github.com/dotnet/razor/pull/12577))
 
 # 2.111.x
 * Razor logging cleanup and documentation update (PR: [#8843](https://github.com/dotnet/vscode-csharp/pull/8843))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.3.0-2.25604.5",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25608.3",
+    "razor": "10.0.0-preview.25613.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.3.11128.18"
   },


### PR DESCRIPTION
Weekly bump, but with an important fix for https://github.com/dotnet/razor/issues/12595

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/d0e74061827c5fc9f1c561cb2fe737598b793c96...6978342ef7b051d46597e2b846f95b7f82beeed3?w=1)
* Encode double slash as underscore slash in hint names (PR: [#12597](https://github.com/dotnet/razor/pull/12597))
* Navigate to a Razor file when GTD/FAR/GTI is run in C# on the class name (PR: [#12580](https://github.com/dotnet/razor/pull/12580))
* Update TextMate grammar for render fragments (PR: [#12584](https://github.com/dotnet/razor/pull/12584))
* Fix: Handle MarkupEphemeralTextLiteralSyntax in TagHelper attribute processing (PR: [#12575](https://github.com/dotnet/razor/pull/12575))
* [main] Update dependencies from dotnet/arcade (PR: [#12570](https://github.com/dotnet/razor/pull/12570))
* Fix rename of components in the global namespace, and add integration tests (PR: [#12577](https://github.com/dotnet/razor/pull/12577))
* Be OS agnostic when generating semantic token baseline files (PR: [#12581](https://github.com/dotnet/razor/pull/12581))
* Reference a newer Roslyn.Diagnostics.Analyzers (PR: [#12573](https://github.com/dotnet/razor/pull/12573))
* Migrate to slnx (PR: [#12574](https://github.com/dotnet/razor/pull/12574))
* Various integration test fixes (PR: [#12572](https://github.com/dotnet/razor/pull/12572))