### PR TITLE
Bump xamlTools to 18.9.11909.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   * Shut down the BuildHost before we start the restore (PR: [#83860](https://github.com/dotnet/roslyn/pull/83860))
   * Suppress Razor completion when @ is typed in Emmet numbering context (PR: [#83837](https://github.com/dotnet/roslyn/pull/83837))
   * Convert to local function: ensure unique names for multiple discard parameters (PR: [#83644](https://github.com/dotnet/roslyn/pull/83644))
+* Update xamlTools to 18.9.11909.33 (PR: [#9409](https://github.com/dotnet/vscode-csharp/pull/9409))
+  * Hot Reload E2E diagnostics fundamentals (PR: AzDO#731599)
+  * Fix MetadataUpdateHandlers were not called in some cases in MAUI apps (PR: AzDO#731599)
+  * XAML Language server telemetry (PR: AzDO#733556)
 
 * Update Roslyn to 5.8.0-1.26267.2 (PR: [#9321](https://github.com/dotnet/vscode-csharp/pull/9321))
   * Fix racecondition on UnsuedDirectiveCache.Set (PR: [#83693](https://github.com/dotnet/roslyn/pull/83693))

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "roslyn": "5.9.0-1.26303.15",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "18.7.11727.258"
+    "xamlTools": "18.9.11909.33"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Same as #9382, but now it doesn't rely on Roslyn's Debugger.Contracts DLL, so there will be no MEF composition exception on initialization.