### PR TITLE
Update roslyn to 5.10.0-1.26376.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,8 @@
 # 2.147.x
 * Update Roslyn to 5.10.0-1.26376.1 (PR: [#9584](https://github.com/dotnet/vscode-csharp/pull/9584))
   * Don't throw exceptions for nested, prefixed, tag helpers (PR: [#84611](https://github.com/dotnet/roslyn/pull/84611))
-  * Prevent diagnostic port inheritance by child processes (PR: [#84620](https://github.com/dotnet/roslyn/pull/84620))
-  * Implement LSP daemon mode (PR: [#84199](https://github.com/dotnet/roslyn/pull/84199))
-  * Compiler: Guard EditorConfig section matching recursion (PR: [#84606](https://github.com/dotnet/roslyn/pull/84606))
-  * Fix false positive with Color Color static member access (PR: [#84533](https://github.com/dotnet/roslyn/pull/84533))
-  * Defer Introduce Parameter's call-site search to when the action is applied (PR: [#84572](https://github.com/dotnet/roslyn/pull/84572))
   * File-based apps: avoid running a few irrelevant editor features (PR: [#84575](https://github.com/dotnet/roslyn/pull/84575))
-  * Restore solution as a whole on auto-load instead of per-project (PR: [#84202](https://github.com/dotnet/roslyn/pull/84202))
   * Fix linked editing for empty tag pairs (PR: [#84562](https://github.com/dotnet/roslyn/pull/84562))
-
 * Update Debugger and MonowebAssemblyBridge (PR: [#9543](https://github.com/dotnet/vscode-csharp/pull/9543))
 * Add one-time feedback survey for Copilot Chat users (PR: [#9551](https://github.com/dotnet/vscode-csharp/pull/9551))
 * Optional source based test discovery support in C# Dev Kit. (PR: [#9426](https://github.com/dotnet/vscode-csharp/pull/9426))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.147.x
-* Update Roslyn to 5.10.0-1.26376.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.10.0-1.26376.1 (PR: [#9584](https://github.com/dotnet/vscode-csharp/pull/9584))
   * Don't throw exceptions for nested, prefixed, tag helpers (PR: [#84611](https://github.com/dotnet/roslyn/pull/84611))
   * Prevent diagnostic port inheritance by child processes (PR: [#84620](https://github.com/dotnet/roslyn/pull/84620))
   * Implement LSP daemon mode (PR: [#84199](https://github.com/dotnet/roslyn/pull/84199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.147.x
+* Update Roslyn to 5.10.0-1.26376.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Don't throw exceptions for nested, prefixed, tag helpers (PR: [#84611](https://github.com/dotnet/roslyn/pull/84611))
+  * Prevent diagnostic port inheritance by child processes (PR: [#84620](https://github.com/dotnet/roslyn/pull/84620))
+  * Implement LSP daemon mode (PR: [#84199](https://github.com/dotnet/roslyn/pull/84199))
+  * Compiler: Guard EditorConfig section matching recursion (PR: [#84606](https://github.com/dotnet/roslyn/pull/84606))
+  * Fix false positive with Color Color static member access (PR: [#84533](https://github.com/dotnet/roslyn/pull/84533))
+  * Defer Introduce Parameter's call-site search to when the action is applied (PR: [#84572](https://github.com/dotnet/roslyn/pull/84572))
+  * File-based apps: avoid running a few irrelevant editor features (PR: [#84575](https://github.com/dotnet/roslyn/pull/84575))
+  * Restore solution as a whole on auto-load instead of per-project (PR: [#84202](https://github.com/dotnet/roslyn/pull/84202))
+  * Fix linked editing for empty tag pairs (PR: [#84562](https://github.com/dotnet/roslyn/pull/84562))
+
 * Update Debugger and MonowebAssemblyBridge (PR: [#9543](https://github.com/dotnet/vscode-csharp/pull/9543))
 * Add one-time feedback survey for Copilot Chat users (PR: [#9551](https://github.com/dotnet/vscode-csharp/pull/9551))
 * Optional source based test discovery support in C# Dev Kit. (PR: [#9426](https://github.com/dotnet/vscode-csharp/pull/9426))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.10.0-1.26367.9",
+    "roslyn": "5.10.0-1.26376.1",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.10.12014.341",

--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -55,13 +55,19 @@ export async function prepareVSCodeAndExecuteTests(
         await execChildProcess(`${dotnetPath} build ${sln}`, workspacePath, process.env);
     }
 
+    const launchArgs = [workspacePath, '-n', '--user-data-dir', userDataDir, '--log', 'ms-dotnettools.csharp:trace'];
+    if (process.platform === 'linux') {
+        // CI containers have a small /dev/shm allocation, which can cause the renderer to crash.
+        launchArgs.push('--disable-dev-shm-usage');
+    }
+
     // Download VS Code, unzip it and run the integration test
     const exitCode = await runTests({
         vscodeExecutablePath: vscodeExecutablePath,
         extensionDevelopmentPath: extensionDevelopmentPath,
         extensionTestsPath: extensionTestsPath,
         // Launch with info logging as anything else is way too verbose and will hide test results.
-        launchArgs: [workspacePath, '-n', '--user-data-dir', userDataDir, '--log', 'ms-dotnettools.csharp:trace'],
+        launchArgs,
         extensionTestsEnv: env,
     });
 


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/104895c7c0c783f5d7c43f05631364eabc6e6d88...09173f5d7777c115c4dd0f5c2af6a7ff1dbf2d83?w=1)
* Don't throw exceptions for nested, prefixed, tag helpers (PR: [#84611](https://github.com/dotnet/roslyn/pull/84611))
* Prevent diagnostic port inheritance by child processes (PR: [#84620](https://github.com/dotnet/roslyn/pull/84620))
* Implement LSP daemon mode (PR: [#84199](https://github.com/dotnet/roslyn/pull/84199))
* Update nuget project model to STJ version (PR: [#84618](https://github.com/dotnet/roslyn/pull/84618))
* Bump Microsoft.Build to 18.7.1 and mark ShowMessageForImplicitlySkipAnalyzers multithreadable (PR: [#84343](https://github.com/dotnet/roslyn/pull/84343))
* Compiler: Guard EditorConfig section matching recursion (PR: [#84606](https://github.com/dotnet/roslyn/pull/84606))
* Avoid nullref when opening XAML documents with no view adapter (PR: [#84595](https://github.com/dotnet/roslyn/pull/84595))
* CI desktop test jobs: run Release_64 instead of Release_32 on PRs. Delete Debug_32 job. (PR: [#84598](https://github.com/dotnet/roslyn/pull/84598))
* Fix false positive with Color Color static member access (PR: [#84533](https://github.com/dotnet/roslyn/pull/84533))
* Simplify NuGet authentication step (PR: [#84593](https://github.com/dotnet/roslyn/pull/84593))
* Remove feedUrl from NuGetAuthenticate task (PR: [#84592](https://github.com/dotnet/roslyn/pull/84592))
* Defer Introduce Parameter's call-site search to when the action is applied (PR: [#84572](https://github.com/dotnet/roslyn/pull/84572))
* File-based apps: avoid running a few irrelevant editor features (PR: [#84575](https://github.com/dotnet/roslyn/pull/84575))
* Remove per-feature Razor code generation opt-ins (PR: [#84567](https://github.com/dotnet/roslyn/pull/84567))
* Add missing feed configuration to our pr-validation pipeline (PR: [#84566](https://github.com/dotnet/roslyn/pull/84566))
* Optimize DecisionDagBuilder with Tests.ValueSet for large or-patterns (PR: [#83513](https://github.com/dotnet/roslyn/pull/83513))
* Unsafe evolution: report error for `unsafe` with no effect (PR: [#84378](https://github.com/dotnet/roslyn/pull/84378))
* Adjust/add unions tests (PR: [#84565](https://github.com/dotnet/roslyn/pull/84565))
* Handle iterator safe contexts in ref safety analysis (PR: [#84254](https://github.com/dotnet/roslyn/pull/84254))
* Restore solution as a whole on auto-load instead of per-project (PR: [#84202](https://github.com/dotnet/roslyn/pull/84202))
* Update analyzer rules docs stuff (PR: [#84481](https://github.com/dotnet/roslyn/pull/84481))
* Clean up and ultimately remove LanguageServerFeatureOptions (PR: [#84559](https://github.com/dotnet/roslyn/pull/84559))
* Fix linked editing for empty tag pairs (PR: [#84562](https://github.com/dotnet/roslyn/pull/84562))
* Enable publishing for MVU demo branch (PR: [#84551](https://github.com/dotnet/roslyn/pull/84551))
* Adjust IL used for a null check in the compiler-synthesized inline-array helpers (PR: [#84523](https://github.com/dotnet/roslyn/pull/84523))
* Unions: Merge implementation of Try-Both approach to main (PR: [#84531](https://github.com/dotnet/roslyn/pull/84531))
* Unions: Address remaining PROTOTYPE comments (PR: [#84499](https://github.com/dotnet/roslyn/pull/84499))
* Unions: Standardize on UnionMatchingMode property (PR: [#84436](https://github.com/dotnet/roslyn/pull/84436))
* Unions: Implement Try-Both approach for recursive patterns (PR: [#84418](https://github.com/dotnet/roslyn/pull/84418))
* Unions: Implement Try-Both approach for `var`, declaration and list patterns (PR: [#84365](https://github.com/dotnet/roslyn/pull/84365))
* Unions: Implement Try-Both approach for type pattern (PR: [#84323](https://github.com/dotnet/roslyn/pull/84323))

