### PR TITLE
Update Azure Pipelines Node installer task

### DIFF
--- a/azure-pipelines/install-node.yml
+++ b/azure-pipelines/install-node.yml
@@ -1,5 +1,5 @@
 steps:
-- task: NodeTool@0
+- task: UseNode@1
   displayName: 'Install Node.js 24.x'
   inputs:
-    versionSpec: '24.x'
+    version: '24.x'


### PR DESCRIPTION
The Azure Pipelines NodeTool@0 task is deprecated and emits warnings even when builds pass. This updates to a non-deprecated task for the same functionality.