### PR TITLE
Run language server executable on mac

### DIFF
--- a/src/lsptoolshost/activate.ts
+++ b/src/lsptoolshost/activate.ts
@@ -162,11 +162,6 @@ function getInstalledServerPath(platformInfo: PlatformInformation): string {
     let extension = '';
     if (platformInfo.isWindows()) {
         extension = '.exe';
-    } else if (platformInfo.isMacOS()) {
-        // MacOS executables must be signed with codesign.  Currently all Roslyn server executables are built on windows
-        // and therefore dotnet publish does not automatically sign them.
-        // Tracking bug - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1767519/
-        extension = '.dll';
     }
 
     let pathWithExtension = `${serverFilePath}${extension}`;


### PR DESCRIPTION
Now that we're shipping this as a .net tool, the executable on macos works correctly
<img width="1136" height="372" alt="Screenshot 2026-01-28 at 6 01 42 PM" src="https://github.com/user-attachments/assets/95839794-07cd-48ba-b0ac-d1f2c65715b7" />

