### PR TITLE
Fix release publish invocation to use hashtable splat

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -107,22 +107,27 @@ extends:
                     $publishArtifacts = $allArtifacts[0]
                     Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
                     $publishScript = Join-Path '$(Pipeline.Workspace)' 'Publish-Vsix.ps1'
-                    $publishArgs = @('-Path', $publishArtifacts.FullName)
+                    # Use a hashtable (not an array) for splatting so arguments bind by name.
+                    # An array splat binds positionally, which would pass '-Path' itself as the
+                    # positional value of $Path and then fail to bind the actual folder path.
+                    $publishArgs = @{
+                      Path = $publishArtifacts.FullName
+                      CI   = $true
+                    }
                     if ($uploadPrerelease) {
                       Write-Host "Publish to pre-release channel."
-                      $publishArgs += '-PreRelease'
+                      $publishArgs['PreRelease'] = $true
                     } else {
                       Write-Host "Publish to release channel."
                     }
 
                     if ("${{ parameters.test }}" -eq "true") {
                       Write-Host "In test mode, publish commands are printed instead of executed."
-                      $publishArgs += '-DryRun'
+                      $publishArgs['DryRun'] = $true
                     }
 
-                    $publishArgs += '-CI'
-
-                    Write-Host "##[command]& $publishScript $($publishArgs -join ' ')"
+                    $publishArgsDisplay = ($publishArgs.GetEnumerator() | ForEach-Object { "-$($_.Key) $($_.Value)" }) -join ' '
+                    Write-Host "##[command]& $publishScript $publishArgsDisplay"
                     & $publishScript @publishArgs
 
     - stage: 'TagRelease'


### PR DESCRIPTION
The publish step in release.yml built \ as an array and splatted it into Publish-Vsix.ps1. Array splatting binds positionally, so the literal string '-Path' was bound to the position-0 parameter \, leaving the actual artifact folder with no positional slot and failing with:

  A positional parameter cannot be found that accepts argument
  '.../VSIX_Prerelease'.

Switch to a hashtable so arguments bind by name. Since release.yml is always taken from main, this fixes both prerelease and release publishing on the next run without requiring a rebuild.