### PR TITLE
Update Debugger to v2.136.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1432,12 +1432,12 @@
                   "coreclr",
                   "clr"
                 ],
-                "description": "Type type of code to debug. Can be either 'coreclr' for .NET Core debugging, or 'clr' for Desktop .NET Framework. 'clr' only works on Windows as the Desktop framework is Windows-only.",
+                "markdownDescription": "%generateOptionsSchema.type.markdownDescription%",
                 "default": "coreclr"
               },
               "debugServer": {
                 "type": "number",
-                "description": "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
+                "description": "%generateOptionsSchema.debugServer.description%",
                 "default": 4711
               }
             }

--- a/package.json
+++ b/package.json
@@ -427,7 +427,7 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
@@ -437,12 +437,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
-      "integrity": "61F2DFAD969C0D4AEC0A9D7216CBDACDDE3A191FF98394AA0FD12554A3C91700"
+      "integrity": "EB8080440555BBBAA37D5B40BE756996124452E0FA6098C3FFE425C8B8E97741"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-win10-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-win10-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
@@ -451,12 +451,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
-      "integrity": "98C98517794C0EF31EEF7EB75F6756E6FF7BC9D0D646775A23A940BD48F23962"
+      "integrity": "CC91DBB843B2F598D5AA530EF8CE89D317FD2A096BF77FDF51DFD96CF8C04BB4"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-osx-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "darwin"
@@ -470,12 +470,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui",
-      "integrity": "0AC449332375CD7E0963ACEF0D9DC13106B8AE519CD2099812A010C6A28DC697"
+      "integrity": "EF0E1D604BD0894F7526AB3CB6434357BFDAFB4A1506417F5C423ACA8EFCB05B"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / arm64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-osx-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-osx-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "darwin"
@@ -488,12 +488,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui",
-      "integrity": "0160FCB0F64532B5DF22C0812617F42AD98B16FB98CB8D8A6AD22783FB9786CF"
+      "integrity": "32F424F8891576B0DB259BF80B83172C6FF9C3AA08E7FEACAF3A4B2C4510EBBE"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-linux-arm.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-linux-arm.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -506,12 +506,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "C73C09964386A7036076C3CF1442E497DE95470BF442534598E6BB9457AF9278"
+      "integrity": "23B47E75DB750A4C7FD502626D2BC742CCEF047635595E681F11EEF8FAEEFF07"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-linux-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-linux-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -524,12 +524,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "5FEA2A074890FE01ED664D41B9952FF9C092F2B8F4E543A54550829B6033BE34"
+      "integrity": "50629AE7B7656F080D5AB97E6C9A38AF2C7187E90D082422FE5E8B9694F2F09C"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-linux-musl-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-linux-musl-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -542,12 +542,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "9E03969EE4FF40BA5A678772CE28BD095EBA8CC0462F807AAD724D54279CEF15"
+      "integrity": "2D8B977BD55F786C615F23644268B8CE78755E86834F4B9A2ADB719AD490736C"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-linux-musl-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-linux-musl-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -560,12 +560,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "F3984D09C7A866C6A29B1021277EE4CDF5DCD78543F9E88964E8D3AB393F4ED2"
+      "integrity": "D27A393840FAC8E5E26730CD492825E099605EAC03C3C852B66227E8D2EE7B2D"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-131-0/coreclr-debug-linux-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-136-0/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -578,7 +578,7 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "7851CBACD7FA6FF8A7DC5A617F4C7D8C5D91711BBBED65002452092C364A24FF"
+      "integrity": "383A96AD0A16935DDC3C09040BEB6B86BD01D127DE035CC29DAA984BCB3746B4"
     },
     {
       "id": "RazorOmnisharp",
@@ -1211,6 +1211,11 @@
             "description": "%generateOptionsSchema.expressionEvaluationOptions.showRawValues.description%",
             "default": false
           },
