### PR TITLE
Categorize this extension as a formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "Debuggers",
     "Programming Languages",
     "Linters",
-    "Snippets"
+    "Snippets",
+    "Formatters"
   ],
   "keywords": [
     "multi-root ready",


### PR DESCRIPTION
When trying to format a C# file in vanilla VS Code (no extensions), users get prompted to install a formatter, which automatically searches VS Code extensions for `category:formatters csharp`. This extension does not show up in that search because it's not currently marked as a formatter. This PR adds the "formatters" category so now we do show up :)