### PR TITLE
Do not limit fetch depth

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -156,7 +156,6 @@ extends:
           clean: true
           submodules: false
           fetchTags: false
-          fetchDepth: 1
         - pwsh: |
             git checkout $(resources.pipeline.officialBuildCI.sourceCommit)
           displayName: 'Checkout build source branch'


### PR DESCRIPTION
By limiting fetch depth we did not have the `sourceCommit` in our enlistment. 