### PR TITLE
Update Debugger and MonowebAssemblyBridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -426,7 +426,7 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-win7-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
@@ -436,12 +436,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
-      "integrity": "5043FA5790848CA925B0412ABA0BD8BF0C6DE1D66CAD203FD0CCC64C755C9D52"
+      "integrity": "BFB2C7AFCF07D9B2158861F753025E00104F1DCBA466EE2890B228CF2C665D95"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-win10-arm64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-win10-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
@@ -450,12 +450,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
-      "integrity": "BB0F3E33238521101B723B2C8DAEA66426913B8CC6B9DE39B92C611D6EBF67CC"
+      "integrity": "1B947657EE3F335B6C2CC749C13A3D613192569A0DC494878655A2582194C4C2"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-osx-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "darwin"
@@ -469,12 +469,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui",
-      "integrity": "FBFBDD59116845894731BCA59ED88EFDA391F495FA489F5FD8E60AD796AD250C"
+      "integrity": "F191F31DB355805AC8652751717391320CA8D1E314D38439D31393BD12A51BB5"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / arm64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-osx-arm64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-osx-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "darwin"
@@ -487,12 +487,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui",
-      "integrity": "7D146354B9E86CD4EE9FE9E609BC0BC3D2F11F85B5C3F444EE6E9C07C48EAFFE"
+      "integrity": "BF933293B572B82B3912CB56055C8961858B1F220110F9A3B3633CD69A0074EF"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-linux-arm.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-linux-arm.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -505,12 +505,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "883742C1A41976B29322D26E4BDBC9AD950321E7866BC1B18D6053831AF0A06F"
+      "integrity": "9F357EBA4BD0EAA3F3AF5FF99B6C840B252C9F850FA6C0D0F0599A8352DFB2AD"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-linux-arm64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-linux-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -523,12 +523,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "7C3A6C702688A326A0E6AEB9D649B230A69049C583B677F9C415BDD8F972583A"
+      "integrity": "19D5DE263909C03F4D4422E9AEA56F91475CF31FF7F342544E7333AFD4F5076F"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-linux-musl-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-linux-musl-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -541,12 +541,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "1F43DEEF83C428D9ECC8FCF72F6BAF00CE7DF379944F500F4074DC0DAB1F2F78"
+      "integrity": "C9BA94FC4323827ABAD63E659FDDB32A7F91500EB080C07D35DA9CCE22072E46"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-linux-musl-arm64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-linux-musl-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -559,12 +559,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "259E76A41CBBCDBD705FEF4890090145A4AB26DBFCEAA0D0552F018C5DFB6ECC"
+      "integrity": "D7A8FDCF600E51E14BFB540200E74959148D5708973A053F2A3CF7790B1C75A0"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-141-1/coreclr-debug-linux-x64.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/41afcf17-a7cd-4e7a-87d3-1559a2f1b9a1/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -577,7 +577,7 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "55595A399AD5D7B04815DC694E3F1F1F835B673529F72593650BEDF127E751C4"
+      "integrity": "3CA508D05379DC4D0412EB543598E559D6ED0CF338F9C261ADF716A17496DFCC"
     },
     {
       "id": "RazorOmnisharp",
@@ -696,7 +696,7 @@
     {
       "id": "VSWebAssemblyBridge",
       "description": "VSWebAssemblyBridge (Platform Agnostic)",
-      "url": "https://vsdebugger.blob.core.windows.net/vswebassemblybridge-9-0-705702/vswebassemblybridge.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/7c7c246e-d1c9-4ff5-b951-1ac7801eb55f/vswebassemblybridge.zip",
       "installPath": ".vswebassemblybridge",
       "platforms": [
         "win32",
@@ -708,7 +708,7 @@
         "x86_64",
         "arm64"
       ],
-      "integrity": "9FDBDC91E2D79028A8932C1A96D3ABCFC7F40472FBC8F226E3FB1F6A1B5C97E7"
+      "integrity": "F319130CF57E7E1233532895EC3105FC9FD8952CEFA36215DE3B68E50248A697"
     }
   ],
   "engines": {

--- a/src/tools/updatePackageDependencies.ts
+++ b/src/tools/updatePackageDependencies.ts
@@ -23,7 +23,7 @@ interface PackageJSONFile {
 const dottedVersionRegExp = /[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*/g;
 const dashedVersionRegExp = /[0-9]+-[0-9]+-[0-9]+/g;
 
-// The 'id's of the runtime dependencies published through ESRP. These are updated by GUID rather than by version.
+// The IDs of the runtime dependencies published through ESRP. These are updated by GUID rather than by version.
 const esrpPackageIds = ['Debugger', 'VSWebAssemblyBridge'];
 
 function readPackageJson(): PackageJSONFile {
@@ -53,7 +53,7 @@ function createDownloadAndGetHash(): (url: string) => Promise<string> {
         }
     });
     const networkSettingsProvider: NetworkSettingsProvider = () =>
-        new NetworkSettings(/*proxy:*/ '', /*stringSSL:*/ true);
+        new NetworkSettings(/*proxy:*/ '', /*strictSSL:*/ true);
 
     return async (url: string): Promise<string> => {
         console.log(`Downloading from '${url}'`);

--- a/src/tools/updatePackageDependencies.ts
+++ b/src/tools/updatePackageDependencies.ts
@@ -23,38 +23,15 @@ interface PackageJSONFile {
 const dottedVersionRegExp = /[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*/g;
 const dashedVersionRegExp = /[0-9]+-[0-9]+-[0-9]+/g;
 
+// The 'id's of the runtime dependencies published through ESRP. These are updated by GUID rather than by version.
+const esrpPackageIds = ['Debugger', 'VSWebAssemblyBridge'];
+
 export async function updatePackageDependencies(): Promise<void> {
     const newPrimaryUrls = process.env['NEW_DEPS_URLS'];
     const newVersion = process.env['NEW_DEPS_VERSION'];
     const oldVersion = process.env['OLD_DEPS_VERSION'] ?? ''; // Optional: Will fallback to trying to replace version with a regex.
     const packageId = process.env['NEW_DEPS_ID'];
-
-    if ((!packageId && !newPrimaryUrls) || !newVersion) {
-        console.log();
-        console.log("'npm run gulp updatePackageDependencies' will update package.json with new URLs of dependencies.");
-        console.log();
-        console.log('To use:');
-        const setEnvVarPrefix = os.platform() === 'win32' ? 'set ' : 'export ';
-        const setEnvVarQuote = os.platform() === 'win32' ? '' : "'";
-        console.log(
-            `  ${setEnvVarPrefix}NEW_DEPS_URLS=${setEnvVarQuote}https://example1/foo-osx.zip,https://example1/foo-win.zip,https://example1/foo-linux.zip${setEnvVarQuote}`
-        );
-        console.log('-or-');
-        console.log(`  ${setEnvVarPrefix}NEW_DEPS_ID=${setEnvVarQuote}Debugger${setEnvVarQuote}`);
-        console.log('-and-');
-        console.log(`  ${setEnvVarPrefix}NEW_DEPS_VERSION=${setEnvVarQuote}1.2.3${setEnvVarQuote}`);
-        console.log('  npm run gulp updatePackageDependencies');
-        console.log();
-        return;
-    }
-
-    if (!/^[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*$/.test(newVersion)) {
-        throw new Error("Unexpected 'NEW_DEPS_VERSION' value. Expected format similar to: 1.2.3.");
-    }
-
-    if (oldVersion.length > 0 && !/^[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*$/.test(oldVersion)) {
-        throw new Error("Unexpected 'OLD_DEPS_VERSION' value. Expected format similar to: 1.2.2.");
-    }
+    const newEsrpGuid = process.env['NEW_DEPS_ESRP_GUID'];
 
     const packageJSON: PackageJSONFile = JSON.parse(fs.readFileSync('package.json').toString());
 
@@ -74,6 +51,112 @@ export async function updatePackageDependencies(): Promise<void> {
         const buffer: Buffer = await DownloadFile(url, eventStream, networkSettingsProvider, url);
         return getBufferIntegrityHash(buffer);
     };
+
+    const writePackageJson = (): void => {
+        let content = JSON.stringify(packageJSON, null, 2);
+        if (os.platform() === 'win32') {
+            content = content.replace(/\n/gm, '\r\n');
+        }
+
+        // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
+        // convert that from the readable espace sequence, to just an invisible character. Convert it back to the visible espace sequence.
+        content = content.replace(/\u200b/gm, '\\u200b');
+
+        fs.writeFileSync('package.json', content);
+    };
+
+    // The debugger and VSWebAssemblyBridge are published through ESRP, which assigns each release a GUID rather than a
+    // version number. When a GUID is provided we rewrite the matching package URLs to point at the new ESRP download
+    // rather than replacing a version substring. This flow is only supported for the ESRP-published packages.
+    if (newEsrpGuid) {
+        if (!packageId || !esrpPackageIds.includes(packageId)) {
+            throw new Error(
+                `'NEW_DEPS_ESRP_GUID' is only supported for ${esrpPackageIds.join(
+                    ', '
+                )}. Set 'NEW_DEPS_ID' to one of these.`
+            );
+        }
+
+        if (newVersion || oldVersion) {
+            throw new Error(
+                "'NEW_DEPS_VERSION' and 'OLD_DEPS_VERSION' are not supported when 'NEW_DEPS_ESRP_GUID' is used."
+            );
+        }
+
+        if (!/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(newEsrpGuid)) {
+            throw new Error(
+                "Unexpected 'NEW_DEPS_ESRP_GUID' value. Expected a GUID similar to: 00000000-0000-0000-0000-000000000000."
+            );
+        }
+
+        let packageFound = false;
+        for (const dependency of packageJSON.runtimeDependencies) {
+            if (dependency.id !== packageId) {
+                continue;
+            }
+            packageFound = true;
+
+            dependency.url = replaceEsrpGuid(dependency.url, newEsrpGuid);
+            dependency.integrity = await downloadAndGetHash(dependency.url);
+
+            if (dependency.fallbackUrl) {
+                dependency.fallbackUrl = replaceEsrpGuid(dependency.fallbackUrl, newEsrpGuid);
+                const fallbackUrlIntegrity = await downloadAndGetHash(dependency.fallbackUrl);
+                if (dependency.integrity !== fallbackUrlIntegrity) {
+                    throw new Error(
+                        `File downloaded from primary URL '${dependency.url}' doesn't match '${dependency.fallbackUrl}'.`
+                    );
+                }
+            }
+        }
+
+        if (!packageFound) {
+            throw new Error(`Failed to find package with 'id' of '${packageId}'.`);
+        }
+
+        writePackageJson();
+        return;
+    }
+
+    // The ESRP-published packages must be updated by GUID, not by version.
+    if (packageId && esrpPackageIds.includes(packageId)) {
+        throw new Error(
+            `'${packageId}' is published through ESRP and must be updated with 'NEW_DEPS_ESRP_GUID' rather than 'NEW_DEPS_VERSION'.`
+        );
+    }
+
+    if ((!packageId && !newPrimaryUrls) || !newVersion) {
+        console.log();
+        console.log("'npm run gulp updatePackageDependencies' will update package.json with new URLs of dependencies.");
+        console.log();
+        console.log('To use:');
+        const setEnvVarPrefix = os.platform() === 'win32' ? 'set ' : 'export ';
+        const setEnvVarQuote = os.platform() === 'win32' ? '' : "'";
+        console.log(
+            `  ${setEnvVarPrefix}NEW_DEPS_URLS=${setEnvVarQuote}https://example1/foo-osx.zip,https://example1/foo-win.zip,https://example1/foo-linux.zip${setEnvVarQuote}`
+        );
+        console.log('-or-');
+        console.log(`  ${setEnvVarPrefix}NEW_DEPS_ID=${setEnvVarQuote}OmniSharp${setEnvVarQuote}`);
+        console.log('-and-');
+        console.log(`  ${setEnvVarPrefix}NEW_DEPS_VERSION=${setEnvVarQuote}1.2.3${setEnvVarQuote}`);
+        console.log(`-or, to update a package published through ESRP (${esrpPackageIds.join(', ')})-`);
+        console.log(`  ${setEnvVarPrefix}NEW_DEPS_ID=${setEnvVarQuote}${esrpPackageIds[0]}${setEnvVarQuote}`);
+        console.log('-and-');
+        console.log(
+            `  ${setEnvVarPrefix}NEW_DEPS_ESRP_GUID=${setEnvVarQuote}00000000-0000-0000-0000-000000000000${setEnvVarQuote}`
+        );
+        console.log('  npm run gulp updatePackageDependencies');
+        console.log();
+        return;
+    }
+
+    if (!/^[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*$/.test(newVersion)) {
+        throw new Error("Unexpected 'NEW_DEPS_VERSION' value. Expected format similar to: 1.2.3.");
+    }
+
+    if (oldVersion.length > 0 && !/^[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*$/.test(oldVersion)) {
+        throw new Error("Unexpected 'OLD_DEPS_VERSION' value. Expected format similar to: 1.2.2.");
+    }
 
     const updateDependency = async (dependency: Package): Promise<void> => {
         dependency.integrity = await downloadAndGetHash(dependency.url);
@@ -179,16 +262,7 @@ export async function updatePackageDependencies(): Promise<void> {
         }
     }
 
-    let content = JSON.stringify(packageJSON, null, 2);
-    if (os.platform() === 'win32') {
-        content = content.replace(/\n/gm, '\r\n');
-    }
-
-    // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
-    // convert that from the readable espace sequence, to just an invisible character. Convert it back to the visible espace sequence.
-    content = content.replace(/\u200b/gm, '\\u200b');
-
-    fs.writeFileSync('package.json', content);
+    writePackageJson();
 }
 
 function replaceVersion(fileName: string, oldVersion: string, newVersion: string): string;
@@ -216,6 +290,11 @@ function replaceVersion(fileName: string | undefined, oldVersion: string, newVer
     }
 
     return fileName.replace(regex, newValue);
+}
+
+function replaceEsrpGuid(url: string, newEsrpGuid: string): string {
+    const fileName = url.substring(url.lastIndexOf('/') + 1);
+    return `https://download.visualstudio.microsoft.com/download/pr/${newEsrpGuid}/${fileName}`;
 }
 
 function verifyVersionSubstringCount(value: string | undefined, shouldContainVersion = false): void {

--- a/src/tools/updatePackageDependencies.ts
+++ b/src/tools/updatePackageDependencies.ts
@@ -26,15 +26,24 @@ const dashedVersionRegExp = /[0-9]+-[0-9]+-[0-9]+/g;
 // The 'id's of the runtime dependencies published through ESRP. These are updated by GUID rather than by version.
 const esrpPackageIds = ['Debugger', 'VSWebAssemblyBridge'];
 
-export async function updatePackageDependencies(): Promise<void> {
-    const newPrimaryUrls = process.env['NEW_DEPS_URLS'];
-    const newVersion = process.env['NEW_DEPS_VERSION'];
-    const oldVersion = process.env['OLD_DEPS_VERSION'] ?? ''; // Optional: Will fallback to trying to replace version with a regex.
-    const packageId = process.env['NEW_DEPS_ID'];
-    const newEsrpGuid = process.env['NEW_DEPS_ESRP_GUID'];
+function readPackageJson(): PackageJSONFile {
+    return JSON.parse(fs.readFileSync('package.json').toString());
+}
 
-    const packageJSON: PackageJSONFile = JSON.parse(fs.readFileSync('package.json').toString());
+function writePackageJson(packageJSON: PackageJSONFile): void {
+    let content = JSON.stringify(packageJSON, null, 2);
+    if (os.platform() === 'win32') {
+        content = content.replace(/\n/gm, '\r\n');
+    }
 
+    // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
+    // convert that from the readable escape sequence, to just an invisible character. Convert it back to the visible escape sequence.
+    content = content.replace(/\u200b/gm, '\\u200b');
+
+    fs.writeFileSync('package.json', content);
+}
+
+function createDownloadAndGetHash(): (url: string) => Promise<string> {
     const eventStream = new EventStream();
     eventStream.subscribe((event: Event.BaseEvent) => {
         switch (event.type) {
@@ -46,24 +55,19 @@ export async function updatePackageDependencies(): Promise<void> {
     const networkSettingsProvider: NetworkSettingsProvider = () =>
         new NetworkSettings(/*proxy:*/ '', /*stringSSL:*/ true);
 
-    const downloadAndGetHash = async (url: string): Promise<string> => {
+    return async (url: string): Promise<string> => {
         console.log(`Downloading from '${url}'`);
         const buffer: Buffer = await DownloadFile(url, eventStream, networkSettingsProvider, url);
         return getBufferIntegrityHash(buffer);
     };
+}
 
-    const writePackageJson = (): void => {
-        let content = JSON.stringify(packageJSON, null, 2);
-        if (os.platform() === 'win32') {
-            content = content.replace(/\n/gm, '\r\n');
-        }
-
-        // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
-        // convert that from the readable espace sequence, to just an invisible character. Convert it back to the visible espace sequence.
-        content = content.replace(/\u200b/gm, '\\u200b');
-
-        fs.writeFileSync('package.json', content);
-    };
+export async function updatePackageDependencies(): Promise<void> {
+    const newPrimaryUrls = process.env['NEW_DEPS_URLS'];
+    const newVersion = process.env['NEW_DEPS_VERSION'];
+    const oldVersion = process.env['OLD_DEPS_VERSION'] ?? ''; // Optional: Will fallback to trying to replace version with a regex.
+    const packageId = process.env['NEW_DEPS_ID'];
+    const newEsrpGuid = process.env['NEW_DEPS_ESRP_GUID'];
 
     // The debugger and VSWebAssemblyBridge are published through ESRP, which assigns each release a GUID rather than a
     // version number. When a GUID is provided we rewrite the matching package URLs to point at the new ESRP download
@@ -88,6 +92,9 @@ export async function updatePackageDependencies(): Promise<void> {
                 "Unexpected 'NEW_DEPS_ESRP_GUID' value. Expected a GUID similar to: 00000000-0000-0000-0000-000000000000."
             );
         }
+
+        const packageJSON = readPackageJson();
+        const downloadAndGetHash = createDownloadAndGetHash();
 
         let packageFound = false;
         for (const dependency of packageJSON.runtimeDependencies) {
@@ -114,7 +121,7 @@ export async function updatePackageDependencies(): Promise<void> {
             throw new Error(`Failed to find package with 'id' of '${packageId}'.`);
         }
 
-        writePackageJson();
+        writePackageJson(packageJSON);
         return;
     }
 
@@ -157,6 +164,9 @@ export async function updatePackageDependencies(): Promise<void> {
     if (oldVersion.length > 0 && !/^[0-9]+\.[0-9]+\.[0-9]+[-a-zA-Z0-9.]*$/.test(oldVersion)) {
         throw new Error("Unexpected 'OLD_DEPS_VERSION' value. Expected format similar to: 1.2.2.");
     }
+
+    const packageJSON = readPackageJson();
+    const downloadAndGetHash = createDownloadAndGetHash();
 
     const updateDependency = async (dependency: Package): Promise<void> => {
         dependency.integrity = await downloadAndGetHash(dependency.url);
@@ -262,7 +272,7 @@ export async function updatePackageDependencies(): Promise<void> {
         }
     }
 
-    writePackageJson();
+    writePackageJson(packageJSON);
 }
 
 function replaceVersion(fileName: string, oldVersion: string, newVersion: string): string;


### PR DESCRIPTION
This PR updates the Debugger and MonowebAssemblyBridge packages and also moves them to use the ESRP urls https://download.visualstudio.microsoft.com/download/pr

Also updating the package update scripts to use the new format.