### PR TITLE
Opt container startup into Node 24

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,8 @@ schedules:
         - main
 
 variables:
+- name: AZP_AGENT_USE_NODE24_TO_START_CONTAINER
+  value: 'true'
 - name: testVSCodeVersion
   ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
     value: insiders


### PR DESCRIPTION
Some jobs still use Node 20, which is EOL. This PR opts the CI pipeline into the agent's Node 24 container startup path so Linux container test jobs no longer emit the Node 20 startup warning.