### PR TITLE
Update roslyn to 5.8.0-1.26276.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,8 @@
 
 # 2.143.x
 * Update Roslyn to 5.8.0-1.26276.4 (PR: [#9352](https://github.com/dotnet/vscode-csharp/pull/9352))
-  * Fix service broker initializers to consistently be LSP services (PR: [#83890](https://github.com/dotnet/roslyn/pull/83890))
+  * Fix XAML hot reload (PR: [#83890](https://github.com/dotnet/roslyn/pull/83890))
   * Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
-  * Use dedicated type for union syntax. (PR: [#83808](https://github.com/dotnet/roslyn/pull/83808))
-  * Suppress IDE0019 when local is later passed to out/ref of nullable parameter (PR: [#83883](https://github.com/dotnet/roslyn/pull/83883))
-  * Don't offer IDE0058 for Null-conditional assignment (PR: [#83817](https://github.com/dotnet/roslyn/pull/83817))
-  * Add full semantic tokens support to Razor (PR: [#83800](https://github.com/dotnet/roslyn/pull/83800))
-  * Don't pass client capabilities via a string (PR: [#83871](https://github.com/dotnet/roslyn/pull/83871))
-
-* Update Roslyn to 5.8.0-1.26273.3 (PR: [#9348](https://github.com/dotnet/vscode-csharp/pull/9348))
   * Suppress Razor completion when @ is typed in Emmet numbering context (PR: [#83837](https://github.com/dotnet/roslyn/pull/83837))
   * Convert to local function: ensure unique names for multiple discard parameters (PR: [#83644](https://github.com/dotnet/roslyn/pull/83644))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.143.x
+* Update Roslyn to 5.8.0-1.26276.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Fix service broker initializers to consistently be LSP services (PR: [#83890](https://github.com/dotnet/roslyn/pull/83890))
+  * Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
+  * Use dedicated type for union syntax. (PR: [#83808](https://github.com/dotnet/roslyn/pull/83808))
+  * Suppress IDE0019 when local is later passed to out/ref of nullable parameter (PR: [#83883](https://github.com/dotnet/roslyn/pull/83883))
+  * Don't offer IDE0058 for Null-conditional assignment (PR: [#83817](https://github.com/dotnet/roslyn/pull/83817))
+  * Add full semantic tokens support to Razor (PR: [#83800](https://github.com/dotnet/roslyn/pull/83800))
+  * Don't pass client capabilities via a string (PR: [#83871](https://github.com/dotnet/roslyn/pull/83871))
+
 * Update Roslyn to 5.8.0-1.26273.3 (PR: [#9348](https://github.com/dotnet/vscode-csharp/pull/9348))
   * Suppress Razor completion when @ is typed in Emmet numbering context (PR: [#83837](https://github.com/dotnet/roslyn/pull/83837))
   * Convert to local function: ensure unique names for multiple discard parameters (PR: [#83644](https://github.com/dotnet/roslyn/pull/83644))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.143.x
-* Update Roslyn to 5.8.0-1.26276.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.8.0-1.26276.4 (PR: [#9352](https://github.com/dotnet/vscode-csharp/pull/9352))
   * Fix service broker initializers to consistently be LSP services (PR: [#83890](https://github.com/dotnet/roslyn/pull/83890))
   * Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
   * Use dedicated type for union syntax. (PR: [#83808](https://github.com/dotnet/roslyn/pull/83808))

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.8.0-1.26273.3",
+    "roslyn": "5.8.0-1.26276.4",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.7.11727.258"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/9cb18487b56c7758ba73e676c0f34b3d2453aa35...b1a419548cd16cb12721dfba2f0799e924d3bdd2?w=1)
* Update resource management configuration in YAML (PR: [#83888](https://github.com/dotnet/roslyn/pull/83888))
* Fix service broker initializers to consistently be LSP services (PR: [#83890](https://github.com/dotnet/roslyn/pull/83890))
* Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
* Use dedicated type for union syntax. (PR: [#83808](https://github.com/dotnet/roslyn/pull/83808))
* Suppress IDE0019 when local is later passed to out/ref of nullable parameter (PR: [#83883](https://github.com/dotnet/roslyn/pull/83883))
* Don't offer IDE0058 for Null-conditional assignment (PR: [#83817](https://github.com/dotnet/roslyn/pull/83817))
* Fix Razor integration tests in DartLab (PR: [#83874](https://github.com/dotnet/roslyn/pull/83874))
* Add full semantic tokens support to Razor (PR: [#83800](https://github.com/dotnet/roslyn/pull/83800))
* Minor cleanups in Razor Workspaces (PR: [#83870](https://github.com/dotnet/roslyn/pull/83870))
* Don't pass client capabilities via a string (PR: [#83871](https://github.com/dotnet/roslyn/pull/83871))