+          "csharp.debug.terminateChildProcesses": {
+            "type": "boolean",
+            "description": "%generateOptionsSchema.terminateChildProcesses.description%",
+            "default": false
+          },
           "csharp.wasm.debug.useVSDbg": {
             "type": "boolean",
             "description": "%generateOptionsSchema.useVSDbg.description%",
@@ -1427,12 +1432,12 @@
                   "coreclr",
                   "clr"
                 ],
-                "markdownDescription": "%generateOptionsSchema.type.markdownDescription%",
+                "description": "Type type of code to debug. Can be either 'coreclr' for .NET Core debugging, or 'clr' for Desktop .NET Framework. 'clr' only works on Windows as the Desktop framework is Windows-only.",
                 "default": "coreclr"
               },
               "debugServer": {
                 "type": "number",
-                "description": "%generateOptionsSchema.debugServer.description%",
+                "description": "For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
                 "default": 4711
               }
             }
@@ -2755,6 +2760,11 @@
                 "type": "boolean",
                 "description": "%generateOptionsSchema.checkForDevCert.description%",
                 "default": true
+              },
+              "terminateChildProcesses": {
+                "type": "boolean",
+                "description": "%generateOptionsSchema.terminateChildProcesses.description%",
+                "default": false
               }
             }
           },
@@ -4095,6 +4105,11 @@
                 "type": "boolean",
                 "description": "%generateOptionsSchema.checkForDevCert.description%",
                 "default": true
+              },
+              "terminateChildProcesses": {
+                "type": "boolean",
+                "description": "%generateOptionsSchema.terminateChildProcesses.description%",
+                "default": false
               }
             }
           },

--- a/package.nls.json
+++ b/package.nls.json
@@ -473,7 +473,7 @@
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
-    "generateOptionsSchema.type.markdownDescription": {
+  "generateOptionsSchema.type.markdownDescription": {
     "message": "Type type of code to debug. Can be either `coreclr` for .NET Core debugging, or `clr` for Desktop .NET Framework. `clr` only works on Windows as the Desktop framework is Windows-only.",
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."

--- a/package.nls.json
+++ b/package.nls.json
@@ -473,7 +473,7 @@
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
-  "generateOptionsSchema.type.markdownDescription": {
+    "generateOptionsSchema.type.markdownDescription": {
     "message": "Type type of code to debug. Can be either `coreclr` for .NET Core debugging, or `clr` for Desktop .NET Framework. `clr` only works on Windows as the Desktop framework is Windows-only.",
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
@@ -484,6 +484,12 @@
   },
   "generateOptionsSchema.checkForDevCert.description": {
     "message": "If you are launching a web project on Windows or macOS and this is enabled, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.terminateChildProcesses.description": {
+    "message": "When the debug session ends, if this is set to `true`, the debugger will terminate the debuggee and all child processes it spawned. If set to `false`, only the debuggee itself is terminated and child processes are left running. This option defaults to `false`.\n\nOn Windows, child processes are tracked using a Job Object. Processes that need to outlive the debug session can opt out by passing the `CREATE_BREAKAWAY_FROM_JOB` flag when calling `CreateProcess`.",
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -472,6 +472,11 @@
           "type": "boolean",
           "description": "If you are launching a web project on Windows or macOS and this is enabled, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
           "default": true
+        },
+        "terminateChildProcesses": {
+          "type": "boolean",
+          "description": "When the debug session ends, if this is set to `true`, the debugger will terminate the debuggee and all child processes it spawned. If set to `false`, only the debuggee itself is terminated and child processes are left running. This option defaults to `false`.\n\nOn Windows, child processes are tracked using a Job Object. Processes that need to outlive the debug session can opt out by passing the `CREATE_BREAKAWAY_FROM_JOB` flag when calling `CreateProcess`.",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
This update includes adding a new launch option called `terminateChildProcesses` that will terminate the debuggee and any child process it spawns.

Addresses: https://github.com/dotnet/vscode-csharp/issues/4325

# Testing
- [x] Windows
- [x] Linux (WSL Ubuntu)
- [x] macOS

# TODO
- [x] Update vscode-docs for new flag
   - https://github.com/microsoft/vscode-docs/pull/9679