### PR TITLE
Update roslyn to 5.9.0-1.26308.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@
 
 # 2.143.x
 * Update Roslyn to 5.9.0-1.26308.3 (PR: [#9403](https://github.com/dotnet/vscode-csharp/pull/9403))
-  * Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
-  * Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
   * Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
   * Fix Razor diagnostics exception when HTML diagnostic range exceeds SourceText bounds (PR: [#84002](https://github.com/dotnet/roslyn/pull/84002))
   * Fix rename in VS Code from a C# document (PR: [#83971](https://github.com/dotnet/roslyn/pull/83971))
-  * Complete server shutdown when mutex is closed (PR: [#83921](https://github.com/dotnet/roslyn/pull/83921))
   * Only add reference counts on CodeLens elements that are supported (PR: [#82641](https://github.com/dotnet/roslyn/pull/82641))
 * Remove Razor logger (PR: [#9368](https://github.com/dotnet/vscode-csharp/pull/9368))
 * Update Roslyn to 5.9.0-1.26279.7 (PR: [#9367](https://github.com/dotnet/vscode-csharp/pull/9367))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.143.x
-* Update Roslyn to 5.9.0-1.26308.3 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.9.0-1.26308.3 (PR: [#9403](https://github.com/dotnet/vscode-csharp/pull/9403))
   * Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
   * Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
   * Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.143.x
+* Update Roslyn to 5.9.0-1.26308.3 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
+  * Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
+  * Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
+  * Fix Razor diagnostics exception when HTML diagnostic range exceeds SourceText bounds (PR: [#84002](https://github.com/dotnet/roslyn/pull/84002))
+  * Fix rename in VS Code from a C# document (PR: [#83971](https://github.com/dotnet/roslyn/pull/83971))
+  * Complete server shutdown when mutex is closed (PR: [#83921](https://github.com/dotnet/roslyn/pull/83921))
+  * Only add reference counts on CodeLens elements that are supported (PR: [#82641](https://github.com/dotnet/roslyn/pull/82641))
 * Remove Razor logger (PR: [#9368](https://github.com/dotnet/vscode-csharp/pull/9368))
 * Update Roslyn to 5.9.0-1.26279.7 (PR: [#9367](https://github.com/dotnet/vscode-csharp/pull/9367))
   * Log Razor messages to normal LSP log endpoint (PR: [#83935](https://github.com/dotnet/roslyn/pull/83935))

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.9.0-1.26279.7",
+    "roslyn": "5.9.0-1.26308.3",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.7.11727.258"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/234388520edf9c9a844ce493d7a7ca5343c4dc00...82ad1e15e364edbd6ca59d8a8325df2b6488e28e?w=1)
* Unsafe evolution: propagate unsafe context to constructor initializer (PR: [#83969](https://github.com/dotnet/roslyn/pull/83969))
* Parameterize DartLab templates repository alias (PR: [#84037](https://github.com/dotnet/roslyn/pull/84037))
* Fix frontmatter syntax in Compiler.instructions.md (PR: [#84032](https://github.com/dotnet/roslyn/pull/84032))
* Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
* Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
* Fix a number of helix issues (PR: [#84039](https://github.com/dotnet/roslyn/pull/84039))
* Use xsd:anyURI type to detect external completion instead of vs:preferredextensions (PR: [#84033](https://github.com/dotnet/roslyn/pull/84033))
* Add formatting tests for code blocks above markup (PR: [#84027](https://github.com/dotnet/roslyn/pull/84027))
* Move Razor docs under docs (PR: [#84024](https://github.com/dotnet/roslyn/pull/84024))
* Add test to demonstrate adding using for inject directives works (PR: [#84026](https://github.com/dotnet/roslyn/pull/84026))
* Fix incremental build in Microsoft.Build.Tasks.CodeAnalysis.UnitTests (PR: [#84016](https://github.com/dotnet/roslyn/pull/84016))
* Remove unneeded logging (PR: [#84023](https://github.com/dotnet/roslyn/pull/84023))
* Convert copilot-instructions to AGENTS.md (PR: [#84022](https://github.com/dotnet/roslyn/pull/84022))
* SourceMemberMethodSymbol.IsMetadataVirtual should force complete declaring type when queried by a different module (PR: [#84013](https://github.com/dotnet/roslyn/pull/84013))
* Free pooled objects across cancellation exceptions (PR: [#83875](https://github.com/dotnet/roslyn/pull/83875))
* Bump Debugger.Contracts to 18.3.0-beta.26277.4 (PR: [#84018](https://github.com/dotnet/roslyn/pull/84018))
* Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
* Fix Razor diagnostics exception when HTML diagnostic range exceeds SourceText bounds (PR: [#84002](https://github.com/dotnet/roslyn/pull/84002))
* Use MEF services in VS Code cohost tests (PR: [#83986](https://github.com/dotnet/roslyn/pull/83986))
* Implement runtime async support for dynamic (PR: [#83713](https://github.com/dotnet/roslyn/pull/83713))
* Remove IDynamicFileInfoProvider and related code (PR: [#83928](https://github.com/dotnet/roslyn/pull/83928))
* Add IAsyncLifetime overhead adjustment to test scheduling (PR: [#83915](https://github.com/dotnet/roslyn/pull/83915))
* Move a couple of helpers to the remote project (PR: [#83990](https://github.com/dotnet/roslyn/pull/83990))
* Unsafe evolution: consolidate reserved attributes (PR: [#83908](https://github.com/dotnet/roslyn/pull/83908))
* Fix rename in VS Code from a C# document (PR: [#83971](https://github.com/dotnet/roslyn/pull/83971))
* Remove invalid casts in PairedExtensionOperatorSignatureComparer (PR: [#83934](https://github.com/dotnet/roslyn/pull/83934))
* Remove the state from MSBuildDiagnosticLogger (PR: [#83977](https://github.com/dotnet/roslyn/pull/83977))
* Unions: `not` pattern is applied to the incoming value itself (PR: [#83904](https://github.com/dotnet/roslyn/pull/83904))
* Complete server shutdown when mutex is closed (PR: [#83921](https://github.com/dotnet/roslyn/pull/83921))
* Fix some missing attributes on partial async and iterator methods (PR: [#83790](https://github.com/dotnet/roslyn/pull/83790))
* Unsafe evolution: safe/unsafe externs (PR: [#83661](https://github.com/dotnet/roslyn/pull/83661))
* Use `params ImmutableArray<T>` on all applicable public APIs. (PR: [#83858](https://github.com/dotnet/roslyn/pull/83858))
* Unsafe evolution: avoid unnecessary diagnostics on params collection declarations (PR: [#83641](https://github.com/dotnet/roslyn/pull/83641))
* Cache Razor cohost MEF setup across tests (PR: [#83936](https://github.com/dotnet/roslyn/pull/83936))
* Consolidate Linked Editing Range up to its callers (PR: [#83956](https://github.com/dotnet/roslyn/pull/83956))
* Consolidate Semantic Tokens code up to where it should be (PR: [#83955](https://github.com/dotnet/roslyn/pull/83955))
* Consolidate Diagnostics code up into Remote.Razor (PR: [#83951](https://github.com/dotnet/roslyn/pull/83951))
* Consolidate Rename code up into Remote.Razor (PR: [#83950](https://github.com/dotnet/roslyn/pull/83950))
* Consolidate Document Symbols code up into Remote.Razor (PR: [#83949](https://github.com/dotnet/roslyn/pull/83949))
* Consolidate Folding Ranges code up into Remote.Razor (PR: [#83948](https://github.com/dotnet/roslyn/pull/83948))
* Consolidate Spell Check code up into Remote.Razor (PR: [#83947](https://github.com/dotnet/roslyn/pull/83947))
* Per server workspace and project factories (PR: [#83857](https://github.com/dotnet/roslyn/pull/83857))
* Fix marketplace name for dotnet/skills (PR: [#83961](https://github.com/dotnet/roslyn/pull/83961))
* Only add reference counts on CodeLens elements that are supported (PR: [#82641](https://github.com/dotnet/roslyn/pull/82641))
* [main] Update dependencies from dotnet/arcade (PR: [#83941](https://github.com/dotnet/roslyn/pull/83941))
* Closed classes: add a few interface matching tests (PR: [#83940](https://github.com/dotnet/roslyn/pull/83940))
* Fix x86 test host OOM in TemporaryStorageService (PR: [#83952](https://github.com/dotnet/roslyn/pull/83952))
* Change insertionCreateDraftPR to false (PR: [#83958](https://github.com/dotnet/roslyn/pull/83958))
* Allow running DartLab as VS test gate (PR: [#83690](https://github.com/dotnet/roslyn/pull/83690))
* Remove ExternalAccess.Razor and give Razor deeper IVT to Roslyn (PR: [#83879](https://github.com/dotnet/roslyn/pull/83879))
* Remove catch from FBA fuzz test (PR: [#83820](https://github.com/dotnet/roslyn/pull/83820))
* Move cohost handlers from ExternalAccess.Razor to Razor (PR: [#83880](https://github.com/dotnet/roslyn/pull/83880))
* Empty and Remove ExternalAccess.Razor (PR: [#83920](https://github.com/dotnet/roslyn/pull/83920))

