### PR TITLE
Add one-time feedback survey for Copilot Chat users

### DIFF
--- a/src/lsptoolshost/activate.ts
+++ b/src/lsptoolshost/activate.ts
@@ -79,7 +79,7 @@ export async function activateRoslynLanguageServer(
     registerLanguageStatusItems(context, languageServer, languageServerEvents);
     registerMiscellaneousFileNotifier(context, languageServer);
     registerCopilotContextProviders(context, languageServer, _channel);
-    registerCopilotChatSurvey(context, languageServerEvents, reporter, _channel);
+    registerCopilotChatSurvey(context, languageServer, languageServerEvents, reporter, _channel);
 
     // Register any commands that need to be handled by the extension.
     registerCommands(context, languageServer, hostExecutableResolver, _channel, _traceChannel, reporter);

--- a/src/lsptoolshost/activate.ts
+++ b/src/lsptoolshost/activate.ts
@@ -26,6 +26,7 @@ import { WorkspaceStatus } from './workspace/workspaceStatus';
 import { ProjectContextStatus } from './projectContext/projectContextStatus';
 import { RoslynLanguageServer } from './server/roslynLanguageServer';
 import { registerCopilotContextProviders } from './copilot/contextProviders';
+import { registerCopilotChatSurvey } from './copilot/copilotChatSurvey';
 import { registerRazorEndpoints } from './razor/razorEndpoints';
 import { ObservableLogOutputChannel } from './logging/observableLogOutputChannel';
 import { registerSourceGeneratorRefresh } from './generators/sourceGeneratorsRefresh';
@@ -78,6 +79,7 @@ export async function activateRoslynLanguageServer(
     registerLanguageStatusItems(context, languageServer, languageServerEvents);
     registerMiscellaneousFileNotifier(context, languageServer);
     registerCopilotContextProviders(context, languageServer, _channel);
+    registerCopilotChatSurvey(context, languageServerEvents, reporter, _channel);
 
     // Register any commands that need to be handled by the extension.
     registerCommands(context, languageServer, hostExecutableResolver, _channel, _traceChannel, reporter);

--- a/src/lsptoolshost/copilot/copilotChatSurvey.ts
+++ b/src/lsptoolshost/copilot/copilotChatSurvey.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { LanguageServerEvents, ServerState } from '../server/languageServerEvents';
+import { ITelemetryReporter } from '../../shared/telemetryReporter';
+import { TelemetryEventNames } from '../../shared/telemetryEventNames';
+
+const globalStateKey = 'csharp.copilotChatSurvey';
+
+// Snooze applied after an ignored/closed toast, after which the survey becomes eligible again.
+const ignoredSnoozeMs = 60 * 60 * 1000;
+
+const surveyUrl = 'https://aka.ms/vscode-csharp-dotnetskills-general-survey';
+
+interface SurveyState {
+    // Terminal one-shot: set only on an explicit choice ("Take Survey" / "Not Now").
+    surveyShown: boolean;
+    // ISO timestamp; while in the future the survey is snoozed (suppressed but not retired).
+    snoozedUntil?: string;
+}
+
+/**
+ * Offers a one-time feedback survey to C# extension customers using GitHub Copilot Chat.
+ *
+ * Deferred until project initialization completes so the toast doesn't contend with the burst of
+ * startup notifications. Eligibility is gated on an available Copilot chat model. An ignored/closed
+ * toast is snoozed rather than retired, so only an explicit choice permanently consumes the one-shot.
+ */
+export function registerCopilotChatSurvey(
+    context: vscode.ExtensionContext,
+    languageServerEvents: LanguageServerEvents,
+    reporter: ITelemetryReporter,
+    channel: vscode.LogOutputChannel
+): void {
+    if (getState(context).surveyShown === true) {
+        return;
+    }
+
+    // Registration is gated on an async availability probe; fire-and-forget it.
+    void registerSurveyWhenChatAvailable(context, languageServerEvents, reporter, channel);
+}
+
+async function registerSurveyWhenChatAvailable(
+    context: vscode.ExtensionContext,
+    languageServerEvents: LanguageServerEvents,
+    reporter: ITelemetryReporter,
+    channel: vscode.LogOutputChannel
+): Promise<void> {
+    // Bail before registering anything if the customer can't use Copilot Chat.
+    if (!(await isCopilotChatAvailable())) {
+        return;
+    }
+
+    // ProjectInitializationComplete can fire more than once per session (e.g. solution reload),
+    // so dispose after the first prompt attempt.
+    const disposable = languageServerEvents.onServerStateChange(async (e) => {
+        if (e.state !== ServerState.ProjectInitializationComplete) {
+            return;
+        }
+
+        const state = getState(context);
+        if (state.surveyShown === true) {
+            disposable.dispose();
+            return;
+        }
+        // Snoozed: stay registered so a later initialization can re-surface it once it lapses.
+        if (isSnoozed(state)) {
+            return;
+        }
+
+        disposable.dispose();
+        await showSurveyPrompt(context, reporter, channel);
+    });
+    context.subscriptions.push(disposable);
+}
+
+/**
+ * Whether the user can use Copilot Chat right now: at least one Copilot-vendor model is available
+ * (i.e. Chat is set up and signed in). Returns false (never throws) if the query fails.
+ */
+async function isCopilotChatAvailable(): Promise<boolean> {
+    try {
+        const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+        return models.length > 0;
+    } catch {
+        return false;
+    }
+}
+
+function getState(context: vscode.ExtensionContext): SurveyState {
+    return context.globalState.get<SurveyState>(globalStateKey, { surveyShown: false });
+}
+
+function isSnoozed(state: SurveyState): boolean {
+    if (!state.snoozedUntil) {
+        return false;
+    }
+    const until = Date.parse(state.snoozedUntil);
+    return !Number.isNaN(until) && until > Date.now();
+}
+
+async function snoozeSurvey(context: vscode.ExtensionContext): Promise<void> {
+    // globalState is shared across windows — never downgrade a terminal choice made elsewhere.
+    if (getState(context).surveyShown) {
+        return;
+    }
+    await context.globalState.update(globalStateKey, {
+        surveyShown: false,
+        snoozedUntil: new Date(Date.now() + ignoredSnoozeMs).toISOString(),
+    });
+}
+
+async function showSurveyPrompt(
+    context: vscode.ExtensionContext,
+    reporter: ITelemetryReporter,
+    channel: vscode.LogOutputChannel
+): Promise<void> {
+    const takeAction = vscode.l10n.t('Take Survey');
+    const dismiss = vscode.l10n.t('Not Now');
+    const message = vscode.l10n.t(
+        "You've been using GitHub Copilot Chat with the C# experience. We'd appreciate your feedback!"
+    );
+
+    try {
+        // Count as shown up front: the toast is non-modal and may never be interacted with.
+        reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'shown' });
+
+        const result = await vscode.window.showInformationMessage(message, takeAction, dismiss);
+
+        if (result === takeAction) {
+            // Only retire once the browser actually opened; otherwise snooze so it can resurface.
+            const opened = await vscode.env.openExternal(vscode.Uri.parse(surveyUrl));
+            if (opened) {
+                await context.globalState.update(globalStateKey, { surveyShown: true });
+                reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'accepted' });
+            } else {
+                await snoozeSurvey(context);
+            }
+        } else if (result === dismiss) {
+            await context.globalState.update(globalStateKey, { surveyShown: true });
+            reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'dismissed' });
+        } else {
+            // Ignored or closed without a choice — snooze rather than retire.
+            await snoozeSurvey(context);
+        }
+    } catch (error) {
+        // Only the error type is sent, never user content.
+        channel.error('Failed to show C# Copilot Chat survey prompt', error);
+        reporter.sendTelemetryErrorEvent(TelemetryEventNames.CopilotChatSurveyError, {
+            error: error instanceof Error ? error.name : 'error',
+        });
+    }
+}

