### PR TITLE
Add setting to show all C# code actions in Razor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1623,6 +1623,12 @@
             "scope": "window",
             "default": false,
             "description": "%configuration.razor.razor.completion.commitElementsWithSpace%"
+          },
+          "razor.advanced.showAllCSharpCodeActions": {
+            "type": "boolean",
+            "scope": "window",
+            "default": false,
+            "description": "%configuration.razor.razor.advanced.showAllCSharpCodeActions%"
           }
         }
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -140,6 +140,7 @@
   "configuration.razor.razor.format.codeBlockBraceOnNextLine": "Forces the open brace after an @code or @functions directive to be on the following line.",
   "configuration.razor.razor.format.attributeIndentStyle": "Specifies the indentation style for Html and component tag attributes in Razor files.",
   "configuration.razor.razor.completion.commitElementsWithSpace": "Specifies whether to commit tag helper and component elements with a space.",
+  "configuration.razor.razor.advanced.showAllCSharpCodeActions": "Show all C# code actions in Razor files. These actions are untested in Razor and may introduce syntax errors when applied. If this happens, please report a bug.",
   "debuggers.coreclr.configurationSnippets.label.console-local": ".NET: Launch Executable file (Console)",
   "debuggers.coreclr.configurationSnippets.label.web-local": ".NET: Launch Executable file (Web)",
   "debuggers.coreclr.configurationSnippets.label.attach-local": ".NET: Attach to a .NET process",


### PR DESCRIPTION
Razor can now optionally display all code actions that come from C#.

Goes with https://github.com/dotnet/roslyn/pull/84673.