### PR TITLE
Update roslyn to 5.10.0-1.26352.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
-* Update Roslyn to 5.10.0-1.26352.10 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))
   * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
   * Unsafe evolution: avoid errors inside nameof (PR: [#84325](https://github.com/dotnet/roslyn/pull/84325))
   * Respect object initializer severity for fade diagnostics (PR: [#84324](https://github.com/dotnet/roslyn/pull/84324))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@
 # 2.151.x
 * Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))
   * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
-  * Unsafe evolution: avoid errors inside nameof (PR: [#84325](https://github.com/dotnet/roslyn/pull/84325))
-  * Respect object initializer severity for fade diagnostics (PR: [#84324](https://github.com/dotnet/roslyn/pull/84324))
-  * Handle instrumented conditions in post-lowering passes (PR: [#84244](https://github.com/dotnet/roslyn/pull/84244))
-  * Dispose builders in declaration computer (PR: [#84339](https://github.com/dotnet/roslyn/pull/84339))
   * Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))
-  * Guard Razor semantic token spans (PR: [#84334](https://github.com/dotnet/roslyn/pull/84334))
-  * Don't assume a Razor buffer is non-null, until we know it's ours (PR: [#84337](https://github.com/dotnet/roslyn/pull/84337))
 * Update Roslyn to 5.10.0-1.26330.4 (PR: [#9485](https://github.com/dotnet/vscode-csharp/pull/9485))
   * Filter false CSS024 diagnostics from Html (PR: [#84320](https://github.com/dotnet/roslyn/pull/84320))
   * Ignore Razor comment edits from the Html formatter (PR: [#84318](https://github.com/dotnet/roslyn/pull/84318))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
+* Update Roslyn to 5.10.0-1.26352.10 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
+  * Unsafe evolution: avoid errors inside nameof (PR: [#84325](https://github.com/dotnet/roslyn/pull/84325))
+  * Respect object initializer severity for fade diagnostics (PR: [#84324](https://github.com/dotnet/roslyn/pull/84324))
+  * Handle instrumented conditions in post-lowering passes (PR: [#84244](https://github.com/dotnet/roslyn/pull/84244))
+  * Dispose builders in declaration computer (PR: [#84339](https://github.com/dotnet/roslyn/pull/84339))
+  * Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))
+  * Guard Razor semantic token spans (PR: [#84334](https://github.com/dotnet/roslyn/pull/84334))
+  * Don't assume a Razor buffer is non-null, until we know it's ours (PR: [#84337](https://github.com/dotnet/roslyn/pull/84337))
 * Update Roslyn to 5.10.0-1.26330.4 (PR: [#9485](https://github.com/dotnet/vscode-csharp/pull/9485))
   * Filter false CSS024 diagnostics from Html (PR: [#84320](https://github.com/dotnet/roslyn/pull/84320))
   * Ignore Razor comment edits from the Html formatter (PR: [#84318](https://github.com/dotnet/roslyn/pull/84318))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.10.0-1.26330.4",
+    "roslyn": "5.10.0-1.26352.10",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.9.11921.35"


### PR DESCRIPTION
OOF for a few days so putting this up early.

[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/afda3793450ccff3207ab1a396cc8441ab3d24a4...83ca1a6465bb861e28a51cdbb4b56074b69cb5eb?w=1)
* Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
* [EE] Enable `using static` for non-static classes in CSharp EE (PR: [#84042](https://github.com/dotnet/roslyn/pull/84042))
* Update code review skill to push model to not repeat same feedback if previously resolved (PR: [#84348](https://github.com/dotnet/roslyn/pull/84348))
* Remove dead DotNet-VSTS-Infra-Access variable group reference (PR: [#84382](https://github.com/dotnet/roslyn/pull/84382))
* Revert "Update VSSDK to 18.9.496-Preview" (PR: [#84363](https://github.com/dotnet/roslyn/pull/84363))
* Unsafe evolution: avoid errors inside nameof (PR: [#84325](https://github.com/dotnet/roslyn/pull/84325))
* Clarify code review guidance for revert PRs (PR: [#84366](https://github.com/dotnet/roslyn/pull/84366))
* Respect object initializer severity for fade diagnostics (PR: [#84324](https://github.com/dotnet/roslyn/pull/84324))
* Restructure agent knowledge base for context-efficient loading (PR: [#84308](https://github.com/dotnet/roslyn/pull/84308))
* Handle instrumented conditions in post-lowering passes (PR: [#84244](https://github.com/dotnet/roslyn/pull/84244))
* Dispose builders in declaration computer (PR: [#84339](https://github.com/dotnet/roslyn/pull/84339))
* Collect Razor formatting logs during VS feedback recording (PR: [#84303](https://github.com/dotnet/roslyn/pull/84303))
* Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))
* Guard Razor semantic token spans (PR: [#84334](https://github.com/dotnet/roslyn/pull/84334))
* Don't assume a Razor buffer is non-null, until we know it's ours (PR: [#84337](https://github.com/dotnet/roslyn/pull/84337))
* doc(IncrementalGenerators): the square example is wrong, that's only a multiplication by a factor 2 (PR: [#84340](https://github.com/dotnet/roslyn/pull/84340))

