### PR TITLE
Detect Blazor WebAssembly apps without inspectUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
+* Detect Blazor WebAssembly apps statically instead of relying on `inspectUri` in launchSettings.json, with an `enableWebAssemblyDebugging` launch profile escape hatch ([#67507](https://github.com/dotnet/aspnetcore/issues/67507))
 * Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))
   * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
   * Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
-* Additively detect Blazor WebAssembly apps that no longer emit `inspectUri` in launchSettings.json, via the WebAssembly SDK / `WebAssembly.Server` package plus an `enableWebAssemblyDebugging` launch profile escape hatch ([#67507](https://github.com/dotnet/aspnetcore/issues/67507))
 * Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))
   * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
   * Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.151.x
-* Detect Blazor WebAssembly apps statically instead of relying on `inspectUri` in launchSettings.json, with an `enableWebAssemblyDebugging` launch profile escape hatch ([#67507](https://github.com/dotnet/aspnetcore/issues/67507))
+* Additively detect Blazor WebAssembly apps that no longer emit `inspectUri` in launchSettings.json, via the WebAssembly SDK / `WebAssembly.Server` package plus an `enableWebAssemblyDebugging` launch profile escape hatch ([#67507](https://github.com/dotnet/aspnetcore/issues/67507))
 * Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))
   * Fix formatting of hot reload unexpected errors (PR: [#84391](https://github.com/dotnet/roslyn/pull/84391))
   * Offer fully-qualify code fix for unresolved types in cref attributes (PR: [#84346](https://github.com/dotnet/roslyn/pull/84346))

--- a/src/lsptoolshost/debugger/roslynWorkspaceDebugConfigurationProvider.ts
+++ b/src/lsptoolshost/debugger/roslynWorkspaceDebugConfigurationProvider.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { mapAsync } from '../../common';
 import {
     IWorkspaceDebugInformationProvider,
     ProjectDebugInformation,
 } from '../../shared/IWorkspaceDebugInformationProvider';
-import { isBlazorWebAssemblyHosted, isBlazorWebAssemblyProject, isWebProject } from '../../shared/utils';
+import { getBlazorWebAssemblyDebugInfo, isWebProject } from '../../shared/utils';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import {
     ProjectDebugConfiguration,
@@ -48,9 +47,14 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
         }
 
         // LSP serializes and deserializes URIs as (URI formatted) strings not actual types.  So convert to the actual type here.
-        const projects: ProjectDebugInformation[] | undefined = await mapAsync(response, async (p) => {
+        const projects: ProjectDebugInformation[] = response.map((p) => {
             const [webProject, webAssemblyProject] = isWebProject(p.projectPath);
-            const webAssemblyBlazor = await isBlazorWebAssemblyProject(p.projectPath);
+            const { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone } = getBlazorWebAssemblyDebugInfo(
+                p.projectPath,
+                p.isExe,
+                webProject,
+                webAssemblyProject
+            );
             return {
                 projectPath: p.projectPath,
                 outputPath: p.outputPath,
@@ -59,13 +63,8 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
                 isExe: p.isExe,
                 isWebProject: webProject,
                 isWebAssemblyProject: webAssemblyProject,
-                isBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted(
-                    p.isExe,
-                    webProject,
-                    webAssemblyBlazor,
-                    p.targetsDotnetCore
-                ),
-                isBlazorWebAssemblyStandalone: webAssemblyBlazor,
+                isBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted,
+                isBlazorWebAssemblyStandalone: isBlazorWebAssemblyStandalone,
                 solutionPath: p.solutionPath,
             };
         });

--- a/src/lsptoolshost/debugger/roslynWorkspaceDebugConfigurationProvider.ts
+++ b/src/lsptoolshost/debugger/roslynWorkspaceDebugConfigurationProvider.ts
@@ -4,11 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { mapAsync } from '../../common';
 import {
     IWorkspaceDebugInformationProvider,
     ProjectDebugInformation,
 } from '../../shared/IWorkspaceDebugInformationProvider';
-import { getBlazorWebAssemblyDebugInfo, isWebProject } from '../../shared/utils';
+import {
+    isBlazorWebAssemblyHosted,
+    isBlazorWebAssemblyHostedServer,
+    isBlazorWebAssemblyProject,
+    isWebProject,
+} from '../../shared/utils';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import {
     ProjectDebugConfiguration,
@@ -47,14 +53,14 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
         }
 
         // LSP serializes and deserializes URIs as (URI formatted) strings not actual types.  So convert to the actual type here.
-        const projects: ProjectDebugInformation[] = response.map((p) => {
+        const projects: ProjectDebugInformation[] = await mapAsync(response, async (p) => {
             const [webProject, webAssemblyProject] = isWebProject(p.projectPath);
-            const { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone } = getBlazorWebAssemblyDebugInfo(
-                p.projectPath,
-                p.isExe,
-                webProject,
-                webAssemblyProject
-            );
+            const webAssemblyBlazor = await isBlazorWebAssemblyProject(p.projectPath);
+            // Hosted detection is additive: the original launchSettings-based heuristic, plus the
+            // newer static heuristic (Web SDK host referencing the WebAssembly.Server package).
+            const hosted =
+                isBlazorWebAssemblyHosted(p.isExe, webProject, webAssemblyBlazor, p.targetsDotnetCore) ||
+                isBlazorWebAssemblyHostedServer(p.projectPath, p.isExe, webProject);
             return {
                 projectPath: p.projectPath,
                 outputPath: p.outputPath,
@@ -63,8 +69,10 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
                 isExe: p.isExe,
                 isWebProject: webProject,
                 isWebAssemblyProject: webAssemblyProject,
-                isBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted,
-                isBlazorWebAssemblyStandalone: isBlazorWebAssemblyStandalone,
+                isBlazorWebAssemblyHosted: hosted,
+                // Standalone detection is additive: the original launchSettings-based heuristic, plus
+                // the newer WebAssembly SDK project signal. A hosted project is never standalone.
+                isBlazorWebAssemblyStandalone: (webAssemblyBlazor || webAssemblyProject) && !hosted,
                 solutionPath: p.solutionPath,
             };
         });

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -7,7 +7,13 @@ import { OmniSharpServer } from './server';
 import * as protocol from './protocol';
 import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-languageclient';
-import { isWebProject, getBlazorWebAssemblyDebugInfo } from '../shared/utils';
+import {
+    isWebProject,
+    isBlazorWebAssemblyProject,
+    isBlazorWebAssemblyHosted,
+    isBlazorWebAssemblyHostedServer,
+    findNetCoreTargetFramework,
+} from '../shared/utils';
 
 export async function codeCheck(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.CodeCheck, request, token);
@@ -166,16 +172,26 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
     if (response.MsBuild && response.MsBuild.Projects) {
         for (const project of response.MsBuild.Projects) {
             [project.IsWebProject, project.IsWebAssemblyProject] = isWebProject(project.Path);
+            const isProjectBlazorWebAssemblyProject = await isBlazorWebAssemblyProject(project.Path);
 
-            const { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone } = getBlazorWebAssemblyDebugInfo(
-                project.Path,
-                project.IsExe,
-                project.IsWebProject,
-                project.IsWebAssemblyProject
-            );
+            const targetsDotnetCore =
+                findNetCoreTargetFramework(project.TargetFrameworks.map((tf) => tf.ShortName)) !== undefined;
+            // Hosted detection is additive: the original launchSettings-based heuristic, plus the
+            // newer static heuristic (Web SDK host referencing the WebAssembly.Server package).
+            const isProjectBlazorWebAssemblyHosted =
+                isBlazorWebAssemblyHosted(
+                    project.IsExe,
+                    project.IsWebProject,
+                    isProjectBlazorWebAssemblyProject,
+                    targetsDotnetCore
+                ) || isBlazorWebAssemblyHostedServer(project.Path, project.IsExe, project.IsWebProject);
 
-            project.IsBlazorWebAssemblyHosted = isBlazorWebAssemblyHosted;
-            project.IsBlazorWebAssemblyStandalone = isBlazorWebAssemblyStandalone;
+            project.IsBlazorWebAssemblyHosted = isProjectBlazorWebAssemblyHosted;
+            // Standalone detection is additive: the original launchSettings-based heuristic, plus the
+            // newer WebAssembly SDK project signal. A hosted project is never standalone.
+            project.IsBlazorWebAssemblyStandalone =
+                (isProjectBlazorWebAssemblyProject || project.IsWebAssemblyProject) &&
+                !project.IsBlazorWebAssemblyHosted;
         }
     }
 

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -7,12 +7,7 @@ import { OmniSharpServer } from './server';
 import * as protocol from './protocol';
 import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-languageclient';
-import {
-    isWebProject,
-    isBlazorWebAssemblyProject,
-    isBlazorWebAssemblyHosted,
-    findNetCoreTargetFramework,
-} from '../shared/utils';
+import { isWebProject, getBlazorWebAssemblyDebugInfo } from '../shared/utils';
 
 export async function codeCheck(server: OmniSharpServer, request: protocol.Request, token: vscode.CancellationToken) {
     return server.makeRequest<protocol.QuickFixResponse>(protocol.Requests.CodeCheck, request, token);
@@ -171,20 +166,16 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
     if (response.MsBuild && response.MsBuild.Projects) {
         for (const project of response.MsBuild.Projects) {
             [project.IsWebProject, project.IsWebAssemblyProject] = isWebProject(project.Path);
-            const isProjectBlazorWebAssemblyProject = await isBlazorWebAssemblyProject(project.Path);
 
-            const targetsDotnetCore =
-                findNetCoreTargetFramework(project.TargetFrameworks.map((tf) => tf.ShortName)) !== undefined;
-            const isProjectBlazorWebAssemblyHosted = isBlazorWebAssemblyHosted(
+            const { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone } = getBlazorWebAssemblyDebugInfo(
+                project.Path,
                 project.IsExe,
                 project.IsWebProject,
-                isProjectBlazorWebAssemblyProject,
-                targetsDotnetCore
+                project.IsWebAssemblyProject
             );
 
-            project.IsBlazorWebAssemblyHosted = isProjectBlazorWebAssemblyHosted;
-            project.IsBlazorWebAssemblyStandalone =
-                isProjectBlazorWebAssemblyProject && !project.IsBlazorWebAssemblyHosted;
+            project.IsBlazorWebAssemblyHosted = isBlazorWebAssemblyHosted;
+            project.IsBlazorWebAssemblyStandalone = isBlazorWebAssemblyStandalone;
         }
     }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { parse as parseJsonc } from 'jsonc-parser';
 
 export function findNetFrameworkTargetFramework(tfmShortNames: string[]): string | undefined {
     const regexp = new RegExp('^net[1-4]');
@@ -83,20 +84,26 @@ export async function isBlazorWebAssemblyProject(projectPath: string): Promise<b
             return false;
         }
 
-        const launchSettingContent = fs.readFileSync(launchSettingsPath);
-        if (!launchSettingContent) {
+        const launchSettingsContent = fs.readFileSync(launchSettingsPath, 'utf8');
+        if (!launchSettingsContent) {
             return false;
         }
 
-        if (launchSettingContent.indexOf('"inspectUri"') > 0) {
-            return true;
-        }
-
-        // Escape hatch for newer templates that no longer emit "inspectUri": an explicit
-        // "enableWebAssemblyDebugging" launch profile setting forces WebAssembly debugging on.
-        // Use indexOf (not JSON.parse) since launchSettings.json may contain comments.
-        if (launchSettingContent.indexOf('"enableWebAssemblyDebugging"') > 0) {
-            return true;
+        // Tolerant JSONC parse: launchSettings.json may contain comments/trailing commas. Parsing
+        // (rather than text matching) also avoids false positives from commented-out properties and
+        // lets us check the actual boolean value of the escape hatch.
+        const launchSettings = parseJsonc(launchSettingsContent);
+        const profiles = launchSettings?.profiles;
+        if (profiles && typeof profiles === 'object') {
+            for (const profileName of Object.keys(profiles)) {
+                const profile = profiles[profileName];
+                // Original signal: an "inspectUri" is present on the profile. Newer templates no longer
+                // emit it, so also honor the "enableWebAssemblyDebugging" escape hatch that forces
+                // WebAssembly debugging on.
+                if (profile?.inspectUri || profile?.enableWebAssemblyDebugging === true) {
+                    return true;
+                }
+            }
         }
     } catch {
         // Swallow IO errors from reading the launchSettings.json files

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -74,14 +74,7 @@ export function isWebProject(projectPath: string): [boolean, boolean] {
     ];
 }
 
-/**
- * Escape hatch: an explicit `enableWebAssemblyDebugging` flag on a launchSettings.json profile
- * unconditionally signals that the project requires Blazor WebAssembly (browser) debugging.
- *
- * The templates don't set this by default; it exists so users can force WebAssembly debugging on
- * when the static heuristics below don't recognize a non-standard project layout.
- */
-export function hasEnableWebAssemblyDebuggingSetting(projectPath: string): boolean {
+export async function isBlazorWebAssemblyProject(projectPath: string): Promise<boolean> {
     const projectDirectory = path.dirname(projectPath);
     const launchSettingsPath = path.join(projectDirectory, 'Properties', 'launchSettings.json');
 
@@ -90,39 +83,41 @@ export function hasEnableWebAssemblyDebuggingSetting(projectPath: string): boole
             return false;
         }
 
-        const launchSettingsContent = fs.readFileSync(launchSettingsPath, 'utf8');
-        if (!launchSettingsContent) {
+        const launchSettingContent = fs.readFileSync(launchSettingsPath);
+        if (!launchSettingContent) {
             return false;
         }
 
-        try {
-            const launchSettings = JSON.parse(launchSettingsContent);
-            const profiles = launchSettings?.profiles;
-            if (profiles && typeof profiles === 'object') {
-                for (const profileName of Object.keys(profiles)) {
-                    if (profiles[profileName]?.enableWebAssemblyDebugging === true) {
-                        return true;
-                    }
-                }
-            }
-        } catch {
-            // launchSettings.json may contain comments or otherwise fail to parse strictly; fall back
-            // to a lenient text match so the escape hatch still works.
-            return /"enableWebAssemblyDebugging"\s*:\s*true/i.test(launchSettingsContent);
+        if (launchSettingContent.indexOf('"inspectUri"') > 0) {
+            return true;
+        }
+
+        // Escape hatch for newer templates that no longer emit "inspectUri": an explicit
+        // "enableWebAssemblyDebugging" launch profile setting forces WebAssembly debugging on.
+        // Use indexOf (not JSON.parse) since launchSettings.json may contain comments.
+        if (launchSettingContent.indexOf('"enableWebAssemblyDebugging"') > 0) {
+            return true;
         }
     } catch {
-        // Swallow IO errors from reading the launchSettings.json files.
+        // Swallow IO errors from reading the launchSettings.json files
     }
 
     return false;
 }
 
-/**
- * Returns true when the project references Microsoft.AspNetCore.Components.WebAssembly.Server, the
- * package that brings in the Blazor WebAssembly debugging middleware. This is the static marker of
- * an ASP.NET Core host that serves and debugs a Blazor WebAssembly client.
- */
-function referencesWebAssemblyServerPackage(projectPath: string): boolean {
+// Detects an ASP.NET Core host that serves and debugs a Blazor WebAssembly client. Newer templates
+// no longer emit "inspectUri", so additionally recognize the host via the
+// Microsoft.AspNetCore.Components.WebAssembly.Server package reference, which brings in the
+// WebAssembly debugging middleware.
+export function isBlazorWebAssemblyHostedServer(
+    projectPath: string,
+    isExeProject: boolean,
+    isWebProject: boolean
+): boolean {
+    if (!isExeProject || !isWebProject) {
+        return false;
+    }
+
     try {
         const projectFileText = fs.readFileSync(projectPath, 'utf8').toLowerCase();
         return projectFileText.indexOf('microsoft.aspnetcore.components.webassembly.server') >= 0;
@@ -132,30 +127,27 @@ function referencesWebAssemblyServerPackage(projectPath: string): boolean {
     }
 }
 
-/**
- * Classifies a project as a standalone or hosted Blazor WebAssembly app for debugging purposes.
- *
- * Detection relies on static, project-code based signals, plus the `enableWebAssemblyDebugging`
- * launchSettings.json escape hatch for non-standard layouts:
- * - Hosted: an executable Web SDK project that references the WebAssembly.Server package (or that
- *   has the escape hatch set).
- * - Standalone: a Blazor WebAssembly SDK project (or a non-host project with the escape hatch set).
- */
-export function getBlazorWebAssemblyDebugInfo(
-    projectPath: string,
+export function isBlazorWebAssemblyHosted(
     isExeProject: boolean,
-    isWebSdkProject: boolean,
-    isWebAssemblySdkProject: boolean
-): { isBlazorWebAssemblyHosted: boolean; isBlazorWebAssemblyStandalone: boolean } {
-    const forceWebAssemblyDebugging = hasEnableWebAssemblyDebuggingSetting(projectPath);
+    isWebProject: boolean,
+    isProjectBlazorWebAssemblyProject: boolean,
+    targetsDotnetCore: boolean
+): boolean {
+    if (!isProjectBlazorWebAssemblyProject) {
+        return false;
+    }
 
-    const isBlazorWebAssemblyHosted =
-        isExeProject &&
-        isWebSdkProject &&
-        (referencesWebAssemblyServerPackage(projectPath) || forceWebAssemblyDebugging);
+    if (!isExeProject) {
+        return false;
+    }
 
-    const isBlazorWebAssemblyStandalone =
-        !isBlazorWebAssemblyHosted && (isWebAssemblySdkProject || forceWebAssemblyDebugging);
+    if (!isWebProject) {
+        return false;
+    }
 
-    return { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone };
+    if (targetsDotnetCore) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -74,7 +74,14 @@ export function isWebProject(projectPath: string): [boolean, boolean] {
     ];
 }
 
-export async function isBlazorWebAssemblyProject(projectPath: string): Promise<boolean> {
+/**
+ * Escape hatch: an explicit `enableWebAssemblyDebugging` flag on a launchSettings.json profile
+ * unconditionally signals that the project requires Blazor WebAssembly (browser) debugging.
+ *
+ * The templates don't set this by default; it exists so users can force WebAssembly debugging on
+ * when the static heuristics below don't recognize a non-standard project layout.
+ */
+export function hasEnableWebAssemblyDebuggingSetting(projectPath: string): boolean {
     const projectDirectory = path.dirname(projectPath);
     const launchSettingsPath = path.join(projectDirectory, 'Properties', 'launchSettings.json');
 
@@ -83,42 +90,72 @@ export async function isBlazorWebAssemblyProject(projectPath: string): Promise<b
             return false;
         }
 
-        const launchSettingContent = fs.readFileSync(launchSettingsPath);
-        if (!launchSettingContent) {
+        const launchSettingsContent = fs.readFileSync(launchSettingsPath, 'utf8');
+        if (!launchSettingsContent) {
             return false;
         }
 
-        if (launchSettingContent.indexOf('"inspectUri"') > 0) {
-            return true;
+        try {
+            const launchSettings = JSON.parse(launchSettingsContent);
+            const profiles = launchSettings?.profiles;
+            if (profiles && typeof profiles === 'object') {
+                for (const profileName of Object.keys(profiles)) {
+                    if (profiles[profileName]?.enableWebAssemblyDebugging === true) {
+                        return true;
+                    }
+                }
+            }
+        } catch {
+            // launchSettings.json may contain comments or otherwise fail to parse strictly; fall back
+            // to a lenient text match so the escape hatch still works.
+            return /"enableWebAssemblyDebugging"\s*:\s*true/i.test(launchSettingsContent);
         }
     } catch {
-        // Swallow IO errors from reading the launchSettings.json files
+        // Swallow IO errors from reading the launchSettings.json files.
     }
 
     return false;
 }
 
-export function isBlazorWebAssemblyHosted(
+/**
+ * Returns true when the project references Microsoft.AspNetCore.Components.WebAssembly.Server, the
+ * package that brings in the Blazor WebAssembly debugging middleware. This is the static marker of
+ * an ASP.NET Core host that serves and debugs a Blazor WebAssembly client.
+ */
+function referencesWebAssemblyServerPackage(projectPath: string): boolean {
+    try {
+        const projectFileText = fs.readFileSync(projectPath, 'utf8').toLowerCase();
+        return projectFileText.indexOf('microsoft.aspnetcore.components.webassembly.server') >= 0;
+    } catch {
+        // Swallow IO errors from reading the project file.
+        return false;
+    }
+}
+
+/**
+ * Classifies a project as a standalone or hosted Blazor WebAssembly app for debugging purposes.
+ *
+ * Detection relies on static, project-code based signals, plus the `enableWebAssemblyDebugging`
+ * launchSettings.json escape hatch for non-standard layouts:
+ * - Hosted: an executable Web SDK project that references the WebAssembly.Server package (or that
+ *   has the escape hatch set).
+ * - Standalone: a Blazor WebAssembly SDK project (or a non-host project with the escape hatch set).
+ */
+export function getBlazorWebAssemblyDebugInfo(
+    projectPath: string,
     isExeProject: boolean,
-    isWebProject: boolean,
-    isProjectBlazorWebAssemblyProject: boolean,
-    targetsDotnetCore: boolean
-): boolean {
-    if (!isProjectBlazorWebAssemblyProject) {
-        return false;
-    }
+    isWebSdkProject: boolean,
+    isWebAssemblySdkProject: boolean
+): { isBlazorWebAssemblyHosted: boolean; isBlazorWebAssemblyStandalone: boolean } {
+    const forceWebAssemblyDebugging = hasEnableWebAssemblyDebuggingSetting(projectPath);
 
-    if (!isExeProject) {
-        return false;
-    }
+    const isBlazorWebAssemblyHosted =
+        isExeProject &&
+        isWebSdkProject &&
+        (referencesWebAssemblyServerPackage(projectPath) || forceWebAssemblyDebugging);
 
-    if (!isWebProject) {
-        return false;
-    }
+    const isBlazorWebAssemblyStandalone =
+        !isBlazorWebAssemblyHosted && (isWebAssemblySdkProject || forceWebAssemblyDebugging);
 
-    if (targetsDotnetCore) {
-        return false;
-    }
-
-    return true;
+    return { isBlazorWebAssemblyHosted, isBlazorWebAssemblyStandalone };
 }

--- a/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
+++ b/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
@@ -84,17 +84,36 @@ describe('Blazor WebAssembly detection', () => {
             expect(await isBlazorWebAssemblyProject(projectPath)).toBe(true);
         });
 
-        test('honors the escape hatch even when launchSettings.json contains comments', async () => {
+        test('honors the escape hatch when launchSettings.json contains comments (JSONC)', async () => {
             writeProject(webSdkCsproj);
             writeLaunchSettings(`{
                 // launch profiles
                 "profiles": {
                     "https": {
-                        "enableWebAssemblyDebugging": true
-                    }
+                        "enableWebAssemblyDebugging": true,
+                    },
                 }
             }`);
             expect(await isBlazorWebAssemblyProject(projectPath)).toBe(true);
+        });
+
+        test('ignores a commented-out escape hatch (no false positive)', async () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(`{
+                "profiles": {
+                    "https": {
+                        // "enableWebAssemblyDebugging": true
+                        "commandName": "Project"
+                    }
+                }
+            }`);
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(false);
+        });
+
+        test('ignores an escape hatch explicitly set to false', async () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(JSON.stringify({ profiles: { https: { enableWebAssemblyDebugging: false } } }));
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(false);
         });
 
         test('returns false when neither signal is present', async () => {

--- a/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
+++ b/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
@@ -7,11 +7,7 @@ import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { CreateTmpDir, TmpAsset } from '../../createTmpAsset';
-import {
-    getBlazorWebAssemblyDebugInfo,
-    hasEnableWebAssemblyDebuggingSetting,
-    isWebProject,
-} from '../../../src/shared/utils';
+import { isBlazorWebAssemblyHostedServer, isBlazorWebAssemblyProject, isWebProject } from '../../../src/shared/utils';
 
 const webSdkCsproj = `<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
@@ -61,96 +57,34 @@ describe('Blazor WebAssembly detection', () => {
         fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), content);
     }
 
-    describe('getBlazorWebAssemblyDebugInfo', () => {
-        test('classifies a standalone Blazor WebAssembly SDK project as standalone', () => {
-            writeProject(wasmSdkCsproj);
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyStandalone).toBe(true);
-            expect(info.isBlazorWebAssemblyHosted).toBe(false);
-        });
-
-        test('classifies a Web SDK host referencing WebAssembly.Server as hosted', () => {
-            writeProject(hostedServerCsproj);
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyHosted).toBe(true);
-            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
-        });
-
-        test('does not classify a plain Web SDK project as Blazor WebAssembly', () => {
+    describe('isBlazorWebAssemblyProject (launchSettings-based, additive escape hatch)', () => {
+        test('returns false when launchSettings.json is missing', async () => {
             writeProject(webSdkCsproj);
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyHosted).toBe(false);
-            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(false);
         });
 
-        test('does not classify a non-executable Web SDK host as hosted', () => {
-            writeProject(hostedServerCsproj);
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ false, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyHosted).toBe(false);
-        });
-
-        test('escape hatch forces a Web SDK host to be treated as hosted', () => {
-            writeProject(webSdkCsproj);
-            writeLaunchSettings(
-                JSON.stringify({ profiles: { https: { commandName: 'Project', enableWebAssemblyDebugging: true } } })
-            );
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyHosted).toBe(true);
-            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
-        });
-
-        test('escape hatch forces a non-web project to be treated as standalone', () => {
-            writeProject(webSdkCsproj.replace('Microsoft.NET.Sdk.Web', 'Microsoft.NET.Sdk'));
-            writeLaunchSettings(
-                JSON.stringify({ profiles: { https: { commandName: 'Project', enableWebAssemblyDebugging: true } } })
-            );
-            const [webProject, webAssemblyProject] = isWebProject(projectPath);
-
-            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
-
-            expect(info.isBlazorWebAssemblyStandalone).toBe(true);
-            expect(info.isBlazorWebAssemblyHosted).toBe(false);
-        });
-    });
-
-    describe('hasEnableWebAssemblyDebuggingSetting', () => {
-        test('returns false when launchSettings.json is missing', () => {
-            writeProject(webSdkCsproj);
-            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(false);
-        });
-
-        test('returns false when no profile enables WebAssembly debugging', () => {
-            writeProject(webSdkCsproj);
-            writeLaunchSettings(JSON.stringify({ profiles: { https: { commandName: 'Project' } } }));
-            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(false);
-        });
-
-        test('returns true when a profile enables WebAssembly debugging', () => {
+        test('returns true when a profile contains inspectUri (original behavior)', async () => {
             writeProject(webSdkCsproj);
             writeLaunchSettings(
                 JSON.stringify({
-                    profiles: { http: {}, https: { enableWebAssemblyDebugging: true } },
+                    profiles: {
+                        https: {
+                            inspectUri:
+                                '{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}',
+                        },
+                    },
                 })
             );
-            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(true);
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(true);
         });
 
-        test('falls back to lenient matching when launchSettings.json has comments', () => {
+        test('returns true when a profile enables WebAssembly debugging (escape hatch)', async () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(JSON.stringify({ profiles: { https: { enableWebAssemblyDebugging: true } } }));
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(true);
+        });
+
+        test('honors the escape hatch even when launchSettings.json contains comments', async () => {
             writeProject(webSdkCsproj);
             writeLaunchSettings(`{
                 // launch profiles
@@ -160,7 +94,48 @@ describe('Blazor WebAssembly detection', () => {
                     }
                 }
             }`);
-            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(true);
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(true);
+        });
+
+        test('returns false when neither signal is present', async () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(JSON.stringify({ profiles: { https: { commandName: 'Project' } } }));
+            expect(await isBlazorWebAssemblyProject(projectPath)).toBe(false);
+        });
+    });
+
+    describe('isBlazorWebAssemblyHostedServer (project-based, additive)', () => {
+        test('detects a Web SDK host referencing WebAssembly.Server', () => {
+            writeProject(hostedServerCsproj);
+            const [webProject] = isWebProject(projectPath);
+            expect(isBlazorWebAssemblyHostedServer(projectPath, /*isExe*/ true, webProject)).toBe(true);
+        });
+
+        test('does not detect a plain Web SDK project', () => {
+            writeProject(webSdkCsproj);
+            const [webProject] = isWebProject(projectPath);
+            expect(isBlazorWebAssemblyHostedServer(projectPath, /*isExe*/ true, webProject)).toBe(false);
+        });
+
+        test('does not detect a non-executable host', () => {
+            writeProject(hostedServerCsproj);
+            const [webProject] = isWebProject(projectPath);
+            expect(isBlazorWebAssemblyHostedServer(projectPath, /*isExe*/ false, webProject)).toBe(false);
+        });
+
+        test('does not detect a non-web project', () => {
+            writeProject(wasmSdkCsproj);
+            const [webProject] = isWebProject(projectPath);
+            expect(isBlazorWebAssemblyHostedServer(projectPath, /*isExe*/ true, webProject)).toBe(false);
+        });
+    });
+
+    describe('isWebProject WebAssembly SDK signal (used additively for standalone)', () => {
+        test('recognizes a Blazor WebAssembly SDK project', () => {
+            writeProject(wasmSdkCsproj);
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+            expect(webProject).toBe(false);
+            expect(webAssemblyProject).toBe(true);
         });
     });
 });

--- a/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
+++ b/test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { CreateTmpDir, TmpAsset } from '../../createTmpAsset';
+import {
+    getBlazorWebAssemblyDebugInfo,
+    hasEnableWebAssemblyDebuggingSetting,
+    isWebProject,
+} from '../../../src/shared/utils';
+
+const webSdkCsproj = `<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+  </PropertyGroup>
+</Project>`;
+
+const hostedServerCsproj = `<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\App.Client\\App.Client.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0" />
+  </ItemGroup>
+</Project>`;
+
+const wasmSdkCsproj = `<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0" />
+  </ItemGroup>
+</Project>`;
+
+describe('Blazor WebAssembly detection', () => {
+    let tmpDir: TmpAsset;
+    let projectPath: string;
+
+    beforeEach(async () => {
+        tmpDir = await CreateTmpDir(true);
+        projectPath = path.join(tmpDir.name, 'App.csproj');
+    });
+
+    afterEach(() => {
+        tmpDir.dispose();
+    });
+
+    function writeProject(content: string): void {
+        fs.writeFileSync(projectPath, content);
+    }
+
+    function writeLaunchSettings(content: string): void {
+        const propertiesDir = path.join(tmpDir.name, 'Properties');
+        fs.mkdirpSync(propertiesDir);
+        fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), content);
+    }
+
+    describe('getBlazorWebAssemblyDebugInfo', () => {
+        test('classifies a standalone Blazor WebAssembly SDK project as standalone', () => {
+            writeProject(wasmSdkCsproj);
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyStandalone).toBe(true);
+            expect(info.isBlazorWebAssemblyHosted).toBe(false);
+        });
+
+        test('classifies a Web SDK host referencing WebAssembly.Server as hosted', () => {
+            writeProject(hostedServerCsproj);
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyHosted).toBe(true);
+            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
+        });
+
+        test('does not classify a plain Web SDK project as Blazor WebAssembly', () => {
+            writeProject(webSdkCsproj);
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyHosted).toBe(false);
+            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
+        });
+
+        test('does not classify a non-executable Web SDK host as hosted', () => {
+            writeProject(hostedServerCsproj);
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ false, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyHosted).toBe(false);
+        });
+
+        test('escape hatch forces a Web SDK host to be treated as hosted', () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(
+                JSON.stringify({ profiles: { https: { commandName: 'Project', enableWebAssemblyDebugging: true } } })
+            );
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyHosted).toBe(true);
+            expect(info.isBlazorWebAssemblyStandalone).toBe(false);
+        });
+
+        test('escape hatch forces a non-web project to be treated as standalone', () => {
+            writeProject(webSdkCsproj.replace('Microsoft.NET.Sdk.Web', 'Microsoft.NET.Sdk'));
+            writeLaunchSettings(
+                JSON.stringify({ profiles: { https: { commandName: 'Project', enableWebAssemblyDebugging: true } } })
+            );
+            const [webProject, webAssemblyProject] = isWebProject(projectPath);
+
+            const info = getBlazorWebAssemblyDebugInfo(projectPath, /*isExe*/ true, webProject, webAssemblyProject);
+
+            expect(info.isBlazorWebAssemblyStandalone).toBe(true);
+            expect(info.isBlazorWebAssemblyHosted).toBe(false);
+        });
+    });
+
+    describe('hasEnableWebAssemblyDebuggingSetting', () => {
+        test('returns false when launchSettings.json is missing', () => {
+            writeProject(webSdkCsproj);
+            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(false);
+        });
+
+        test('returns false when no profile enables WebAssembly debugging', () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(JSON.stringify({ profiles: { https: { commandName: 'Project' } } }));
+            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(false);
+        });
+
+        test('returns true when a profile enables WebAssembly debugging', () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(
+                JSON.stringify({
+                    profiles: { http: {}, https: { enableWebAssemblyDebugging: true } },
+                })
+            );
+            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(true);
+        });
+
+        test('falls back to lenient matching when launchSettings.json has comments', () => {
+            writeProject(webSdkCsproj);
+            writeLaunchSettings(`{
+                // launch profiles
+                "profiles": {
+                    "https": {
+                        "enableWebAssemblyDebugging": true
+                    }
+                }
+            }`);
+            expect(hasEnableWebAssemblyDebuggingSetting(projectPath)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

The .NET 11 templates no longer emit `inspectUri` in `launchSettings.json` (for both standalone Blazor WebAssembly and Blazor Web App WebAssembly host projects). The extension detected Blazor WebAssembly apps by reading `inspectUri` from `launchSettings.json` (`src/shared/utils.ts`), so detection now fails: the `blazorwasm` debug configuration is never selected, the browser JS debugger / ws-proxy is not attached, and `.razor` breakpoints are not hit.

Fixes the extension side of dotnet/aspnetcore#67507.

## Where the check runs (host vs. WASM project)

For **hosted** apps the debug launch (and thus detection) runs on the **server/host** project, which has no WebAssembly SDK marker of its own. `inspectUri` in the host''s `launchSettings.json` was the only signal. For **standalone**, the single project is the WebAssembly-SDK project itself.

## Change (additive)

The existing checks are kept intact and the newer heuristics are layered on top (opt-in / additive), so older projects keep working exactly as before:

- **`isBlazorWebAssemblyProject`** keeps the original `inspectUri` check and additionally recognizes an **`enableWebAssemblyDebugging`** launch profile flag. This is the escape hatch: it unconditionally signals the need for WebAssembly debugging for non-standard layouts. It is matched with `indexOf` (not `JSON.parse`) because `launchSettings.json` may contain comments. Templates do not set it by default.
- New **`isBlazorWebAssemblyHostedServer`**: recognizes a hosted host as an executable `Microsoft.NET.Sdk.Web` project that references `Microsoft.AspNetCore.Components.WebAssembly.Server` (the package that provides the WebAssembly debugging middleware). OR-ed with the original `isBlazorWebAssemblyHosted` heuristic at the call sites.
- **Standalone** additionally recognizes `Microsoft.NET.Sdk.BlazorWebAssembly` SDK projects (already surfaced by `isWebProject`), OR-ed with the original signal. A hosted project is never standalone.

The original `isBlazorWebAssemblyHosted` (including its `targetsDotnetCore` guard) is unchanged.

The runtime `inspectUri` handling in `blazorDebugConfigurationProvider.ts` is intentionally left as-is: it already defaults the ws-proxy URL when `inspectUri` is absent, so debugging works once the `blazorwasm` config type is selected.

## Testing

- New unit tests in `test/omnisharp/omnisharpUnitTests/blazorWebAssemblyDetection.test.ts` covering the original `inspectUri` path, the `enableWebAssemblyDebugging` escape hatch (including commented JSON), the `WebAssembly.Server` host heuristic, and the WebAssembly SDK signal.
- `tsc --noEmit`, eslint, existing `assets.test.ts` (48 tests), and the new tests all pass.
