### PR TITLE
Bump Roslyn to 5.8.0-1.26256.6 and Razor to 10.4.0-preview.26256.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.142.x
+* Update Roslyn to 5.8.0-1.26256.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Allow LSP character position to go beyond line length (PR: [#83595](https://github.com/dotnet/roslyn/pull/83595))
+  * Fix leaked event handlers in AbstractRefreshQueue and ProjectSystemProject (PR: [#83561](https://github.com/dotnet/roslyn/pull/83561))
+  * Skip dot-prefixed directories in file-based app discovery (PR: [#83547](https://github.com/dotnet/roslyn/pull/83547))
+* Update Razor to 10.4.0-preview.26256.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Suppress snippets and tag helper completions in end-tag contexts (PR: [#83573](https://github.com/dotnet/roslyn/pull/83573))
+  * Fix Razor directive attribute completion issues (PR: [#83559](https://github.com/dotnet/roslyn/pull/83559))
 
 # 2.141.x
 * Skip RoslynCopilot install when AI features are disabeld (PR: [#9196](https://github.com/dotnet/vscode-csharp/pull/9196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.142.x
-* Update Roslyn to 5.8.0-1.26256.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.8.0-1.26256.6 (PR: [#9291](https://github.com/dotnet/vscode-csharp/pull/9291))
   * Allow LSP character position to go beyond line length (PR: [#83595](https://github.com/dotnet/roslyn/pull/83595))
   * Fix leaked event handlers in AbstractRefreshQueue and ProjectSystemProject (PR: [#83561](https://github.com/dotnet/roslyn/pull/83561))
   * Skip dot-prefixed directories in file-based app discovery (PR: [#83547](https://github.com/dotnet/roslyn/pull/83547))
-* Update Razor to 10.4.0-preview.26256.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Razor to 10.4.0-preview.26256.6 (PR: [#9291](https://github.com/dotnet/vscode-csharp/pull/9291))
   * Suppress snippets and tag helper completions in end-tag contexts (PR: [#83573](https://github.com/dotnet/roslyn/pull/83573))
   * Fix Razor directive attribute completion issues (PR: [#83559](https://github.com/dotnet/roslyn/pull/83559))
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.8.0-1.26252.1",
+    "roslyn": "5.8.0-1.26256.6",
     "omniSharp": "1.39.14",
-    "razor": "10.4.0-preview.26252.1",
+    "razor": "10.4.0-preview.26256.6",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.7.11727.258"
   },


### PR DESCRIPTION
Given the infra issues with getting a new package out, I can't update my other PR, so figured this is worth doing in the meantime.



[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/3d098b3a2f24112aa06731d38ea6dd7334169998...c2ed65c206818b5bd7218905b0f2634f7fc8d9e6?w=1)
* Allow LSP character position to go beyond line length (PR: [#83595](https://github.com/dotnet/roslyn/pull/83595))
* Use an AppDomain in the .NET Framework BuildHost to better isolate us from VS-installed MSBuilds (PR: [#83477](https://github.com/dotnet/roslyn/pull/83477))
* Suppress snippets and tag helper completions in end-tag contexts (PR: [#83573](https://github.com/dotnet/roslyn/pull/83573))
* Fix leaked event handlers in AbstractRefreshQueue and ProjectSystemProject (PR: [#83561](https://github.com/dotnet/roslyn/pull/83561))
* Add warning waves proposal (PR: [#83458](https://github.com/dotnet/roslyn/pull/83458))
* Remove design-time code generation from the Razor compiler (PR: [#83510](https://github.com/dotnet/roslyn/pull/83510))
* Fix Razor directive attribute completion issues (PR: [#83559](https://github.com/dotnet/roslyn/pull/83559))
* Add Razor assembly versions to DependentAssemblyVersions.csv (PR: [#83558](https://github.com/dotnet/roslyn/pull/83558))
* Purge cache in roslyn CI (PR: [#83480](https://github.com/dotnet/roslyn/pull/83480))
* Allow creating compilation with empty analyzer list (PR: [#83418](https://github.com/dotnet/roslyn/pull/83418))
* Set source map for VSCode debugger (PR: [#83550](https://github.com/dotnet/roslyn/pull/83550))
* Remove old razor server bits (PR: [#83522](https://github.com/dotnet/roslyn/pull/83522))
* Skip dot-prefixed directories in file-based app discovery (PR: [#83547](https://github.com/dotnet/roslyn/pull/83547))

