### PR TITLE
Fix update changelog action

### DIFF
--- a/tasks/snap/updateChangelog.ts
+++ b/tasks/snap/updateChangelog.ts
@@ -13,6 +13,7 @@ import { findTagsByVersion } from '../gitTasks';
 import { runTask } from '../runTask';
 
 const execAsync = promisify(exec);
+const prRegex = /^\*.+\(PR: \[#(\d+)\]\(/;
 
 runTask(updateChangelog);
 
@@ -79,8 +80,6 @@ async function updateChangelog(): Promise<void> {
     changelogLines.splice(currentHeaderLine + 1, 0, ...newPrs);
     fs.writeFileSync(changelogPath, changelogLines.join(os.EOL));
 }
-
-const prRegex = /^\*.+\(PR: \[#(\d+)\]\(/;
 
 function findNextVersionHeaderLine(changelogLines: string[], startLine: number = 0): [number, string] {
     const headerRegex = /^#\s(\d+\.\d+)\.(x|\d+)$/;


### PR DESCRIPTION
Moved the PR regex declaration earlier in the file because we were seeing:
```
/home/runner/work/vscode-csharp/vscode-csharp/tasks/snap/updateChangelog.ts:101
        const match = prRegex.exec(line!);
                      ^
ReferenceError: Cannot access 'prRegex' before initialization
```