### PR TITLE
Revert "Update XamlTools to v18.9.11902.238 (#9382)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@
   * Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
   * Suppress Razor completion when @ is typed in Emmet numbering context (PR: [#83837](https://github.com/dotnet/roslyn/pull/83837))
   * Convert to local function: ensure unique names for multiple discard parameters (PR: [#83644](https://github.com/dotnet/roslyn/pull/83644))
-* Update xamlTools to 18.9.11902.238 (PR: [#9382](https://github.com/dotnet/vscode-csharp/pull/9382))
-  * Hot Reload E2E diagnostics fundamentals (PR: AzDO#731599)
-  * Fix MetadataUpdateHandlers were not called in some cases in MAUI apps (PR: AzDO#731599)
 
 * Update Roslyn to 5.8.0-1.26267.2 (PR: [#9321](https://github.com/dotnet/vscode-csharp/pull/9321))
   * Fix racecondition on UnsuedDirectiveCache.Set (PR: [#83693](https://github.com/dotnet/roslyn/pull/83693))

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "roslyn": "5.9.0-1.26279.7",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "18.9.11902.238"
+    "xamlTools": "18.7.11727.258"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
This reverts commit ec0492e53f97a06c36871484af480e63e2b3888c, reversing changes made to 63e217de8b2e2ed7ada3329ba4e34007e8786e37.

needs https://github.com/dotnet/roslyn/pull/84018 before this can go in