### PR TITLE
Defer OmniSharp and download-stack loads out of activation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,8 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import { vscodeNetworkSettingsProvider } from './networkSettings';
 import createOptionStream from './shared/observables/createOptionStream';
 import { AbsolutePathPackage } from './packageManager/absolutePathPackage';
-import { downloadAndInstallPackages } from './packageManager/downloadAndInstallPackages';
 import { IInstallDependencies } from './packageManager/IInstallDependencies';
 import { installRuntimeDependencies } from './installRuntimeDependencies';
-import { isValidDownload } from './packageManager/isValidDownload';
 import { MigrateOptions } from './shared/migrateOptions';
 import { CSharpExtensionExports, LimitedExtensionExports, OmnisharpExtensionExports } from './csharpExtensionExports';
 import { getCSharpDevKit } from './utils/getCSharpDevKit';
@@ -27,7 +25,6 @@ import { commonOptions, omnisharpOptions } from './shared/options';
 import { TelemetryEventNames } from './shared/telemetryEventNames';
 import { checkDotNetRuntimeExtensionVersion } from './checkDotNetRuntimeExtensionVersion';
 import { checkIsSupportedPlatform } from './checkSupportedPlatform';
-import { activateOmniSharp } from './activateOmniSharp';
 import { activateRoslyn } from './activateRoslyn';
 import { LimitedActivationStatus } from './shared/limitedActivationStatus';
 
@@ -85,8 +82,19 @@ export async function activate(
 
     const networkSettingsProvider = vscodeNetworkSettingsProvider(vscode);
     const useFramework = useOmnisharpServer && omnisharpOptions.useModernNet !== true;
-    const installDependencies: IInstallDependencies = async (dependencies: AbsolutePathPackage[]) =>
-        downloadAndInstallPackages(dependencies, networkSettingsProvider, eventStream, isValidDownload, reporter);
+    const installDependencies: IInstallDependencies = async (dependencies: AbsolutePathPackage[]) => {
+        // Defer loading the download/zip stack (yauzl, proxy agents, fs-extra, etc.) until a
+        // component actually needs to be downloaded, which normally never happens after install.
+        const { downloadAndInstallPackages } = await import('./packageManager/downloadAndInstallPackages');
+        const { isValidDownload } = await import('./packageManager/isValidDownload');
+        return downloadAndInstallPackages(
+            dependencies,
+            networkSettingsProvider,
+            eventStream,
+            isValidDownload,
+            reporter
+        );
+    };
 
     const runtimeDependenciesExist = await installRuntimeDependencies(
         context.extension.packageJSON,
@@ -142,6 +150,9 @@ export async function activate(
                 getCoreClrDebugPromise
             );
         } else {
+            // Defer loading the OmniSharp implementation and its module graph until we actually
+            // activate it, so the default Roslyn activations don't pay to compile/execute it.
+            const { activateOmniSharp } = await import('./activateOmniSharp');
             exports = activateOmniSharp(
                 context,
                 platformInfo,


### PR DESCRIPTION
The extension bundles everything into a single dist/extension.js, so every statically-imported module's top-level code and its require()->realpathSync canonicalization runs synchronously during activation. A CPU profile of an unresponsive activation showed ~70% of a ~1s freeze in a single blocking realpathSync during module loading.

Roslyn is the default server, but main.ts statically imported activateOmniSharp (pulling in the entire OmniSharp graph, the Razor-OmniSharp package, and vscode-html-languageservice) and the download/zip stack (yauzl, http(s)-proxy agents, fs-extra) on every activation even though downloads normally never happen after first install.

Load activateOmniSharp via dynamic import() only when the OmniSharp server is actually used, and load downloadAndInstallPackages/isValidDownload via dynamic import() only when a component actually needs downloading. Roslyn continues to load eagerly. Verified against the built bundle that these graphs are now lazy __esm chunks with no eager caller: ~180 fewer wrapped modules execute at activation, including the 175-module Razor-OmniSharp package, 28 modules of vscode-html-languageservice, and the yauzl/proxy-agent download stack.

On my machine, dropped extension activation time from ~350ms to ~260ms