### PR TITLE
Update roslyn to 5.9.0-1.26314.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.144.x
+* Update Roslyn to 5.9.0-1.26314.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Records: Avoid synthesized non-virtual calls to abstract methods (PR: [#84101](https://github.com/dotnet/roslyn/pull/84101))
+  * Reduce allocation churn in tag helper context discovery pools (PR: [#84123](https://github.com/dotnet/roslyn/pull/84123))
+  * Fix multiline lambda formatting in non-directive attributes (PR: [#84121](https://github.com/dotnet/roslyn/pull/84121))
+  * Strengthen NullableWalker.IsSlotMember against NullReferenceException (PR: [#84071](https://github.com/dotnet/roslyn/pull/84071))
+  * Allow disposable pooled objects in compiler (PR: [#84082](https://github.com/dotnet/roslyn/pull/84082))
+  * Fix file watching leaks for shared server (PR: [#84049](https://github.com/dotnet/roslyn/pull/84049))
+  * Fix Razor allowed child validation in code blocks (PR: [#84116](https://github.com/dotnet/roslyn/pull/84116))
+  * Add the server name to the LSP initialization result (PR: [#84109](https://github.com/dotnet/roslyn/pull/84109))
+  * Fix signature help selecting wrong overload for multiple type parameter extension methods (PR: [#84089](https://github.com/dotnet/roslyn/pull/84089))
+  * Fix design-time-builds from out-of-proc nodes returning empty data (PR: [#84096](https://github.com/dotnet/roslyn/pull/84096))
+  * Fix ArrayBuilder<SyntaxNode> pool leak in ComputeDeclarationAnalysisData (PR: [#84046](https://github.com/dotnet/roslyn/pull/84046))
+  * Fix mishandling of large embedded C# literals (PR: [#84043](https://github.com/dotnet/roslyn/pull/84043))
+  * Unsafe evolution: propagate unsafe context to constructor initializer (PR: [#83969](https://github.com/dotnet/roslyn/pull/83969))
+  * Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
+  * Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
+  * Use xsd:anyURI type to detect external completion instead of vs:preferredextensions (PR: [#84033](https://github.com/dotnet/roslyn/pull/84033))
+  * SourceMemberMethodSymbol.IsMetadataVirtual should force complete declaring type when queried by a different module (PR: [#84013](https://github.com/dotnet/roslyn/pull/84013))
+  * Free pooled objects across cancellation exceptions (PR: [#83875](https://github.com/dotnet/roslyn/pull/83875))
+  * Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
 
 # 2.143.x
 * Update Roslyn to 5.9.0-1.26303.15 (PR: [#9404](https://github.com/dotnet/vscode-csharp/pull/9404))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,8 @@
 
 # 2.144.x
 * Update Roslyn to 5.9.0-1.26314.1 (PR: [#9430](https://github.com/dotnet/vscode-csharp/pull/9430))
-  * Records: Avoid synthesized non-virtual calls to abstract methods (PR: [#84101](https://github.com/dotnet/roslyn/pull/84101))
-  * Reduce allocation churn in tag helper context discovery pools (PR: [#84123](https://github.com/dotnet/roslyn/pull/84123))
   * Fix multiline lambda formatting in non-directive attributes (PR: [#84121](https://github.com/dotnet/roslyn/pull/84121))
-  * Strengthen NullableWalker.IsSlotMember against NullReferenceException (PR: [#84071](https://github.com/dotnet/roslyn/pull/84071))
-  * Allow disposable pooled objects in compiler (PR: [#84082](https://github.com/dotnet/roslyn/pull/84082))
-  * Fix file watching leaks for shared server (PR: [#84049](https://github.com/dotnet/roslyn/pull/84049))
-  * Fix Razor allowed child validation in code blocks (PR: [#84116](https://github.com/dotnet/roslyn/pull/84116))
-  * Add the server name to the LSP initialization result (PR: [#84109](https://github.com/dotnet/roslyn/pull/84109))
   * Fix signature help selecting wrong overload for multiple type parameter extension methods (PR: [#84089](https://github.com/dotnet/roslyn/pull/84089))
-  * Fix design-time-builds from out-of-proc nodes returning empty data (PR: [#84096](https://github.com/dotnet/roslyn/pull/84096))
-  * Fix ArrayBuilder<SyntaxNode> pool leak in ComputeDeclarationAnalysisData (PR: [#84046](https://github.com/dotnet/roslyn/pull/84046))
-  * Fix mishandling of large embedded C# literals (PR: [#84043](https://github.com/dotnet/roslyn/pull/84043))
-  * Unsafe evolution: propagate unsafe context to constructor initializer (PR: [#83969](https://github.com/dotnet/roslyn/pull/83969))
-  * Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
-  * Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
-  * Use xsd:anyURI type to detect external completion instead of vs:preferredextensions (PR: [#84033](https://github.com/dotnet/roslyn/pull/84033))
-  * SourceMemberMethodSymbol.IsMetadataVirtual should force complete declaring type when queried by a different module (PR: [#84013](https://github.com/dotnet/roslyn/pull/84013))
-  * Free pooled objects across cancellation exceptions (PR: [#83875](https://github.com/dotnet/roslyn/pull/83875))
   * Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
 
 # 2.143.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.144.x
-* Update Roslyn to 5.9.0-1.26314.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.9.0-1.26314.1 (PR: [#9430](https://github.com/dotnet/vscode-csharp/pull/9430))
   * Records: Avoid synthesized non-virtual calls to abstract methods (PR: [#84101](https://github.com/dotnet/roslyn/pull/84101))
   * Reduce allocation churn in tag helper context discovery pools (PR: [#84123](https://github.com/dotnet/roslyn/pull/84123))
   * Fix multiline lambda formatting in non-directive attributes (PR: [#84121](https://github.com/dotnet/roslyn/pull/84121))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.9.0-1.26303.15",
+    "roslyn": "5.9.0-1.26314.1",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.9.11909.33"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/c022430432aa6c83ecd2075587c22d06ed48bee2...94180ea43ae879ba286300360d677cc72f0a1369?w=1)
* Records: Avoid synthesized non-virtual calls to abstract methods (PR: [#84101](https://github.com/dotnet/roslyn/pull/84101))
* Reduce allocation churn in tag helper context discovery pools (PR: [#84123](https://github.com/dotnet/roslyn/pull/84123))
* Fix multiline lambda formatting in non-directive attributes (PR: [#84121](https://github.com/dotnet/roslyn/pull/84121))
* Embed Workspaces.MSBuild.Contracts into the Workspaces.MSBuild NuGet (PR: [#84113](https://github.com/dotnet/roslyn/pull/84113))
* Document cache contents as a trusted compilation input (PR: [#84114](https://github.com/dotnet/roslyn/pull/84114))
* Allow multiple host workspaces for PdbMatchingSourceTextProvider (PR: [#84094](https://github.com/dotnet/roslyn/pull/84094))
* Strengthen NullableWalker.IsSlotMember against NullReferenceException (PR: [#84071](https://github.com/dotnet/roslyn/pull/84071))
* Allow disposable pooled objects in compiler (PR: [#84082](https://github.com/dotnet/roslyn/pull/84082))
* Fix file watching leaks for shared server (PR: [#84049](https://github.com/dotnet/roslyn/pull/84049))
* Fix Razor allowed child validation in code blocks (PR: [#84116](https://github.com/dotnet/roslyn/pull/84116))
* Add Razor compiler integration tests for most C# features since C# 8 (PR: [#83862](https://github.com/dotnet/roslyn/pull/83862))
* Adjust telemetry to identify file-based apps with no directives (PR: [#84111](https://github.com/dotnet/roslyn/pull/84111))
* Use cached mef compositions in language server tests when possible (PR: [#84083](https://github.com/dotnet/roslyn/pull/84083))
* Add the server name to the LSP initialization result (PR: [#84109](https://github.com/dotnet/roslyn/pull/84109))
* Fix signature help selecting wrong overload for multiple type parameter extension methods (PR: [#84089](https://github.com/dotnet/roslyn/pull/84089))
* Fix design-time-builds from out-of-proc nodes returning empty data (PR: [#84096](https://github.com/dotnet/roslyn/pull/84096))
* Fix ArrayBuilder<SyntaxNode> pool leak in ComputeDeclarationAnalysisData (PR: [#84046](https://github.com/dotnet/roslyn/pull/84046))
* Exclude all root `.md` files from CI (PR: [#84074](https://github.com/dotnet/roslyn/pull/84074))
* Update instructions around PROTOTYPE comments (PR: [#84073](https://github.com/dotnet/roslyn/pull/84073))
* Increase timeout for Correctness_Analyzers job (PR: [#84064](https://github.com/dotnet/roslyn/pull/84064))
* Fix mishandling of large embedded C# literals (PR: [#84043](https://github.com/dotnet/roslyn/pull/84043))
* Unsafe evolution: propagate unsafe context to constructor initializer (PR: [#83969](https://github.com/dotnet/roslyn/pull/83969))
* Parameterize DartLab templates repository alias (PR: [#84037](https://github.com/dotnet/roslyn/pull/84037))
* Fix frontmatter syntax in Compiler.instructions.md (PR: [#84032](https://github.com/dotnet/roslyn/pull/84032))
* Add baseline availability status to HTML completion tooltips (PR: [#84054](https://github.com/dotnet/roslyn/pull/84054))
* Fix Razor breakpoint placement (PR: [#84029](https://github.com/dotnet/roslyn/pull/84029))
* Fix a number of helix issues (PR: [#84039](https://github.com/dotnet/roslyn/pull/84039))
* Use xsd:anyURI type to detect external completion instead of vs:preferredextensions (PR: [#84033](https://github.com/dotnet/roslyn/pull/84033))
* Add formatting tests for code blocks above markup (PR: [#84027](https://github.com/dotnet/roslyn/pull/84027))
* Move Razor docs under docs (PR: [#84024](https://github.com/dotnet/roslyn/pull/84024))
* Add test to demonstrate adding using for inject directives works (PR: [#84026](https://github.com/dotnet/roslyn/pull/84026))
* Fix incremental build in Microsoft.Build.Tasks.CodeAnalysis.UnitTests (PR: [#84016](https://github.com/dotnet/roslyn/pull/84016))
* Remove unneeded logging (PR: [#84023](https://github.com/dotnet/roslyn/pull/84023))
* Convert copilot-instructions to AGENTS.md (PR: [#84022](https://github.com/dotnet/roslyn/pull/84022))
* SourceMemberMethodSymbol.IsMetadataVirtual should force complete declaring type when queried by a different module (PR: [#84013](https://github.com/dotnet/roslyn/pull/84013))
* Free pooled objects across cancellation exceptions (PR: [#83875](https://github.com/dotnet/roslyn/pull/83875))
* Bump Debugger.Contracts to 18.3.0-beta.26277.4 (PR: [#84018](https://github.com/dotnet/roslyn/pull/84018))
* Enable parallel builds in the LSP when loading projects (PR: [#83982](https://github.com/dotnet/roslyn/pull/83982))
