### PR TITLE
Bump Razor to 10.0.0-preview.26226.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@
 
 # 2.141.x
 * Update Razor to 10.0.0-preview.26226.17 (PR: [#9240](https://github.com/dotnet/vscode-csharp/pull/9240))
-  * Parallelize HTML and OOP completion requests in Razor cohost endpoint (PR: [#13092](https://github.com/dotnet/razor/pull/13092))
+  * Parallelize HTML and Razor completion requests (PR: [#13092](https://github.com/dotnet/razor/pull/13092))
   * Fix formatting for self-closing multiline templates (PR: [#13069](https://github.com/dotnet/razor/pull/13069))
   * Return empty incomplete list when HTML completion fails in Razor (PR: [#13090](https://github.com/dotnet/razor/pull/13090))
-  * Perf: Skip GetAttributes() for non-viable component properties (PR: [#13091](https://github.com/dotnet/razor/pull/13091))
-  * Fix #13056 - Debugger and stack exception pointed to incorrect line/code as source of issue (PR: [#13057](https://github.com/dotnet/razor/pull/13057))
 
 # 2.136.x
 * Update Roslyn to 5.7.0-1.26220.12 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.141.x
-* Update Razor to 10.0.0-preview.26226.17 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Razor to 10.0.0-preview.26226.17 (PR: [#9240](https://github.com/dotnet/vscode-csharp/pull/9240))
   * Parallelize HTML and OOP completion requests in Razor cohost endpoint (PR: [#13092](https://github.com/dotnet/razor/pull/13092))
   * Fix formatting for self-closing multiline templates (PR: [#13069](https://github.com/dotnet/razor/pull/13069))
   * Return empty incomplete list when HTML completion fails in Razor (PR: [#13090](https://github.com/dotnet/razor/pull/13090))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.141.x
+* Update Razor to 10.0.0-preview.26226.17 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Parallelize HTML and OOP completion requests in Razor cohost endpoint (PR: [#13092](https://github.com/dotnet/razor/pull/13092))
+  * Fix formatting for self-closing multiline templates (PR: [#13069](https://github.com/dotnet/razor/pull/13069))
+  * Return empty incomplete list when HTML completion fails in Razor (PR: [#13090](https://github.com/dotnet/razor/pull/13090))
+  * Perf: Skip GetAttributes() for non-viable component properties (PR: [#13091](https://github.com/dotnet/razor/pull/13091))
+  * Fix #13056 - Debugger and stack exception pointed to incorrect line/code as source of issue (PR: [#13057](https://github.com/dotnet/razor/pull/13057))
 
 # 2.136.x
 * Update Roslyn to 5.7.0-1.26220.12 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.7.0-1.26220.12",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.26217.1",
+    "razor": "10.0.0-preview.26226.17",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.7.11721.33"
   },


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/78f7baedf34d5583f386e819474d68584161c6f0...0f6925db833176ee2df811cd2b2280144a378039?w=1)
* Parallelize HTML and OOP completion requests in Razor cohost endpoint (PR: [#13092](https://github.com/dotnet/razor/pull/13092))
* [main] Source code updates from dotnet/dotnet (PR: [#13058](https://github.com/dotnet/razor/pull/13058))
* Log file kind and syntax tree in formatting logs (PR: [#13093](https://github.com/dotnet/razor/pull/13093))
* Fix formatting for self-closing multiline templates (PR: [#13069](https://github.com/dotnet/razor/pull/13069))
* Return empty incomplete list when HTML completion fails in Razor (PR: [#13090](https://github.com/dotnet/razor/pull/13090))
* Perf: Skip GetAttributes() for non-viable component properties (PR: [#13091](https://github.com/dotnet/razor/pull/13091))
* Fix active Component Governance alerts (PR: [#13065](https://github.com/dotnet/razor/pull/13065))
* [main] Update dependencies from dotnet/arcade (PR: [#13070](https://github.com/dotnet/razor/pull/13070))
* Fix #13056 - Debugger and stack exception pointed to incorrect line/code as source of issue (PR: [#13057](https://github.com/dotnet/razor/pull/13057))
* Unskip generate method and associated tests (PR: [#13063](https://github.com/dotnet/razor/pull/13063))

