### PR TITLE
Adjust Select Project Context editor menu item location

### DIFF
--- a/package.json
+++ b/package.json
@@ -5628,19 +5628,19 @@
       ],
       "editor/context": [
         {
+          "command": "csharp.changeProjectContextEditor",
+          "when": "(resourceLangId == csharp || resourceLangId == aspnetcorerazor) && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'RoslynDevKit')",
+          "group": "2_dotnet@1"
+        },
+        {
           "command": "dotnet.test.runTestsInContext",
           "when": "editorLangId == csharp && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp')",
-          "group": "2_dotnet@1"
+          "group": "3_dotnet@1"
         },
         {
           "command": "dotnet.test.debugTestsInContext",
           "when": "editorLangId == csharp && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp')",
-          "group": "2_dotnet@2"
-        },
-        {
-          "command": "csharp.changeProjectContextEditor",
-          "when": "(resourceLangId == csharp || resourceLangId == aspnetcorerazor) && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'RoslynDevKit')",
-          "group": "2_dotnet@1"
+          "group": "3_dotnet@2"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
Give the Select Project Context its own item group in the editor context menu. This hopefully is enough to draw a distinction between `Tests in Context` a `Select Project Context`. We may want to additionally consider changing `Tests in Context` to `Tests at Cursor`.

Before:
<img width="281" height="727" alt="image" src="https://github.com/user-attachments/assets/6231eeea-a4f8-4f0d-8ff5-b1ee5c607cbe" />

After:
<img width="281" height="652" alt="image" src="https://github.com/user-attachments/assets/daa88e5e-f3c6-42f2-92e1-6cbe8456a7c3" />
