### PR TITLE
Update roslyn to 5.9.0-1.26326.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
+* Update Roslyn to 5.9.0-1.26326.7 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Relax rules for completion of `fixed` keyword (PR: [#84133](https://github.com/dotnet/roslyn/pull/84133))
+  * Unsafe evolution: extend compat mode to legacy callers (PR: [#83660](https://github.com/dotnet/roslyn/pull/83660))
+  * Stop propagating union type information as soon as output value is explicitly narrowed to a specific type (PR: [#84248](https://github.com/dotnet/roslyn/pull/84248))
+  * Update RuntimeAsync error message (PR: [#84263](https://github.com/dotnet/roslyn/pull/84263))
+  * [labeled break/continue] Analyzer + fixer to prefer labeled break/continue over goto/flag workarounds (PR: [#84170](https://github.com/dotnet/roslyn/pull/84170))
+  * Add warning to 'make async Task' fixer regarding delegate return type change (PR: [#84142](https://github.com/dotnet/roslyn/pull/84142))
+  * Adjust decision Dag reachability based on nullable analysis when reporting unhandled `null` values in a switch expression (PR: [#84207](https://github.com/dotnet/roslyn/pull/84207))
+  * [labeled break/continue] Resolve label even when the target loop/switch is missing (experimental) (PR: [#83503](https://github.com/dotnet/roslyn/pull/83503))
+  * Use real MethodImplAttributes/Options when available (PR: [#84218](https://github.com/dotnet/roslyn/pull/84218))
+  * Treat more recoverable pipe failures as non-fatal (PR: [#84076](https://github.com/dotnet/roslyn/pull/84076))
+  * Extension indexers: validate basic IDE support (PR: [#84175](https://github.com/dotnet/roslyn/pull/84175))
+  * [labeled break/continue] Quick Info (PR: [#83203](https://github.com/dotnet/roslyn/pull/83203))
+  * [labeled break/continue] Find References and document highlight (PR: [#83202](https://github.com/dotnet/roslyn/pull/83202))
+  * [labeled break/continue] Keyword highlighting (PR: [#83201](https://github.com/dotnet/roslyn/pull/83201))
+  * [labeled break/continue] Go to Definition (PR: [#83200](https://github.com/dotnet/roslyn/pull/83200))
+  * [labeled break/continue] Completion of enclosing labels (PR: [#83199](https://github.com/dotnet/roslyn/pull/83199))
+  * [labeled break/continue] Binding, lowering, emit, and semantic model (PR: [#83198](https://github.com/dotnet/roslyn/pull/83198))
+  * Add syntax and parsing support for labeled break/continue (PR: [#83197](https://github.com/dotnet/roslyn/pull/83197))
 
 # 2.145.x
 * Update Roslyn to 5.9.0-1.26319.6 (PR: [#9457](https://github.com/dotnet/vscode-csharp/pull/9457))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
-* Update Roslyn to 5.9.0-1.26326.7 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.9.0-1.26326.7 (PR: [#9480](https://github.com/dotnet/vscode-csharp/pull/9480))
   * Relax rules for completion of `fixed` keyword (PR: [#84133](https://github.com/dotnet/roslyn/pull/84133))
   * Unsafe evolution: extend compat mode to legacy callers (PR: [#83660](https://github.com/dotnet/roslyn/pull/83660))
   * Stop propagating union type information as soon as output value is explicitly narrowed to a specific type (PR: [#84248](https://github.com/dotnet/roslyn/pull/84248))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,7 @@
 # 2.151.x
 * Update Roslyn to 5.9.0-1.26326.7 (PR: [#9480](https://github.com/dotnet/vscode-csharp/pull/9480))
   * Relax rules for completion of `fixed` keyword (PR: [#84133](https://github.com/dotnet/roslyn/pull/84133))
-  * Unsafe evolution: extend compat mode to legacy callers (PR: [#83660](https://github.com/dotnet/roslyn/pull/83660))
-  * Stop propagating union type information as soon as output value is explicitly narrowed to a specific type (PR: [#84248](https://github.com/dotnet/roslyn/pull/84248))
-  * Update RuntimeAsync error message (PR: [#84263](https://github.com/dotnet/roslyn/pull/84263))
-  * [labeled break/continue] Analyzer + fixer to prefer labeled break/continue over goto/flag workarounds (PR: [#84170](https://github.com/dotnet/roslyn/pull/84170))
-  * Add warning to 'make async Task' fixer regarding delegate return type change (PR: [#84142](https://github.com/dotnet/roslyn/pull/84142))
-  * Adjust decision Dag reachability based on nullable analysis when reporting unhandled `null` values in a switch expression (PR: [#84207](https://github.com/dotnet/roslyn/pull/84207))
-  * [labeled break/continue] Resolve label even when the target loop/switch is missing (experimental) (PR: [#83503](https://github.com/dotnet/roslyn/pull/83503))
-  * Use real MethodImplAttributes/Options when available (PR: [#84218](https://github.com/dotnet/roslyn/pull/84218))
   * Treat more recoverable pipe failures as non-fatal (PR: [#84076](https://github.com/dotnet/roslyn/pull/84076))
-  * Extension indexers: validate basic IDE support (PR: [#84175](https://github.com/dotnet/roslyn/pull/84175))
-  * [labeled break/continue] Quick Info (PR: [#83203](https://github.com/dotnet/roslyn/pull/83203))
-  * [labeled break/continue] Find References and document highlight (PR: [#83202](https://github.com/dotnet/roslyn/pull/83202))
-  * [labeled break/continue] Keyword highlighting (PR: [#83201](https://github.com/dotnet/roslyn/pull/83201))
-  * [labeled break/continue] Go to Definition (PR: [#83200](https://github.com/dotnet/roslyn/pull/83200))
-  * [labeled break/continue] Completion of enclosing labels (PR: [#83199](https://github.com/dotnet/roslyn/pull/83199))
-  * [labeled break/continue] Binding, lowering, emit, and semantic model (PR: [#83198](https://github.com/dotnet/roslyn/pull/83198))
-  * Add syntax and parsing support for labeled break/continue (PR: [#83197](https://github.com/dotnet/roslyn/pull/83197))
 
 # 2.145.x
 * Update Roslyn to 5.9.0-1.26319.6 (PR: [#9457](https://github.com/dotnet/vscode-csharp/pull/9457))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.9.0-1.26319.6",
+    "roslyn": "5.9.0-1.26326.7",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.9.11921.35"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/db649bc3ca504bd1236a119d1cd86c7f8050e95b...411469b8cd5e1ac891644ef6e3bf5cc8fa7943cc?w=1)
* Track status for feature "Extension constants" (PR: [#84270](https://github.com/dotnet/roslyn/pull/84270))
* Clean up HasReferenceAsDelegateInThisProjectAsync: remove redundant partial checks, simplify to single FAR call (PR: [#84288](https://github.com/dotnet/roslyn/pull/84288))
* Relax rules for completion of `fixed` keyword (PR: [#84133](https://github.com/dotnet/roslyn/pull/84133))
* Delete the .editorconfig designer (PR: [#84272](https://github.com/dotnet/roslyn/pull/84272))
* Stabilize TypeScript simplifier options test by removing unnecessary LSP server initialization (PR: [#84092](https://github.com/dotnet/roslyn/pull/84092))
* Unsafe evolution: extend compat mode to legacy callers (PR: [#83660](https://github.com/dotnet/roslyn/pull/83660))
* Merge labeled break/continue feature into .NET 11 preview 6 (PR: [#84281](https://github.com/dotnet/roslyn/pull/84281))
* Change dupe "Bat" to intended "Bar" (PR: [#84289](https://github.com/dotnet/roslyn/pull/84289))
* Stop propagating union type information as soon as output value is explicitly narrowed to a specific type (PR: [#84248](https://github.com/dotnet/roslyn/pull/84248))
* Update RuntimeAsync error message (PR: [#84263](https://github.com/dotnet/roslyn/pull/84263))
* Merge "labeled break and continue" feature into `main` branch (PR: [#84271](https://github.com/dotnet/roslyn/pull/84271))
* [labeled break/continue] Analyzer + fixer to prefer labeled break/continue over goto/flag workarounds (PR: [#84170](https://github.com/dotnet/roslyn/pull/84170))
* Adjust tests (PR: [#84265](https://github.com/dotnet/roslyn/pull/84265))
* Move everything besides buildhost to net10 (PR: [#84192](https://github.com/dotnet/roslyn/pull/84192))
* Collect crash dumps on hang (PR: [#84227](https://github.com/dotnet/roslyn/pull/84227))
* Add warning to 'make async Task' fixer regarding delegate return type change (PR: [#84142](https://github.com/dotnet/roslyn/pull/84142))
* Optimize todo-check.ps1 and have it check for merge markers (PR: [#84204](https://github.com/dotnet/roslyn/pull/84204))
* Extension indexers: record feature as merged (PR: [#84211](https://github.com/dotnet/roslyn/pull/84211))
* Adjust decision Dag reachability based on nullable analysis when reporting unhandled `null` values in a switch expression (PR: [#84207](https://github.com/dotnet/roslyn/pull/84207))
* [labeled break/continue] Resolve label even when the target loop/switch is missing (experimental) (PR: [#83503](https://github.com/dotnet/roslyn/pull/83503))
* Use SQLite3MC (PR: [#84140](https://github.com/dotnet/roslyn/pull/84140))
* Pool validation: add more tracking (PR: [#83799](https://github.com/dotnet/roslyn/pull/83799))
* Remove DOTNET_HOST_PATH workaround (PR: [#84245](https://github.com/dotnet/roslyn/pull/84245))
* Fix duplicate xUnit test case ID in TestBlockScopedNamespaces (PR: [#84237](https://github.com/dotnet/roslyn/pull/84237))
* Use real MethodImplAttributes/Options when available (PR: [#84218](https://github.com/dotnet/roslyn/pull/84218))
* Exclude all root `.md` files from integration CI (PR: [#84242](https://github.com/dotnet/roslyn/pull/84242))
* Add AGENTS guidance to avoid manual edits in eng/common (PR: [#84241](https://github.com/dotnet/roslyn/pull/84241))
* Treat more recoverable pipe failures as non-fatal (PR: [#84076](https://github.com/dotnet/roslyn/pull/84076))
* Track runtime-async-streams feature (PR: [#84229](https://github.com/dotnet/roslyn/pull/84229))
* Remove obsolete CS1998 suppressions (PR: [#84216](https://github.com/dotnet/roslyn/pull/84216))
* [labeled break/continue] CFG tests across switches and try/using regions (PR: [#84231](https://github.com/dotnet/roslyn/pull/84231))
* Move require_api_files to global config to fix RS0016 on benchmark projects (PR: [#84236](https://github.com/dotnet/roslyn/pull/84236))
* Adjust example output in incremental-generators.md (PR: [#82320](https://github.com/dotnet/roslyn/pull/82320))
* [labeled break/continue] NormalizeWhitespace and IL-vs-goto tests (PR: [#84228](https://github.com/dotnet/roslyn/pull/84228))
* Instruct AI to wait for tests to complete (PR: [#84234](https://github.com/dotnet/roslyn/pull/84234))
* De-dupe and clarify `WorkItem` attribute requirements in agent instructions (PR: [#84017](https://github.com/dotnet/roslyn/pull/84017))
* [labeled break/continue] Add labeled break/continue to the Compiler Test Plan (PR: [#84233](https://github.com/dotnet/roslyn/pull/84233))
* Clarify that we only skip zero-width tokens by default (PR: [#84196](https://github.com/dotnet/roslyn/pull/84196))
* Extension indexers: Add test suggestions from test plan review (PR: [#84210](https://github.com/dotnet/roslyn/pull/84210))
* Update reviewer list for Dictionary expressions feature (PR: [#83994](https://github.com/dotnet/roslyn/pull/83994))
* Extension indexers: validate basic IDE support (PR: [#84175](https://github.com/dotnet/roslyn/pull/84175))
* [labeled break/continue] Additional compiler test coverage; update debug-only NullableWalker verifier (PR: [#84186](https://github.com/dotnet/roslyn/pull/84186))
* [labeled break/continue] Baseline formatting tests for labeled iteration_statement (PR: [#83499](https://github.com/dotnet/roslyn/pull/83499))
* [labeled break/continue] Grabbag validation tests (PR: [#83204](https://github.com/dotnet/roslyn/pull/83204))
* [labeled break/continue] Quick Info (PR: [#83203](https://github.com/dotnet/roslyn/pull/83203))
* [labeled break/continue] Find References and document highlight (PR: [#83202](https://github.com/dotnet/roslyn/pull/83202))
* [labeled break/continue] Keyword highlighting (PR: [#83201](https://github.com/dotnet/roslyn/pull/83201))
* [labeled break/continue] Go to Definition (PR: [#83200](https://github.com/dotnet/roslyn/pull/83200))
* [labeled break/continue] Completion of enclosing labels (PR: [#83199](https://github.com/dotnet/roslyn/pull/83199))
* [labeled break/continue] Binding, lowering, emit, and semantic model (PR: [#83198](https://github.com/dotnet/roslyn/pull/83198))
* Add syntax and parsing support for labeled break/continue (PR: [#83197](https://github.com/dotnet/roslyn/pull/83197))
