### PR TITLE
Bump Razor to 10.0.0-preview.25619.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.112.x
-* Update Razor to 10.0.0-preview.25613.1 (PR: [#8858](https://github.com/dotnet/vscode-csharp/pull/8858))
+* Update Razor to 10.0.0-preview.25619.1 (PR: [#8867](https://github.com/dotnet/vscode-csharp/pull/8867))
   * Encode double slash as underscore slash in hint names (PR: [#12597](https://github.com/dotnet/razor/pull/12597))
   * Navigate to a Razor file when GTD/FAR/GTI is run in C# on the class name (PR: [#12580](https://github.com/dotnet/razor/pull/12580))
   * Fix rename of components in the global namespace (PR: [#12577](https://github.com/dotnet/razor/pull/12577))
+  * Return a document symbol representing the "Render" method for a Razor file (PR: [#12568](https://github.com/dotnet/razor/pull/12568))
+* Fix JavaScript highlighting in Razor files after C# control structures without braces (PR: [#8865](https://github.com/dotnet/vscode-csharp/pull/8865))
 
 # 2.111.x
 * Razor logging cleanup and documentation update (PR: [#8843](https://github.com/dotnet/vscode-csharp/pull/8843))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.3.0-2.25604.5",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25613.1",
+    "razor": "10.0.0-preview.25619.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.3.11128.18"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/6978342ef7b051d46597e2b846f95b7f82beeed3...0440ae283c6976a75c6777a4ce4b7926d926a946?w=1)
* Delete azure-pipelines-conditional-integration.yml (PR: [#12615](https://github.com/dotnet/razor/pull/12615))
* Remove ConditionalSkipIdeFact (PR: [#12617](https://github.com/dotnet/razor/pull/12617))
* Update TextMate from C# extension (PR: [#12618](https://github.com/dotnet/razor/pull/12618))
* Update invalid langver error message (PR: [#12611](https://github.com/dotnet/razor/pull/12611))
* Don't colour background of whitespace before component attributes (PR: [#12610](https://github.com/dotnet/razor/pull/12610))
* Add source mapping for rendermode directives (PR: [#12604](https://github.com/dotnet/razor/pull/12604))
* Return a document symbol representing the "Render" method for a Razor file (PR: [#12568](https://github.com/dotnet/razor/pull/12568))
* Don't run tests in official builds (PR: [#12599](https://github.com/dotnet/razor/pull/12599))
* Allow `@rendermode` and `@typeparam` to coexist in basic scenarios (PR: [#12591](https://github.com/dotnet/razor/pull/12591))