### PR TITLE
Give server more time to exit before timing out in tests

### DIFF
--- a/src/lsptoolshost/server/roslynLanguageServer.ts
+++ b/src/lsptoolshost/server/roslynLanguageServer.ts
@@ -370,7 +370,8 @@ export class RoslynLanguageServer {
     }
 
     public async restart(): Promise<void> {
-        await this._languageClient.restart();
+        await this.stop();
+        await this._languageClient.start();
     }
 
     public workspaceDisplayName(): string {


### PR DESCRIPTION
Seeing frequent errors like this in integration tests.  From the logs, it looks like the server does exit, but it takes longer than the default of 2 seconds to fully shut down.

```
Error: Stopping the server timed out
    at /Users/runner/work/1/s/node_modules/vscode-languageclient/lib/common/client.js:1222:23
    at RoslynLanguageClient.restart (/Users/runner/work/1/s/node_modules/vscode-languageclient/lib/node/main.js:164:9)
    at _RoslynLanguageServer.restart (/Users/runner/work/1/s/src/lsptoolshost/server/roslynLanguageServer.ts:373:9)
    at restartServer (/Users/runner/work/1/s/src/lsptoolshost/server/serverCommands.ts:155:5)
    at mA.h (file:///Users/runner/work/1/s/.vscode-test/vscode-darwin-1.108.1/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:116:41743)
    at restartLanguageServer (/Users/runner/work/1/s/test/lsptoolshost/integrationTests/integrationHelpers.ts:107:5)
    at Object.activateCSharpExtension (/Users/runner/work/1/s/test/lsptoolshost/integrationTests/integrationHelpers.ts:55:9)
    at Object.<anonymous> (/Users/runner/work/1/s/test/razor/razorIntegrationTests/reference.integration.test.ts:18:9)
```