### PR TITLE
Fix project context refresh handling on client

### DIFF
--- a/src/lsptoolshost/projectContext/projectContextFeature.ts
+++ b/src/lsptoolshost/projectContext/projectContextFeature.ts
@@ -33,7 +33,7 @@ export class ProjectContextFeature implements DynamicFeature<RoslynProtocol.Proj
         this._client = client;
         this._registrations = new Map();
         this.registrationType = new ProtocolNotificationType0<RoslynProtocol.ProjectContextRegistrationOptions>(
-            RoslynProtocol.ProjectContextRefreshNotification.method
+            RoslynProtocol.ProjectContextRefreshRequest.method
         );
     }
     fillInitializeParams?: ((params: InitializeParams) => void) | undefined;

--- a/src/lsptoolshost/projectContext/projectContextService.ts
+++ b/src/lsptoolshost/projectContext/projectContextService.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import {
-    ProjectContextRefreshNotification,
+    ProjectContextRefreshRequest,
     VSGetProjectContextsRequest,
     VSProjectContext,
     VSProjectContextList,
@@ -85,7 +85,7 @@ export class ProjectContextService {
             }
         });
 
-        _languageClient.onNotification(ProjectContextRefreshNotification.type, async () => {
+        _languageClient.onRequest(ProjectContextRefreshRequest.type, async () => {
             await this.refresh();
         });
 

--- a/src/lsptoolshost/server/roslynProtocol.ts
+++ b/src/lsptoolshost/server/roslynProtocol.ts
@@ -275,10 +275,10 @@ export namespace VSGetProjectContextsRequest {
     export const type = new RequestType<VSGetProjectContextParams, VSProjectContextList, void>(method);
 }
 
-export namespace ProjectContextRefreshNotification {
+export namespace ProjectContextRefreshRequest {
     export const method = 'workspace/projectContext/_vs_refresh';
     export const messageDirection: MessageDirection = MessageDirection.serverToClient;
-    export const type = new NotificationType(method);
+    export const type = new RequestType0(method);
 }
 
 export namespace FeatureProvidersRefreshNotification {


### PR DESCRIPTION
Refreshes in the spec are requests, not notifications.  Because we're using the generic refresh infra in the server, project context refreshes are also requests, not notifications.

Without this, the server throws Remote method not found exceptions, and the refresh request never makes it to the client

should also fix https://github.com/dotnet/vscode-csharp/pull/8933