--- a/src/lsptoolshost/copilot/copilotChatSurvey.ts
+++ b/src/lsptoolshost/copilot/copilotChatSurvey.ts
@@ -4,23 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import type { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import { LanguageServerEvents, ServerState } from '../server/languageServerEvents';
 import { ITelemetryReporter } from '../../shared/telemetryReporter';
 import { TelemetryEventNames } from '../../shared/telemetryEventNames';
 
-const globalStateKey = 'csharp.copilotChatSurvey';
+// Stored under separate keys so a snooze write can never overwrite a terminal "shown"
+// value set in another window (globalState.update replaces the whole value for a key).
+const shownStateKey = 'csharp.copilotChatSurvey.shown';
+const snoozedUntilStateKey = 'csharp.copilotChatSurvey.snoozedUntil';
 
 // Snooze applied after an ignored/closed toast, after which the survey becomes eligible again.
 const ignoredSnoozeMs = 60 * 60 * 1000;
 
 const surveyUrl = 'https://aka.ms/vscode-csharp-dotnetskills-general-survey';
-
-interface SurveyState {
-    // Terminal one-shot: set only on an explicit choice ("Take Survey" / "Not Now").
-    surveyShown: boolean;
-    // ISO timestamp; while in the future the survey is snoozed (suppressed but not retired).
-    snoozedUntil?: string;
-}
 
 /**
  * Offers a one-time feedback survey to C# extension customers using GitHub Copilot Chat.
@@ -31,54 +28,61 @@ interface SurveyState {
  */
 export function registerCopilotChatSurvey(
     context: vscode.ExtensionContext,
+    languageServer: RoslynLanguageServer,
     languageServerEvents: LanguageServerEvents,
     reporter: ITelemetryReporter,
     channel: vscode.LogOutputChannel
 ): void {
-    if (getState(context).surveyShown === true) {
+    if (hasSurveyBeenShown(context)) {
         return;
     }
 
     // Registration is gated on an async availability probe; fire-and-forget it.
-    void registerSurveyWhenChatAvailable(context, languageServerEvents, reporter, channel);
+    void registerSurveyWhenChatAvailable(context, languageServer, languageServerEvents, reporter, channel);
 }
 
 async function registerSurveyWhenChatAvailable(
     context: vscode.ExtensionContext,
+    languageServer: RoslynLanguageServer,
     languageServerEvents: LanguageServerEvents,
     reporter: ITelemetryReporter,
     channel: vscode.LogOutputChannel
 ): Promise<void> {
-    // Bail before registering anything if the customer can't use Copilot Chat.
-    if (!(await isCopilotChatAvailable())) {
-        return;
-    }
+    // Start observing before the async probe so an initialization that completes while the
+    // probe is in flight (or already completed before we ran) isn't missed.
+    const initialized = whenProjectInitialized(languageServer, languageServerEvents);
+    try {
+        if (!(await isCopilotChatAvailable())) {
+            return;
+        }
+        await initialized.completed;
 
-    // Wait for the first project initialization; the listener self-disposes so repeat
-    // events (e.g. solution reload) are ignored.
-    await onceProjectInitialized(context, languageServerEvents);
-
-    const state = getState(context);
-    if (state.surveyShown === true || isSnoozed(state)) {
-        return;
+        if (hasSurveyBeenShown(context) || isSnoozed(context)) {
+            return;
+        }
+        await showSurveyPrompt(context, reporter, channel);
+    } finally {
+        initialized.dispose();
     }
-    await showSurveyPrompt(context, reporter, channel);
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async
-function onceProjectInitialized(
-    context: vscode.ExtensionContext,
+function whenProjectInitialized(
+    languageServer: RoslynLanguageServer,
     languageServerEvents: LanguageServerEvents
-): Promise<void> {
-    return new Promise<void>((resolve) => {
-        const disposable = languageServerEvents.onServerStateChange((e) => {
+): { completed: Promise<void>; dispose: () => void } {
+    let disposable: vscode.Disposable | undefined;
+    const completed = new Promise<void>((resolve) => {
+        if (languageServer.state === ServerState.ProjectInitializationComplete) {
+            resolve();
+            return;
+        }
+        disposable = languageServerEvents.onServerStateChange((e) => {
             if (e.state === ServerState.ProjectInitializationComplete) {
-                disposable.dispose();
                 resolve();
             }
         });
-        context.subscriptions.push(disposable);
     });
+    return { completed, dispose: () => disposable?.dispose() };
 }
 
 /**
@@ -95,29 +99,26 @@ async function isCopilotChatAvailable(): Promise<boolean> {
     }
 }
 
-function getState(context: vscode.ExtensionContext): SurveyState {
-    return context.globalState.get<SurveyState>(globalStateKey, { surveyShown: false });
+function hasSurveyBeenShown(context: vscode.ExtensionContext): boolean {
+    return context.globalState.get<boolean>(shownStateKey, false);
 }
 
-function isSnoozed(state: SurveyState): boolean {
-    if (!state.snoozedUntil) {
+function isSnoozed(context: vscode.ExtensionContext): boolean {
+    const snoozedUntil = context.globalState.get<string>(snoozedUntilStateKey);
+    if (!snoozedUntil) {
         return false;
     }
-    const until = Date.parse(state.snoozedUntil);
+    const until = Date.parse(snoozedUntil);
     return !Number.isNaN(until) && until > Date.now();
 }
 
+async function markSurveyShown(context: vscode.ExtensionContext): Promise<void> {
+    await context.globalState.update(shownStateKey, true);
+}
+
 async function snoozeSurvey(context: vscode.ExtensionContext): Promise<void> {
-    const state = getState(context);
-    // globalState is shared across windows — never downgrade a terminal choice made elsewhere.
-    if (state.surveyShown) {
-        return;
-    }
-    await context.globalState.update(globalStateKey, {
-        ...state,
-        surveyShown: false,
-        snoozedUntil: new Date(Date.now() + ignoredSnoozeMs).toISOString(),
-    });
+    // Touches only the snooze key, so it can't clobber a terminal "shown" set in another window.
+    await context.globalState.update(snoozedUntilStateKey, new Date(Date.now() + ignoredSnoozeMs).toISOString());
 }
 
 async function showSurveyPrompt(
@@ -141,13 +142,13 @@ async function showSurveyPrompt(
             // Only retire once the browser actually opened; otherwise snooze so it can resurface.
             const opened = await vscode.env.openExternal(vscode.Uri.parse(surveyUrl));
             if (opened) {
-                await context.globalState.update(globalStateKey, { surveyShown: true });
+                await markSurveyShown(context);
                 reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'accepted' });
             } else {
                 await snoozeSurvey(context);
             }
         } else if (result === dismiss) {
-            await context.globalState.update(globalStateKey, { surveyShown: true });
+            await markSurveyShown(context);
             reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'dismissed' });
         } else {
             // Ignored or closed without a choice — snooze rather than retire.
@@ -157,7 +158,7 @@ async function showSurveyPrompt(
         // Only the error type is sent, never user content.
         channel.error('Failed to show C# Copilot Chat survey prompt', error);
         reporter.sendTelemetryErrorEvent(TelemetryEventNames.CopilotChatSurveyError, {
-            error: error instanceof Error ? error.name : 'error',
+            'error.name': error instanceof Error ? error.name : 'error',
         });
     }
 }

--- a/src/lsptoolshost/copilot/copilotChatSurvey.ts
+++ b/src/lsptoolshost/copilot/copilotChatSurvey.ts
@@ -87,8 +87,9 @@ function onceProjectInitialized(
  */
 async function isCopilotChatAvailable(): Promise<boolean> {
     try {
-        const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
-        return models.length > 0;
+        // vscode.lm may be absent in older/limited hosts; optional chaining keeps this never-throws.
+        const models = await vscode.lm?.selectChatModels({ vendor: 'copilot' });
+        return (models?.length ?? 0) > 0;
     } catch {
         return false;
     }
@@ -107,11 +108,13 @@ function isSnoozed(state: SurveyState): boolean {
 }
 
 async function snoozeSurvey(context: vscode.ExtensionContext): Promise<void> {
+    const state = getState(context);
     // globalState is shared across windows — never downgrade a terminal choice made elsewhere.
-    if (getState(context).surveyShown) {
+    if (state.surveyShown) {
         return;
     }
     await context.globalState.update(globalStateKey, {
+        ...state,
         surveyShown: false,
         snoozedUntil: new Date(Date.now() + ignoredSnoozeMs).toISOString(),
     });

--- a/src/lsptoolshost/copilot/copilotChatSurvey.ts
+++ b/src/lsptoolshost/copilot/copilotChatSurvey.ts
@@ -33,7 +33,7 @@ export function registerCopilotChatSurvey(
     reporter: ITelemetryReporter,
     channel: vscode.LogOutputChannel
 ): void {
-    if (hasSurveyBeenShown(context)) {
+    if (hasSurveyBeenShown(context) || isSnoozed(context)) {
         return;
     }
 
@@ -78,6 +78,9 @@ function whenProjectInitialized(
         }
         disposable = languageServerEvents.onServerStateChange((e) => {
             if (e.state === ServerState.ProjectInitializationComplete) {
+                // Dispose as soon as we're initialized rather than waiting for the (possibly
+                // long-lived) toast to be dismissed; the finally in the caller is a safety net.
+                disposable?.dispose();
                 resolve();
             }
         });
@@ -133,10 +136,12 @@ async function showSurveyPrompt(
     );
 
     try {
-        // Count as shown up front: the toast is non-modal and may never be interacted with.
+        // Start the toast first, then record "shown"; if showInformationMessage fails
+        // synchronously we won't report a prompt that was never presented.
+        const resultPromise = vscode.window.showInformationMessage(message, takeAction, dismiss);
         reporter.sendTelemetryEvent(TelemetryEventNames.CopilotChatSurvey, { outcome: 'shown' });
 
-        const result = await vscode.window.showInformationMessage(message, takeAction, dismiss);
+        const result = await resultPromise;
 
         if (result === takeAction) {
             // Only retire once the browser actually opened; otherwise snooze so it can resurface.

--- a/src/lsptoolshost/copilot/copilotChatSurvey.ts
+++ b/src/lsptoolshost/copilot/copilotChatSurvey.ts
@@ -54,27 +54,31 @@ async function registerSurveyWhenChatAvailable(
         return;
     }
 
-    // ProjectInitializationComplete can fire more than once per session (e.g. solution reload),
-    // so dispose after the first prompt attempt.
-    const disposable = languageServerEvents.onServerStateChange(async (e) => {
-        if (e.state !== ServerState.ProjectInitializationComplete) {
-            return;
-        }
+    // Wait for the first project initialization; the listener self-disposes so repeat
+    // events (e.g. solution reload) are ignored.
+    await onceProjectInitialized(context, languageServerEvents);
 
-        const state = getState(context);
-        if (state.surveyShown === true) {
-            disposable.dispose();
-            return;
-        }
-        // Snoozed: stay registered so a later initialization can re-surface it once it lapses.
-        if (isSnoozed(state)) {
-            return;
-        }
+    const state = getState(context);
+    if (state.surveyShown === true || isSnoozed(state)) {
+        return;
+    }
+    await showSurveyPrompt(context, reporter, channel);
+}
 
-        disposable.dispose();
-        await showSurveyPrompt(context, reporter, channel);
+// eslint-disable-next-line @typescript-eslint/promise-function-async
+function onceProjectInitialized(
+    context: vscode.ExtensionContext,
+    languageServerEvents: LanguageServerEvents
+): Promise<void> {
+    return new Promise<void>((resolve) => {
+        const disposable = languageServerEvents.onServerStateChange((e) => {
+            if (e.state === ServerState.ProjectInitializationComplete) {
+                disposable.dispose();
+                resolve();
+            }
+        });
+        context.subscriptions.push(disposable);
     });
-    context.subscriptions.push(disposable);
 }
 
 /**

--- a/src/shared/telemetryEventNames.ts
+++ b/src/shared/telemetryEventNames.ts
@@ -32,4 +32,11 @@ export enum TelemetryEventNames {
     ProjectContextChangeFileExplorer = 'roslyn/projectContextChangeFileExplorer',
     ProjectContextChangeEditor = 'roslyn/projectContextChangeEditor',
     ProjectContextChangeCommand = 'roslyn/projectContextChangeCommand',
+
+    // Copilot Chat survey lifecycle. Emitted with an `outcome` property: `shown` when the toast is
+    // presented (emitted up front, since a non-modal toast may never be responded to), and
+    // `accepted`/`dismissed` when the user makes an explicit choice.
+    CopilotChatSurvey = 'roslyn/copilotChatSurvey',
+    // The Copilot Chat survey qualified but failed to be presented due to an error.
+    CopilotChatSurveyError = 'roslyn/copilotChatSurvey/error',
 }


### PR DESCRIPTION
## What

Adds a one-time feedback survey prompt for C# extension users who are using
GitHub Copilot Chat.

## Behavior

- **Eligibility**: at least one Copilot-vendor chat model is available via
  `vscode.lm.selectChatModels({ vendor: ''copilot'' })`. Since Copilot Chat now
  ships with VS Code, an install check no longer distinguishes real users;
  requiring an available Copilot model means the user has Chat set up and is
  signed in. Probed once at registration, so we bail before wiring anything up
  when Chat isn''t usable.
- **Timing**: deferred until `ServerState.ProjectInitializationComplete` (via a
  self-disposing `onServerStateChange` listener) so the toast doesn''t contend
  with reload/restore/IntelliCode notifications at activation.
- **One-shot with snooze** (persisted in `globalState`):
  - **Take Survey** -> opens the survey URL; retires the survey *only after*
    `openExternal` succeeds (otherwise it snoozes so it can resurface).
  - **Not Now** -> retires the survey permanently.
  - **Ignored / closed** -> snoozed for 1 hour, then eligible again.
  - A passively-ignored toast never burns the one-shot.
- **Multi-window safe(r)**: the snooze path re-reads `globalState` and never
  downgrades a terminal `surveyShown: true`, so a choice made in one window
  isn''t clobbered by an ignored toast in another.

## Telemetry

- `roslyn/copilotChatSurvey` with `outcome`: `shown` | `accepted` | `dismissed`.
- `roslyn/copilotChatSurvey/error` when the prompt fails to present.

## Files

- `src/lsptoolshost/copilot/copilotChatSurvey.ts` (new)
- `src/lsptoolshost/activate.ts` (wire-up)
- `src/shared/telemetryEventNames.ts` (new event names)
