### PR TITLE
Update roslyn to 5.10.0-1.26359.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.147.x
+* Update Roslyn to 5.10.0-1.26359.5 (PR: [#9519](https://github.com/dotnet/vscode-csharp/pull/9519))
+  * Fix Razor Find All References displaying lines inconsistently when directives span Razor/C# mapping boundaries (PR: [#84353](https://github.com/dotnet/roslyn/pull/84353))
+  * Fix Razor parsing for adjacent comment delimiters in code blocks (PR: [#84277](https://github.com/dotnet/roslyn/pull/84277))
+  * Ignore Razor comments in component attributes (PR: [#84276](https://github.com/dotnet/roslyn/pull/84276))
+  * Fix protocol version of ManagedHotReloadService descriptor used in DevKit (PR: [#84454](https://github.com/dotnet/roslyn/pull/84454))
+  * Enable import completion for types in cref doc comments (PR: [#84440](https://github.com/dotnet/roslyn/pull/84440))
+  * Parse markup inside switch expression lambda arms (PR: [#84425](https://github.com/dotnet/roslyn/pull/84425))
+  * Change the default for test.includeSourceGeneratedFilesInRealTimeDiscovery (PR: [#84452](https://github.com/dotnet/roslyn/pull/84452))
+  * Respect inherited AttributeUsage in attribute completion filtering (PR: [#84426](https://github.com/dotnet/roslyn/pull/84426))
+  * [LSP] Add progress when loading solution and progress (PR: [#84399](https://github.com/dotnet/roslyn/pull/84399))
 
 # 2.146.x
 * Update Roslyn to 5.10.0-1.26352.10 (PR: [#9500](https://github.com/dotnet/vscode-csharp/pull/9500))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.10.0-1.26352.10",
+    "roslyn": "5.10.0-1.26359.5",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.9.11921.35"


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/83ca1a6465bb861e28a51cdbb4b56074b69cb5eb...4d24fd6cc1bd247579fc2cf42442b03004ecc7bd?w=1)
* Remove obsolete CloudEnvironmentConnected_guid cloud-environment detection (PR: [#84354](https://github.com/dotnet/roslyn/pull/84354))
* Fix Razor Find All References displaying lines inconsistently when directives span Razor/C# mapping boundaries (PR: [#84353](https://github.com/dotnet/roslyn/pull/84353))
* Fix Razor parsing for adjacent comment delimiters in code blocks (PR: [#84277](https://github.com/dotnet/roslyn/pull/84277))
* Ignore Razor comments in component attributes (PR: [#84276](https://github.com/dotnet/roslyn/pull/84276))
* Fix protocol version of ManagedHotReloadService descriptor used in DevKit (PR: [#84454](https://github.com/dotnet/roslyn/pull/84454))
* Enable import completion for types in cref doc comments (PR: [#84440](https://github.com/dotnet/roslyn/pull/84440))
* Parse markup inside switch expression lambda arms (PR: [#84425](https://github.com/dotnet/roslyn/pull/84425))
* Change the default for test.includeSourceGeneratedFilesInRealTimeDiscovery (PR: [#84452](https://github.com/dotnet/roslyn/pull/84452))
* Revert "Revert "Update VSSDK to 18.9.496-Preview"" (PR: [#84403](https://github.com/dotnet/roslyn/pull/84403))
* Respect inherited AttributeUsage in attribute completion filtering (PR: [#84426](https://github.com/dotnet/roslyn/pull/84426))
* Revert "Remove unnecessary NuGetAuthenticate for public azure-public feeds" (PR: [#84446](https://github.com/dotnet/roslyn/pull/84446))
* Remove unnecessary NuGetAuthenticate for public azure-public feeds (PR: [#84427](https://github.com/dotnet/roslyn/pull/84427))
* Consolidate ExternalAccess libraries (PR: [#81593](https://github.com/dotnet/roslyn/pull/81593))
* Migrate devdiv/dotnet-core-internal-tooling to WIF service connection (PR: [#84414](https://github.com/dotnet/roslyn/pull/84414))
* Set EnableProjectLevelAnalysis in all constructors of HotReloadService (PR: [#84404](https://github.com/dotnet/roslyn/pull/84404))
* Set IsClosedTypeAttribute.DerivedTypes (PR: [#84350](https://github.com/dotnet/roslyn/pull/84350))
* validate-sdk: use preview package feed when restoring the test app (PR: [#84410](https://github.com/dotnet/roslyn/pull/84410))
* [LSP] Add progress when loading solution and progress (PR: [#84399](https://github.com/dotnet/roslyn/pull/84399))
* update main to be non-draft (PR: [#84405](https://github.com/dotnet/roslyn/pull/84405))
* Use the shared KnownMonikers.Sparkle for the On-The-Fly Docs Copilot icon (PR: [#84401](https://github.com/dotnet/roslyn/pull/84401))