### PR TITLE
Update roslyn to 5.11.0-1.26380.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 # 2.148.x
 
-* Update Roslyn to 5.11.0-1.26380.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.11.0-1.26380.4 (PR: [#9601](https://github.com/dotnet/vscode-csharp/pull/9601))
   * Fix on-type and code action formatting on Razor explicit statements (PR: [#84699](https://github.com/dotnet/roslyn/pull/84699))
   * Allow MSBuildWorkspace to open file-based apps (PR: [#84139](https://github.com/dotnet/roslyn/pull/84139))
   * Allow submitting rename conflicts and rename unambiguous erroneous references (PR: [#84686](https://github.com/dotnet/roslyn/pull/84686))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # 2.148.x
 
+* Update Roslyn to 5.11.0-1.26380.4 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Fix on-type and code action formatting on Razor explicit statements (PR: [#84699](https://github.com/dotnet/roslyn/pull/84699))
+  * Allow MSBuildWorkspace to open file-based apps (PR: [#84139](https://github.com/dotnet/roslyn/pull/84139))
+  * Allow submitting rename conflicts and rename unambiguous erroneous references (PR: [#84686](https://github.com/dotnet/roslyn/pull/84686))
+  * Allow showing all C# code actions in Razor in VS Code (PR: [#84673](https://github.com/dotnet/roslyn/pull/84673))
+  * Do not report hidden pattern diagnostics (PR: [#84576](https://github.com/dotnet/roslyn/pull/84576))
+  * Stream project.assets.json when checking for unresolved package references (PR: [#84647](https://github.com/dotnet/roslyn/pull/84647))
+  * Fix: LINQ implicit anonymous type property allows stack-only type, causing runtime TypeLoadException (PR: [#84485](https://github.com/dotnet/roslyn/pull/84485))
+
 # 2.147.x
 * Update Roslyn to 5.11.0-1.26379.2 (PR: [#9592](https://github.com/dotnet/vscode-csharp/pull/9592))
   * Unsafe evolution: ensure diagnostics are picked up by IDE (PR: [#84603](https://github.com/dotnet/roslyn/pull/84603))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@
 
 * Update Roslyn to 5.11.0-1.26380.4 (PR: [#9601](https://github.com/dotnet/vscode-csharp/pull/9601))
   * Fix on-type and code action formatting on Razor explicit statements (PR: [#84699](https://github.com/dotnet/roslyn/pull/84699))
-  * Allow MSBuildWorkspace to open file-based apps (PR: [#84139](https://github.com/dotnet/roslyn/pull/84139))
-  * Allow submitting rename conflicts and rename unambiguous erroneous references (PR: [#84686](https://github.com/dotnet/roslyn/pull/84686))
   * Allow showing all C# code actions in Razor in VS Code (PR: [#84673](https://github.com/dotnet/roslyn/pull/84673))
-  * Do not report hidden pattern diagnostics (PR: [#84576](https://github.com/dotnet/roslyn/pull/84576))
-  * Stream project.assets.json when checking for unresolved package references (PR: [#84647](https://github.com/dotnet/roslyn/pull/84647))
-  * Fix: LINQ implicit anonymous type property allows stack-only type, causing runtime TypeLoadException (PR: [#84485](https://github.com/dotnet/roslyn/pull/84485))
 
 # 2.147.x
 * Update Roslyn to 5.11.0-1.26379.2 (PR: [#9592](https://github.com/dotnet/vscode-csharp/pull/9592))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.11.0-1.26379.2",
+    "roslyn": "5.11.0-1.26380.4",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.10.12014.341",


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/d315a4a87b8d77677caf6ded6c2b33ca068c5cd7...dc1db3e7dee178e2744a73eb06dce107c07fa7b1?w=1)
* Fix on-type and code action formatting on Razor explicit statements (PR: [#84699](https://github.com/dotnet/roslyn/pull/84699))
* Fix crash in code gen (PR: [#84681](https://github.com/dotnet/roslyn/pull/84681))
* Allow MSBuildWorkspace to open file-based apps (PR: [#84139](https://github.com/dotnet/roslyn/pull/84139))
* Allow submitting rename conflicts and rename unambiguous erroneous references  (PR: [#84686](https://github.com/dotnet/roslyn/pull/84686))
* Allow showing all C# code actions in Razor in VS Code (PR: [#84673](https://github.com/dotnet/roslyn/pull/84673))
* Fix IdeCore benchmark build isolation (PR: [#84668](https://github.com/dotnet/roslyn/pull/84668))
* Add LSP daemon project-loading benchmarks (PR: [#84667](https://github.com/dotnet/roslyn/pull/84667))
* Adopt editor InlinePromptService for documentation comments (PR: [#84282](https://github.com/dotnet/roslyn/pull/84282))
* Do not report hidden pattern diagnostics (PR: [#84576](https://github.com/dotnet/roslyn/pull/84576))
* Stream project.assets.json when checking for unresolved package references (PR: [#84647](https://github.com/dotnet/roslyn/pull/84647))
* Cache more information for Closed Classes and Unions on NamedTypeSymbol (PR: [#84660](https://github.com/dotnet/roslyn/pull/84660))
* Fix: LINQ implicit anonymous type property allows stack-only type, causing runtime TypeLoadException (PR: [#84485](https://github.com/dotnet/roslyn/pull/84485))
* Add basic instrumentation tests for union declarations (PR: [#84637](https://github.com/dotnet/roslyn/pull/84637))
* Unions: Remove some trivial wrapper methods (PR: [#84678](https://github.com/dotnet/roslyn/pull/84678))

