### PR TITLE
Update roslyn to 5.10.0-1.26330.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
-* Update Roslyn to 5.10.0-1.26330.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.10.0-1.26330.4 (PR: [#9485](https://github.com/dotnet/vscode-csharp/pull/9485))
   * Filter false CSS024 diagnostics from Html (PR: [#84320](https://github.com/dotnet/roslyn/pull/84320))
   * Ignore Razor comment edits from the Html formatter (PR: [#84318](https://github.com/dotnet/roslyn/pull/84318))
 * Update Roslyn to 5.9.0-1.26326.7 (PR: [#9480](https://github.com/dotnet/vscode-csharp/pull/9480))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
+* Update Roslyn to 5.10.0-1.26330.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Filter false CSS024 diagnostics from Html (PR: [#84320](https://github.com/dotnet/roslyn/pull/84320))
+  * Ignore Razor comment edits from the Html formatter (PR: [#84318](https://github.com/dotnet/roslyn/pull/84318))
 * Update Roslyn to 5.9.0-1.26326.7 (PR: [#9480](https://github.com/dotnet/vscode-csharp/pull/9480))
   * Relax rules for completion of `fixed` keyword (PR: [#84133](https://github.com/dotnet/roslyn/pull/84133))
   * Treat more recoverable pipe failures as non-fatal (PR: [#84076](https://github.com/dotnet/roslyn/pull/84076))

--- a/azure-pipelines/build-vsix.yml
+++ b/azure-pipelines/build-vsix.yml
@@ -63,11 +63,6 @@ stages:
         versionNumberOverride: ${{ parameters.versionNumberOverride }}
         installDotNet: true
 
-    - task: UsePythonVersion@0
-      displayName: 'Use Python 3.11'
-      inputs:
-        versionSpec: 3.11
-
     # Non-windows signing requires .NET 8 installed on the machine.
     - task: UseDotNet@2
       displayName: Use .NET Core sdk 8.0.x

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.9.0-1.26326.7",
+    "roslyn": "5.10.0-1.26330.4",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.9.11921.35"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/411469b8cd5e1ac891644ef6e3bf5cc8fa7943cc...afda3793450ccff3207ab1a396cc8441ab3d24a4?w=1)
* Update VSSDK to 18.9.496-Preview (PR: [#84262](https://github.com/dotnet/roslyn/pull/84262))
* Remove unused ID field from `SyntaxAnnotation`. (PR: [#84295](https://github.com/dotnet/roslyn/pull/84295))
* Bump main to 18.10 (5.10.0) after 18.9 snap (PR: [#84329](https://github.com/dotnet/roslyn/pull/84329))
* Filter false CSS024 diagnostics from Html (PR: [#84320](https://github.com/dotnet/roslyn/pull/84320))
* Ignore Razor comment edits from the Html formatter (PR: [#84318](https://github.com/dotnet/roslyn/pull/84318))

